### PR TITLE
Set app name headers for model logging

### DIFF
--- a/packages/agent-sdk/src/model/client.ts
+++ b/packages/agent-sdk/src/model/client.ts
@@ -472,6 +472,8 @@ export class OpenAICompatibleModelClient implements ModelClient {
   }): Promise<ModelResponse> {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
+      "HTTP-Referer": "https://github.com/sean1588/minicode",
+      "X-Title": "minicode",
     };
     const apiKey = this.apiKey?.trim();
     if (apiKey && apiKey.length > 0) {


### PR DESCRIPTION
Add HTTP-Referer and X-Title headers to OpenAI-compatible client so the app shows up as "minicode" instead of "Unknown" in OpenRouter logs.

https://claude.ai/code/session_017ixBDcDsMefii1aZmQZyB3