### PR TITLE
Add hover cursor and visual affordance on graph nodes

### DIFF
--- a/src/shared/graph-styles.ts
+++ b/src/shared/graph-styles.ts
@@ -1,0 +1,103 @@
+// graph-styles.ts — Pure style definitions for the Cytoscape graph.
+// Extracted so they can be tested without browser globals.
+
+export interface KindColor {
+  border: string;
+  bg: string;
+}
+
+export interface EdgeStyle {
+  lineStyle: string;
+  opacity: number;
+  color: string;
+  width: number;
+}
+
+export const KIND_COLORS: Record<string, KindColor> = {
+  function:  { border: '#7aa2f7', bg: 'rgba(122,162,247,0.15)' },
+  class:     { border: '#bb9af7', bg: 'rgba(187,154,247,0.15)' },
+  interface: { border: '#2ac3de', bg: 'rgba(42,195,222,0.15)' },
+  type:      { border: '#e0af68', bg: 'rgba(224,175,104,0.15)' },
+  variable:  { border: '#9ece6a', bg: 'rgba(158,206,106,0.15)' },
+  method:    { border: '#7dcfff', bg: 'rgba(125,207,255,0.15)' },
+};
+
+export const EDGE_STYLES: Record<string, EdgeStyle> = {
+  calls:      { lineStyle: 'solid', opacity: 0.5, color: '#565f89', width: 1 },
+  imports:    { lineStyle: 'dashed', opacity: 0.4, color: '#565f89', width: 1 },
+  extends:    { lineStyle: 'solid', opacity: 0.7, color: '#bb9af7', width: 2 },
+  implements: { lineStyle: 'dashed', opacity: 0.6, color: '#2ac3de', width: 1.5 },
+  references: { lineStyle: 'dotted', opacity: 0.3, color: '#565f89', width: 1 },
+};
+
+export function buildStylesheet(): unknown[] {
+  const styles: unknown[] = [
+    {
+      selector: 'node',
+      style: {
+        'label': 'data(label)',
+        'font-size': 11,
+        'color': '#c0caf5',
+        'text-valign': 'bottom',
+        'text-halign': 'center',
+        'text-margin-y': 5,
+        'width': 20,
+        'height': 20,
+        'shape': 'roundrectangle',
+        'border-width': 1.5,
+        'border-color': '#565f89',
+        'background-color': 'rgba(34,35,54,0.8)',
+        'font-family': "'JetBrains Mono', monospace",
+        'text-wrap': 'none',
+      },
+    },
+    {
+      selector: 'edge',
+      style: {
+        'width': 1,
+        'line-color': '#565f89',
+        'target-arrow-color': '#565f89',
+        'target-arrow-shape': 'triangle',
+        'arrow-scale': 0.6,
+        'curve-style': 'bezier',
+        'opacity': 0.4,
+      },
+    },
+  ];
+
+  for (const [kind, colors] of Object.entries(KIND_COLORS)) {
+    styles.push({
+      selector: `node.${kind}`,
+      style: {
+        'color': colors.border,
+        'border-color': colors.border,
+        'background-color': colors.bg,
+      },
+    });
+  }
+
+  for (const [kind, s] of Object.entries(EDGE_STYLES)) {
+    styles.push({
+      selector: `edge.${kind}`,
+      style: {
+        'line-style': s.lineStyle,
+        'line-color': s.color,
+        'target-arrow-color': s.color,
+        'opacity': s.opacity,
+        'width': s.width,
+      },
+    });
+  }
+
+  styles.push({ selector: 'node.pinned', style: { 'border-color': '#e0af68', 'border-width': 3 } });
+  styles.push({ selector: 'node.faded', style: { 'opacity': 0.15 } });
+  styles.push({ selector: 'edge.faded', style: { 'opacity': 0.05 } });
+  styles.push({ selector: 'node.highlighted', style: { 'border-width': 2.5, 'z-index': 10 } });
+  styles.push({ selector: 'edge.highlighted', style: { 'opacity': 0.9, 'width': 2, 'z-index': 10 } });
+  styles.push({ selector: 'node.agent-pulse', style: { 'border-color': '#ff9e64', 'border-width': 4, 'background-color': 'rgba(255,158,100,0.25)' } });
+  styles.push({ selector: 'node.search-match', style: { 'border-color': '#e0af68', 'border-width': 2.5 } });
+  styles.push({ selector: 'node.expanded', style: { 'border-width': 2.5 } });
+  styles.push({ selector: 'node.hover-target', style: { 'border-width': 3, 'width': 24, 'height': 24, 'overlay-color': '#c0caf5', 'overlay-opacity': 0.08, 'z-index': 20 } });
+
+  return styles;
+}

--- a/src/web/graph.ts
+++ b/src/web/graph.ts
@@ -3,6 +3,7 @@
 // Clicking a node expands its 1-hop neighbors. Walk the graph in real time.
 
 import { escapeHtml, renderMarkdownInto } from './utils.ts';
+import { KIND_COLORS, EDGE_STYLES, buildStylesheet } from '../shared/graph-styles.ts';
 
 declare const cytoscape: (opts: unknown) => CyInstance;
 declare const hljs: { highlightElement(el: HTMLElement): void };
@@ -16,6 +17,7 @@ interface CyInstance {
   fit(padding?: number): void;
   animate(target: unknown, opts: unknown): void;
   resize(): void;
+  container(): HTMLElement;
   on(event: string, handler: (evt: CyEvent) => void): void;
   on(event: string, selector: string, handler: (evt: CyEvent) => void): void;
 }
@@ -71,18 +73,6 @@ interface RawEdge {
   type?: string;
 }
 
-interface KindColor {
-  border: string;
-  bg: string;
-}
-
-interface EdgeStyle {
-  lineStyle: string;
-  opacity: number;
-  color: string;
-  width: number;
-}
-
 let cy: CyInstance | null = null;
 const graphNodes = new Map<string, GraphNode>();
 let graphEdges: GraphEdge[] = [];
@@ -91,23 +81,6 @@ const edgeIndex = new Map<string, GraphEdge[]>();
 const pinnedNames = new Set<string>();
 let allSymbolNames: string[] = [];
 let initialized = false;
-
-const KIND_COLORS: Record<string, KindColor> = {
-  function:  { border: '#7aa2f7', bg: 'rgba(122,162,247,0.15)' },
-  class:     { border: '#bb9af7', bg: 'rgba(187,154,247,0.15)' },
-  interface: { border: '#2ac3de', bg: 'rgba(42,195,222,0.15)' },
-  type:      { border: '#e0af68', bg: 'rgba(224,175,104,0.15)' },
-  variable:  { border: '#9ece6a', bg: 'rgba(158,206,106,0.15)' },
-  method:    { border: '#7dcfff', bg: 'rgba(125,207,255,0.15)' },
-};
-
-const EDGE_STYLES: Record<string, EdgeStyle> = {
-  calls:      { lineStyle: 'solid', opacity: 0.5, color: '#565f89', width: 1 },
-  imports:    { lineStyle: 'dashed', opacity: 0.4, color: '#565f89', width: 1 },
-  extends:    { lineStyle: 'solid', opacity: 0.7, color: '#bb9af7', width: 2 },
-  implements: { lineStyle: 'dashed', opacity: 0.6, color: '#2ac3de', width: 1.5 },
-  references: { lineStyle: 'dotted', opacity: 0.3, color: '#565f89', width: 1 },
-};
 
 const LAYOUT_OPTIONS: Record<string, unknown> = {
   name: 'cose',
@@ -317,79 +290,6 @@ function findNode(name: string): CyCollection | null {
   return match.length > 0 ? match : null;
 }
 
-// -- Stylesheet --
-
-function buildStylesheet(): unknown[] {
-  const styles: unknown[] = [
-    {
-      selector: 'node',
-      style: {
-        'label': 'data(label)',
-        'font-size': 11,
-        'color': '#c0caf5',
-        'text-valign': 'bottom',
-        'text-halign': 'center',
-        'text-margin-y': 5,
-        'width': 20,
-        'height': 20,
-        'shape': 'roundrectangle',
-        'border-width': 1.5,
-        'border-color': '#565f89',
-        'background-color': 'rgba(34,35,54,0.8)',
-        'font-family': "'JetBrains Mono', monospace",
-        'text-wrap': 'none',
-      },
-    },
-    {
-      selector: 'edge',
-      style: {
-        'width': 1,
-        'line-color': '#565f89',
-        'target-arrow-color': '#565f89',
-        'target-arrow-shape': 'triangle',
-        'arrow-scale': 0.6,
-        'curve-style': 'bezier',
-        'opacity': 0.4,
-      },
-    },
-  ];
-
-  for (const [kind, colors] of Object.entries(KIND_COLORS)) {
-    styles.push({
-      selector: `node.${kind}`,
-      style: {
-        'color': colors.border,
-        'border-color': colors.border,
-        'background-color': colors.bg,
-      },
-    });
-  }
-
-  for (const [kind, s] of Object.entries(EDGE_STYLES)) {
-    styles.push({
-      selector: `edge.${kind}`,
-      style: {
-        'line-style': s.lineStyle,
-        'line-color': s.color,
-        'target-arrow-color': s.color,
-        'opacity': s.opacity,
-        'width': s.width,
-      },
-    });
-  }
-
-  styles.push({ selector: 'node.pinned', style: { 'border-color': '#e0af68', 'border-width': 3 } });
-  styles.push({ selector: 'node.faded', style: { 'opacity': 0.15 } });
-  styles.push({ selector: 'edge.faded', style: { 'opacity': 0.05 } });
-  styles.push({ selector: 'node.highlighted', style: { 'border-width': 2.5, 'z-index': 10 } });
-  styles.push({ selector: 'edge.highlighted', style: { 'opacity': 0.9, 'width': 2, 'z-index': 10 } });
-  styles.push({ selector: 'node.agent-pulse', style: { 'border-color': '#ff9e64', 'border-width': 4, 'background-color': 'rgba(255,158,100,0.25)' } });
-  styles.push({ selector: 'node.search-match', style: { 'border-color': '#e0af68', 'border-width': 2.5 } });
-  styles.push({ selector: 'node.expanded', style: { 'border-width': 2.5 } });
-
-  return styles;
-}
-
 // -- Interactions --
 
 function setupInteractions(cyInst: CyInstance, detailEl: HTMLElement): void {
@@ -410,17 +310,24 @@ function setupInteractions(cyInst: CyInstance, detailEl: HTMLElement): void {
     }
   });
 
+  const containerEl = cyInst.container();
+
   cyInst.on('mouseover', 'node', function (evt: CyEvent) {
     if (!cy) return;
     const node = evt.target as unknown as CyCollection;
     const neighborhood = node.closedNeighborhood();
     cy.elements().not(neighborhood).addClass('faded');
     neighborhood.addClass('highlighted');
+    node.addClass('hover-target');
+    containerEl.style.cursor = 'pointer';
   });
 
-  cyInst.on('mouseout', 'node', function () {
+  cyInst.on('mouseout', 'node', function (evt: CyEvent) {
     if (!cy) return;
+    const node = evt.target as unknown as CyCollection;
+    node.removeClass('hover-target');
     cy.elements().removeClass('faded highlighted');
+    containerEl.style.cursor = '';
   });
 
   cyInst.on('tap', function (evt: CyEvent) {

--- a/tests/graph-styles.test.ts
+++ b/tests/graph-styles.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { buildStylesheet, KIND_COLORS } from '../src/shared/graph-styles.js';
+
+interface StyleEntry {
+  selector: string;
+  style: Record<string, unknown>;
+}
+
+describe('buildStylesheet', () => {
+  const styles = buildStylesheet() as StyleEntry[];
+
+  it('returns an array of style entries', () => {
+    assert.ok(Array.isArray(styles));
+    assert.ok(styles.length > 0);
+  });
+
+  it('includes base node style', () => {
+    const base = styles.find((s) => s.selector === 'node');
+    assert.ok(base, 'base node style should exist');
+    assert.equal(base.style['shape'], 'roundrectangle');
+    assert.equal(base.style['label'], 'data(label)');
+  });
+
+  it('includes base edge style', () => {
+    const edge = styles.find((s) => s.selector === 'edge');
+    assert.ok(edge, 'base edge style should exist');
+    assert.equal(edge.style['curve-style'], 'bezier');
+  });
+
+  it('includes a style for each kind color', () => {
+    for (const kind of Object.keys(KIND_COLORS)) {
+      const entry = styles.find((s) => s.selector === `node.${kind}`);
+      assert.ok(entry, `style for node.${kind} should exist`);
+      assert.equal(entry.style['border-color'], KIND_COLORS[kind]!.border);
+      assert.equal(entry.style['background-color'], KIND_COLORS[kind]!.bg);
+    }
+  });
+
+  it('includes hover-target style with pointer affordance cues', () => {
+    const hover = styles.find((s) => s.selector === 'node.hover-target');
+    assert.ok(hover, 'hover-target style should exist');
+    // Increased size signals interactivity
+    assert.equal(hover.style['width'], 24, 'hover-target should enlarge node width');
+    assert.equal(hover.style['height'], 24, 'hover-target should enlarge node height');
+    // Thicker border for visual highlight
+    assert.equal(hover.style['border-width'], 3, 'hover-target should have thicker border');
+    // Overlay provides subtle glow
+    assert.ok(
+      (hover.style['overlay-opacity'] as number) > 0,
+      'hover-target should have a visible overlay',
+    );
+    // Higher z-index to pop above neighbors
+    assert.ok(
+      (hover.style['z-index'] as number) >= 20,
+      'hover-target should have high z-index',
+    );
+  });
+
+  it('includes highlighted style for neighborhood nodes', () => {
+    const highlighted = styles.find((s) => s.selector === 'node.highlighted');
+    assert.ok(highlighted, 'highlighted style should exist');
+    assert.ok(
+      (highlighted.style['border-width'] as number) > 1.5,
+      'highlighted should increase border width',
+    );
+  });
+
+  it('includes faded style for non-neighborhood elements', () => {
+    const fadedNode = styles.find((s) => s.selector === 'node.faded');
+    assert.ok(fadedNode, 'faded node style should exist');
+    assert.ok(
+      (fadedNode.style['opacity'] as number) < 1,
+      'faded nodes should reduce opacity',
+    );
+    const fadedEdge = styles.find((s) => s.selector === 'edge.faded');
+    assert.ok(fadedEdge, 'faded edge style should exist');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #25

- Adds `cursor: pointer` on the Cytoscape canvas when hovering over graph nodes, signaling they are clickable
- Adds a `hover-target` Cytoscape class on the directly hovered node with a subtle glow (overlay), slight size increase (20→24px), thicker border, and elevated z-index — making it visually distinct from its highlighted neighborhood
- Extracts graph style definitions (`buildStylesheet`, `KIND_COLORS`, `EDGE_STYLES`) into `src/shared/graph-styles.ts` so they can be unit-tested without browser globals

## Test plan

- [x] New `tests/graph-styles.test.ts` — verifies stylesheet includes `hover-target`, `highlighted`, `faded`, and all kind-color styles
- [x] All 175 existing tests pass
- [x] `npm run build` succeeds

https://claude.ai/code/session_01LfWLcdr4boFLmaSP8NWPQF