### PR TITLE
Fix npm install by bundling @minicode/agent-sdk in published tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "minicode": "dist/src/index.js"
   },
   "files": ["dist", "README.md", "LICENSE"],
+  "bundleDependencies": ["@minicode/agent-sdk"],
   "scripts": {
     "dev": "node --env-file=.env --import tsx src/index.ts",
     "dev:ink": "CLI_UI_MODE=ink node --env-file=.env --import tsx src/index.ts",


### PR DESCRIPTION
When users install from npm, @minicode/agent-sdk can't be resolved because it's a private workspace package not published to the registry. Adding bundleDependencies ensures the SDK is packed into the tarball so it ships with the package.

https://claude.ai/code/session_01UsMGgcQZtgpMvE1GmL5L9w