### PR TITLE
Fix ctrl-c not terminating serve when browser tab is open

### DIFF
--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -1,5 +1,6 @@
 import { createServer } from "node:http";
-import type { IncomingMessage, ServerResponse } from "node:http";
+import type { IncomingMessage, ServerResponse, Server } from "node:http";
+import type { Socket } from "node:net";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,6 +9,7 @@ import { createWebSocketServer } from "./websocket.js";
 import { handleChatCompletions, handleModels } from "./openai-compat.js";
 import { formatConfigForDisplay } from "../agent/config.js";
 import type { ServerMessage } from "./types.js";
+import type { WebSocketServer } from "ws";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -349,6 +351,47 @@ export function createRequestHandler(bridge: AgentBridge): (req: IncomingMessage
   };
 }
 
+/** Force-shutdown timeout in ms. If graceful close hasn't finished, exit anyway. */
+const SHUTDOWN_TIMEOUT_MS = 3_000;
+
+/**
+ * Forcefully shut down the serve process. Terminates all WebSocket clients,
+ * destroys open HTTP sockets, and stops the server. Exported for testing.
+ */
+export function shutdownServe(
+  server: Server,
+  wss: WebSocketServer,
+  openSockets: Set<Socket>,
+  exit: (code: number) => void = (code) => process.exit(code),
+): void {
+  console.log("\nShutting down...");
+
+  // 1. Terminate every connected WebSocket client immediately.
+  //    wss.close() only stops accepting *new* connections — existing clients
+  //    stay open, which keeps the HTTP server alive (the root cause of #39).
+  for (const client of wss.clients) {
+    client.terminate();
+  }
+  wss.close();
+
+  // 2. Destroy all open TCP sockets so server.close() can finish.
+  for (const socket of openSockets) {
+    socket.destroy();
+  }
+  openSockets.clear();
+
+  // 3. Stop accepting new connections and exit once drained.
+  server.close(() => {
+    exit(0);
+  });
+
+  // 4. Safety net: if something still holds the event loop, force-exit.
+  setTimeout(() => {
+    console.error("Shutdown timed out — forcing exit.");
+    exit(1);
+  }, SHUTDOWN_TIMEOUT_MS).unref();
+}
+
 export async function runServe(verbose: boolean, port: number): Promise<void> {
   console.log("Initializing agent...");
 
@@ -376,13 +419,16 @@ export async function runServe(verbose: boolean, port: number): Promise<void> {
     }
   };
 
+  // Track open sockets so we can destroy them on shutdown
+  const openSockets = new Set<Socket>();
+  server.on("connection", (socket) => {
+    openSockets.add(socket);
+    socket.on("close", () => openSockets.delete(socket));
+  });
+
   // Graceful shutdown
   process.on("SIGINT", () => {
-    console.log("\nShutting down...");
-    wss.close();
-    server.close(() => {
-      process.exit(0);
-    });
+    shutdownServe(server, wss, openSockets);
   });
 
   server.listen(port, "127.0.0.1", () => {

--- a/tests/serve.integration.test.ts
+++ b/tests/serve.integration.test.ts
@@ -3,7 +3,7 @@ import { test, afterEach } from "node:test";
 import type { Server } from "node:http";
 import { createServer } from "node:http";
 import { mkdirSync, writeFileSync, rmSync } from "node:fs";
-import { createRequestHandler } from "../src/serve/server.js";
+import { createRequestHandler, shutdownServe } from "../src/serve/server.js";
 import { AgentBridge } from "../src/serve/agent-bridge.js";
 import type { UiUpdate } from "@minicode/agent-sdk";
 import type { ServerMessage } from "../src/serve/types.js";
@@ -933,4 +933,110 @@ test("GET /api/symbols/:name/explain returns error for unknown symbol", async ()
   assert.equal(res.status, 200); // SSE always starts 200
   const text = await res.text();
   assert.ok(text.includes("error"));
+});
+
+// ── Graceful shutdown tests ──
+
+test("shutdownServe terminates WebSocket clients and calls exit(0)", async () => {
+  const bridge = new MockBridge();
+  const handler = createRequestHandler(bridge);
+  const server = createServer(handler);
+
+  const { WebSocketServer, WebSocket } = await import("ws");
+  const wss = new WebSocketServer({ server });
+
+  const openSockets = new Set<import("node:net").Socket>();
+  server.on("connection", (socket) => {
+    openSockets.add(socket);
+    socket.on("close", () => openSockets.delete(socket));
+  });
+
+  // Start server on random port
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const addr = server.address() as import("node:net").AddressInfo;
+
+  // Connect a WebSocket client (simulates browser tab)
+  const ws = new WebSocket(`ws://127.0.0.1:${addr.port}`);
+  await new Promise<void>((resolve) => ws.on("open", resolve));
+
+  assert.ok(wss.clients.size >= 1, "Should have at least 1 WS client connected");
+  assert.ok(openSockets.size >= 1, "Should have at least 1 open socket");
+
+  // Call shutdownServe with a mock exit function
+  let exitCode: number | undefined;
+  shutdownServe(server, wss, openSockets, (code) => {
+    exitCode = code;
+  });
+
+  // Wait a tick for async cleanup to propagate
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  assert.equal(exitCode, 0, "Should have called exit with code 0");
+  assert.equal(openSockets.size, 0, "All sockets should be cleared");
+  assert.equal(wss.clients.size, 0, "All WS clients should be removed");
+});
+
+test("shutdownServe works when no clients are connected", async () => {
+  const bridge = new MockBridge();
+  const handler = createRequestHandler(bridge);
+  const server = createServer(handler);
+
+  const { WebSocketServer } = await import("ws");
+  const wss = new WebSocketServer({ server });
+  const openSockets = new Set<import("node:net").Socket>();
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  let exitCode: number | undefined;
+  shutdownServe(server, wss, openSockets, (code) => {
+    exitCode = code;
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  assert.equal(exitCode, 0, "Should exit cleanly with no clients");
+});
+
+test("shutdownServe terminates multiple WebSocket clients", async () => {
+  const bridge = new MockBridge();
+  const handler = createRequestHandler(bridge);
+  const server = createServer(handler);
+
+  const { WebSocketServer, WebSocket } = await import("ws");
+  const wss = new WebSocketServer({ server });
+
+  const openSockets = new Set<import("node:net").Socket>();
+  server.on("connection", (socket) => {
+    openSockets.add(socket);
+    socket.on("close", () => openSockets.delete(socket));
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const addr = server.address() as import("node:net").AddressInfo;
+
+  // Connect 3 WebSocket clients
+  const clients: InstanceType<typeof WebSocket>[] = [];
+  for (let i = 0; i < 3; i++) {
+    const ws = new WebSocket(`ws://127.0.0.1:${addr.port}`);
+    await new Promise<void>((resolve) => ws.on("open", resolve));
+    clients.push(ws);
+  }
+
+  assert.equal(wss.clients.size, 3, "Should have 3 WS clients connected");
+
+  let exitCode: number | undefined;
+  shutdownServe(server, wss, openSockets, (code) => {
+    exitCode = code;
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  assert.equal(exitCode, 0, "Should have called exit with code 0");
+  assert.equal(openSockets.size, 0, "All sockets should be cleared");
 });


### PR DESCRIPTION
## Summary

Fixes #39 — `ctrl-c` now immediately terminates `minicode serve` even when browser tabs are connected via WebSocket.

**Root cause:** `wss.close()` only stops the WebSocket server from accepting *new* connections — it does not terminate existing clients. Since `server.close()` waits for all open connections to drain before calling its callback, open browser WebSocket connections keep the process alive indefinitely.

**Fix:**
- Explicitly call `.terminate()` on every connected WebSocket client before closing the WSS
- Track all open TCP sockets on the HTTP server and `.destroy()` them on shutdown
- Add a 3-second safety-net timeout that force-exits if cleanup stalls
- Extract shutdown logic into an exported `shutdownServe()` function (injectable `exit` param for testability)

## Test plan

- [x] 3 new tests for `shutdownServe()`: single client, no clients, multiple clients
- [x] All 168 existing tests pass
- [x] `npm run build` succeeds

https://claude.ai/code/session_012hEZYu3yFQHTVEWPE3Jtdc