### PR TITLE
Cache ASTs to avoid double-parsing during indexing

### DIFF
--- a/src/indexer/plugins/typescript.ts
+++ b/src/indexer/plugins/typescript.ts
@@ -75,6 +75,8 @@ function extractJSDoc(node: ts.Node, sourceFile: ts.SourceFile): string | undefi
 }
 
 function createPlugin(): LanguagePlugin {
+  const astCache = new Map<string, ts.SourceFile>();
+
   return {
     name: "typescript",
     extensions: EXTENSIONS,
@@ -91,6 +93,7 @@ function createPlugin(): LanguagePlugin {
         ts.ScriptTarget.Latest,
         true,
       );
+      astCache.set(filePath, sourceFile);
 
       const symbols: IndexedSymbol[] = [];
       let currentClass: string | null = null;
@@ -322,7 +325,7 @@ function createPlugin(): LanguagePlugin {
 
       for (const [filePath, content] of projectFiles) {
         const fullPath = path.join(rootDir, filePath);
-        const sourceFile = ts.createSourceFile(
+        const sourceFile = astCache.get(filePath) ?? ts.createSourceFile(
           fullPath,
           content,
           ts.ScriptTarget.Latest,
@@ -428,6 +431,7 @@ function createPlugin(): LanguagePlugin {
         visit(sourceFile);
       }
 
+      astCache.clear();
       return edges;
     },
   };

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -334,3 +334,79 @@ function setup() {
   );
   assert.ok(newCallEdge, "new Logger() should produce a calls edge from setup to Logger");
 });
+
+test("AST cache avoids double-parsing: resolveDependencies reuses cached ASTs from indexFile", () => {
+  const code = `
+export interface Task {
+  id: string;
+  name: string;
+}
+
+export function createTask(id: string, name: string): Task {
+  return { id, name };
+}
+
+export class TaskManager {
+  run(task: Task) {
+    return createTask(task.id, task.name);
+  }
+}
+`;
+  // indexFile populates the internal AST cache
+  const symbols = typescriptPlugin.indexFile("cached.ts", code);
+  assert.ok(symbols.length > 0, "should extract symbols");
+
+  // resolveDependencies should reuse the cached AST (no re-parse)
+  const projectFiles = new Map([["cached.ts", code]]);
+  const edges = typescriptPlugin.resolveDependencies!(symbols, projectFiles);
+
+  // Verify edges are still correctly produced (cache didn't break resolution)
+  const callEdge = edges.find(
+    (e) => e.from === "TaskManager.run" && e.to === "createTask" && e.kind === "calls",
+  );
+  assert.ok(callEdge, "should find calls edge from TaskManager.run to createTask");
+
+  const refEdge = edges.find(
+    (e) => e.from === "createTask" && e.to === "Task" && e.kind === "references",
+  );
+  assert.ok(refEdge, "should find references edge from createTask to Task");
+});
+
+test("AST cache is cleared after resolveDependencies completes", () => {
+  const code = `export function foo(): void {}`;
+
+  // First pass: indexFile caches the AST
+  typescriptPlugin.indexFile("clear-test.ts", code);
+
+  // resolveDependencies should clear the cache when done
+  typescriptPlugin.resolveDependencies!(
+    typescriptPlugin.indexFile("clear-test.ts", code),
+    new Map([["clear-test.ts", code]]),
+  );
+
+  // Second pass with different content on same path — should parse fresh, not stale cache
+  const newCode = `export function bar(): string { return "bar"; }`;
+  const symbols = typescriptPlugin.indexFile("clear-test.ts", newCode);
+  const names = symbols.map((s) => s.qualifiedName);
+  assert.ok(names.includes("bar"), "should extract bar from fresh parse");
+  assert.ok(!names.includes("foo"), "should not have stale foo from cache");
+});
+
+test("resolveDependencies works without prior indexFile (cache miss)", () => {
+  const code = `
+function alpha() { beta(); }
+function beta() {}
+`;
+  // Call resolveDependencies without indexFile first — should still work via fallback parse
+  const symbols = [
+    { name: "alpha", qualifiedName: "alpha", kind: "function" as const, filePath: "no-cache.ts", startLine: 2, endLine: 2, signature: "function alpha()", exported: false, dependencies: [] },
+    { name: "beta", qualifiedName: "beta", kind: "function" as const, filePath: "no-cache.ts", startLine: 3, endLine: 3, signature: "function beta()", exported: false, dependencies: [] },
+  ];
+  const projectFiles = new Map([["no-cache.ts", code]]);
+  const edges = typescriptPlugin.resolveDependencies!(symbols, projectFiles);
+
+  const callEdge = edges.find(
+    (e) => e.from === "alpha" && e.to === "beta" && e.kind === "calls",
+  );
+  assert.ok(callEdge, "should resolve dependencies even without cached AST");
+});


### PR DESCRIPTION
## Summary

- Adds an internal AST cache (`Map<string, ts.SourceFile>`) to the TypeScript plugin that stores parsed source files during `indexFile()` and reuses them in `resolveDependencies()`, eliminating the redundant `ts.createSourceFile()` call for every project file
- Falls back to fresh parsing for uncached files (e.g. when `resolveDependencies` is called independently), maintaining backward compatibility
- Clears the cache after `resolveDependencies()` completes to avoid stale ASTs and unbounded memory growth

Fixes #33

## Test plan

- [x] Added test: `resolveDependencies` reuses cached ASTs and produces correct dependency edges
- [x] Added test: cache is cleared after `resolveDependencies` completes (no stale data on re-index)
- [x] Added test: `resolveDependencies` works without prior `indexFile` (cache miss fallback)
- [x] All 165 existing tests pass
- [x] `npm run build` succeeds

https://claude.ai/code/session_01JXwNn72XpXUmnWNMAuD9YM