### PR TITLE
Fix collectSourceFiles filtering out non-TS/JS plugin files

### DIFF
--- a/src/indexer/cache.ts
+++ b/src/indexer/cache.ts
@@ -46,6 +46,7 @@ async function collectSourceFiles(
   dir: string,
   root: string,
   files: string[],
+  validExtensions: Set<string>,
 ): Promise<void> {
   const entries = await readdir(dir, { withFileTypes: true });
 
@@ -54,14 +55,14 @@ async function collectSourceFiles(
 
     if (entry.isDirectory()) {
       if (!SKIP_DIRS.has(entry.name) && !entry.name.startsWith(".")) {
-        await collectSourceFiles(fullPath, root, files);
+        await collectSourceFiles(fullPath, root, files, validExtensions);
       }
       continue;
     }
 
     if (entry.isFile()) {
       const ext = path.extname(entry.name).toLowerCase();
-      if ([".ts", ".tsx", ".js", ".jsx"].includes(ext)) {
+      if (validExtensions.has(ext)) {
         files.push(path.relative(root, fullPath));
       }
     }
@@ -75,8 +76,11 @@ export async function computeFileHashes(
   workspaceRoot: string,
 ): Promise<Map<string, string>> {
   const root = path.resolve(workspaceRoot);
+  const plugins = await loadPlugins(root);
+  const validExtensions = new Set(plugins.flatMap((p) => p.extensions));
+
   const sourceFiles: string[] = [];
-  await collectSourceFiles(root, root, sourceFiles);
+  await collectSourceFiles(root, root, sourceFiles, validExtensions);
 
   const hashes = new Map<string, string>();
   for (const relPath of sourceFiles) {

--- a/src/indexer/project-index.ts
+++ b/src/indexer/project-index.ts
@@ -17,6 +17,7 @@ async function collectSourceFiles(
   dir: string,
   root: string,
   files: string[],
+  validExtensions: Set<string>,
 ): Promise<void> {
   const entries = await readdir(dir, { withFileTypes: true });
 
@@ -25,14 +26,14 @@ async function collectSourceFiles(
 
     if (entry.isDirectory()) {
       if (!SKIP_DIRS.has(entry.name) && !entry.name.startsWith(".")) {
-        await collectSourceFiles(fullPath, root, files);
+        await collectSourceFiles(fullPath, root, files, validExtensions);
       }
       continue;
     }
 
     if (entry.isFile()) {
       const ext = path.extname(entry.name).toLowerCase();
-      if ([".ts", ".tsx", ".js", ".jsx"].includes(ext)) {
+      if (validExtensions.has(ext)) {
         files.push(path.relative(root, fullPath));
       }
     }
@@ -147,9 +148,10 @@ export async function buildProjectIndex(
 ): Promise<ProjectIndex> {
   const plugins = await loadPlugins(workspaceRoot);
   const root = path.resolve(workspaceRoot);
+  const validExtensions = new Set(plugins.flatMap((p) => p.extensions));
 
   const sourceFiles: string[] = [];
-  await collectSourceFiles(root, root, sourceFiles);
+  await collectSourceFiles(root, root, sourceFiles, validExtensions);
 
   const symbols = new Map<string, IndexedSymbol>();
   const files = new Map<string, IndexedSymbol[]>();


### PR DESCRIPTION
## Summary

- **Fixes #29** — `collectSourceFiles` in both `cache.ts` and `project-index.ts` hardcoded `[".ts", ".tsx", ".js", ".jsx"]`, which meant language plugins for other languages (Go, Python, Rust, etc.) never received any files to index.
- Both functions now derive the valid extension set from loaded plugins via their `extensions` field, so any installed plugin's file types are collected and indexed correctly.
- No changes to the `LanguagePlugin` interface — fully backward-compatible.

## Changes

- `src/indexer/cache.ts`: `collectSourceFiles` accepts a `validExtensions: Set<string>` parameter; `computeFileHashes` loads plugins and builds the set.
- `src/indexer/project-index.ts`: Same pattern — `buildProjectIndex` already loads plugins, now passes their extensions to `collectSourceFiles`.

## Test plan

- [x] All 162 existing tests pass
- [ ] Install a third-party plugin (e.g. with `.go` extensions) and verify its files are collected during indexing

https://claude.ai/code/session_0182xX79tCZQuvP5qSdSyreL