### PR TITLE
Fix AnthropicModelClient streaming support

### DIFF
--- a/packages/agent-sdk/src/model/client.ts
+++ b/packages/agent-sdk/src/model/client.ts
@@ -318,13 +318,33 @@ export class AnthropicModelClient implements ModelClient {
     onStream?: (chunk: string) => void;
     signal?: AbortSignal;
   }): Promise<ModelResponse> {
+    const requestParams = {
+      model: params.model,
+      max_tokens: params.maxTokens,
+      system: params.system,
+      messages: toAnthropicMessages(params.messages),
+      tools: params.tools as unknown as Anthropic.Messages.ToolUnion[],
+    };
+
+    if (params.onStream) {
+      const onStream = params.onStream;
+      return withRetry(async () => {
+        const stream = this.client.messages.stream(requestParams);
+        if (params.signal) {
+          params.signal.addEventListener("abort", () => stream.abort(), { once: true });
+        }
+        stream.on("text", (text) => {
+          onStream(text);
+        });
+
+        const finalMessage = await stream.finalMessage();
+        return parseResponse(finalMessage);
+      });
+    }
+
     const response = await withRetry<Anthropic.Messages.Message>(() =>
       this.client.messages.create({
-        model: params.model,
-        max_tokens: params.maxTokens,
-        system: params.system,
-        messages: toAnthropicMessages(params.messages),
-        tools: params.tools as unknown as Anthropic.Messages.ToolUnion[],
+        ...requestParams,
         stream: false,
       }) as Promise<Anthropic.Messages.Message>,
     );


### PR DESCRIPTION
## Summary
- **Implements real streaming** in `AnthropicModelClient` using the Anthropic SDK's `.stream()` method, so the `onStream` callback is invoked with text chunks as they arrive
- When no `onStream` callback is provided, behavior is unchanged (non-streaming `create()` call)
- Matches the existing `OpenAICompatibleModelClient` streaming behavior so both providers deliver real-time feedback

## Details
The fix uses `this.client.messages.stream()` which returns a `MessageStream` object. We listen to the `"text"` event to forward chunks to the `onStream` callback, then call `stream.finalMessage()` to get the complete `Anthropic.Messages.Message` and pass it through the existing `parseResponse()` helper. Abort signal support is wired up via `stream.abort()`.

Fixes #30

## Test plan
- [x] `npm run build` passes
- [x] All 162 existing tests pass
- [x] `npm run lint` passes clean
- [ ] Manual test: run `minicode serve` with `MODEL_PROVIDER=anthropic` and verify streaming chunks appear in the web UI in real time

https://claude.ai/code/session_018vzC9BWEZSbETGa5upxuKh