### PR TITLE
Build adjacency list to avoid O(n²) edge scanning

### DIFF
--- a/src/indexer/code-map.ts
+++ b/src/indexer/code-map.ts
@@ -24,40 +24,60 @@ function isEntryPointFile(filePath: string): boolean {
 }
 
 /**
+ * Build adjacency maps from edges for O(1) lookups per symbol.
+ */
+function buildAdjacencyMaps(edges: DependencyEdge[]): {
+  byFrom: Map<string, DependencyEdge[]>;
+  byTo: Map<string, DependencyEdge[]>;
+} {
+  const byFrom = new Map<string, DependencyEdge[]>();
+  const byTo = new Map<string, DependencyEdge[]>();
+  for (const edge of edges) {
+    const fromList = byFrom.get(edge.from);
+    if (fromList) fromList.push(edge); else byFrom.set(edge.from, [edge]);
+    const toList = byTo.get(edge.to);
+    if (toList) toList.push(edge); else byTo.set(edge.to, [edge]);
+  }
+  return { byFrom, byTo };
+}
+
+/**
  * Build the set of symbols related to focus symbols via dependency edges.
  * Expands 1 hop outbound (what focus symbols depend on) and 1 hop inbound
  * (what depends on focus symbols).
  */
 function expandFocusSet(
   focusSymbols: Set<string>,
-  edges: DependencyEdge[],
+  adjacency: { byFrom: Map<string, DependencyEdge[]>; byTo: Map<string, DependencyEdge[]> },
 ): Set<string> {
   const expanded = new Set(focusSymbols);
-  for (const edge of edges) {
+  for (const sym of focusSymbols) {
     // Outbound: focus symbol depends on something
-    if (focusSymbols.has(edge.from)) {
-      expanded.add(edge.to);
+    const outEdges = adjacency.byFrom.get(sym);
+    if (outEdges) {
+      for (const edge of outEdges) expanded.add(edge.to);
     }
     // Inbound: something depends on focus symbol
-    if (focusSymbols.has(edge.to)) {
-      expanded.add(edge.from);
+    const inEdges = adjacency.byTo.get(sym);
+    if (inEdges) {
+      for (const edge of inEdges) expanded.add(edge.from);
     }
   }
   return expanded;
 }
 
 function createSymbolRanker(
-  edges: DependencyEdge[],
+  adjacency: { byFrom: Map<string, DependencyEdge[]>; byTo: Map<string, DependencyEdge[]> },
   focusSymbols?: Set<string>,
 ) {
   const refCount = new Map<string, number>();
-  for (const e of edges) {
-    refCount.set(e.to, (refCount.get(e.to) ?? 0) + 1);
+  for (const [target, edges] of adjacency.byTo) {
+    refCount.set(target, edges.length);
   }
 
   // Expand focus set to include 1-hop neighbors in the dependency graph
   const boosted = focusSymbols?.size
-    ? expandFocusSet(focusSymbols, edges)
+    ? expandFocusSet(focusSymbols, adjacency)
     : undefined;
 
   return (a: IndexedSymbol, b: IndexedSymbol): number => {
@@ -101,8 +121,11 @@ export function generateCodeMap(
   );
 
   const lines: string[] = ["# Project Code Map", ""];
+  const adjacency = dependencyEdges
+    ? buildAdjacencyMaps(dependencyEdges)
+    : { byFrom: new Map<string, DependencyEdge[]>(), byTo: new Map<string, DependencyEdge[]>() };
   const rank = dependencyEdges
-    ? createSymbolRanker(dependencyEdges, focusSymbols)
+    ? createSymbolRanker(adjacency, focusSymbols)
     : (a: IndexedSymbol, b: IndexedSymbol) =>
         (a.exported === b.exported ? 0 : a.exported ? -1 : 1);
 
@@ -114,7 +137,7 @@ export function generateCodeMap(
   // When we have focus symbols, sort files so that files containing
   // focused symbols come first in the code map.
   const boosted = focusSymbols?.size && dependencyEdges
-    ? expandFocusSet(focusSymbols, dependencyEdges)
+    ? expandFocusSet(focusSymbols, adjacency)
     : undefined;
 
   const sortedFiles = [...symbolsByFile.keys()].sort((a, b) => {

--- a/src/indexer/project-index.ts
+++ b/src/indexer/project-index.ts
@@ -40,6 +40,19 @@ async function collectSourceFiles(
   }
 }
 
+function buildAdjacencyFrom(edges: DependencyEdge[]): Map<string, DependencyEdge[]> {
+  const map = new Map<string, DependencyEdge[]>();
+  for (const edge of edges) {
+    const list = map.get(edge.from);
+    if (list) {
+      list.push(edge);
+    } else {
+      map.set(edge.from, [edge]);
+    }
+  }
+  return map;
+}
+
 export function createProjectIndex(
   symbols: Map<string, IndexedSymbol>,
   files: Map<string, IndexedSymbol[]>,
@@ -48,6 +61,8 @@ export function createProjectIndex(
   projectFiles: Map<string, string>,
   workspaceRoot: string,
 ): ProjectIndex {
+  let adjacencyFrom = buildAdjacencyFrom(dependencyEdges);
+
   return {
     symbols,
     files,
@@ -82,15 +97,15 @@ export function createProjectIndex(
       for (let d = 0; d < depth; d += 1) {
         const next = new Set<string>();
         for (const from of frontier) {
-          for (const edge of dependencyEdges) {
-            if (edge.from === from) {
-              const dep = symbols.get(edge.to) ?? [...symbols.values()].find(
-                (s) => s.qualifiedName === edge.to || s.name === edge.to,
-              );
-              if (dep && !result.has(dep.qualifiedName)) {
-                result.set(dep.qualifiedName, dep);
-                next.add(dep.qualifiedName);
-              }
+          const outEdges = adjacencyFrom.get(from);
+          if (!outEdges) continue;
+          for (const edge of outEdges) {
+            const dep = symbols.get(edge.to) ?? [...symbols.values()].find(
+              (s) => s.qualifiedName === edge.to || s.name === edge.to,
+            );
+            if (dep && !result.has(dep.qualifiedName)) {
+              result.set(dep.qualifiedName, dep);
+              next.add(dep.qualifiedName);
             }
           }
         }
@@ -133,6 +148,7 @@ export function createProjectIndex(
           const allSymbols = [...symbols.values()];
           const edges = p.resolveDependencies(allSymbols, projectFiles);
           dependencyEdges.splice(0, dependencyEdges.length, ...edges);
+          adjacencyFrom = buildAdjacencyFrom(dependencyEdges);
           break;
         }
       }


### PR DESCRIPTION
## Summary

- Replaces linear scans of the `dependencyEdges` array with `Map`-based adjacency lists (`Map<string, DependencyEdge[]>`) for O(1) lookups per symbol
- `getDependencyCone` in `project-index.ts` now uses a `byFrom` adjacency map instead of iterating all edges per frontier node
- `expandFocusSet` and `createSymbolRanker` in `code-map.ts` now build local `byFrom`/`byTo` adjacency maps once per `generateCodeMap` call instead of scanning all edges multiple times
- The adjacency map is automatically rebuilt after `reindexFile` updates edges

Closes #32

## Test plan

- [x] All 162 existing tests pass
- [x] Lint passes with zero warnings
- [x] `getDependencyCone` test verifies correct dependency cone results after optimization
- [x] `reindexFile` test verifies adjacency map is rebuilt after file changes

https://claude.ai/code/session_01K5jQHsTG1JUJGZLHj8ow3E