### PR TITLE
Add reasoning effort levels for API calls

### DIFF
--- a/packages/agent-sdk/src/agent/agent.ts
+++ b/packages/agent-sdk/src/agent/agent.ts
@@ -154,7 +154,7 @@ function computeEffectiveKeepRecent(
 
 export class CodingAgent {
   private readonly session: Session;
-  private readonly config: AgentConfig;
+  private config: AgentConfig;
   private readonly modelClient: ModelClient;
   private readonly toolRegistry: ToolRegistry;
   private readonly getCodeMap: ((focusSymbols?: Set<string>) => CodeMapResult | undefined) | undefined;
@@ -214,6 +214,15 @@ export class CodingAgent {
 
   getSession(): Session {
     return this.session;
+  }
+
+  getReasoningEffort(): AgentConfig["reasoningEffort"] {
+    return this.config.reasoningEffort;
+  }
+
+  setReasoningEffort(effort: AgentConfig["reasoningEffort"]): void {
+    const { reasoningEffort: _, ...rest } = this.config;
+    this.config = effort ? { ...rest, reasoningEffort: effort } : { ...rest };
   }
 
   /**
@@ -368,6 +377,9 @@ export class CodingAgent {
         messages,
         tools: toolSchemas,
         maxTokens: this.config.maxTokens,
+        ...(this.config.reasoningEffort
+          ? { reasoningEffort: this.config.reasoningEffort }
+          : {}),
         ...(this.onUiUpdate
           ? {
               onStream: (chunk: string) => {

--- a/packages/agent-sdk/src/agent/types.ts
+++ b/packages/agent-sdk/src/agent/types.ts
@@ -24,6 +24,9 @@ export interface ToolResultMessage {
 
 export type SessionMessage = UserMessage | AssistantMessage | ToolResultMessage;
 
+/** Valid reasoning effort levels for models that support reasoning tokens. */
+export type ReasoningEffort = "xhigh" | "high" | "medium" | "low" | "minimal" | "none";
+
 export interface AgentConfig {
   modelProvider: "anthropic" | "openai-compatible";
   model: string;
@@ -51,6 +54,8 @@ export interface AgentConfig {
   compactionThreshold?: number;
   /** Model to use for LLM-based compaction. When set, compaction uses an LLM to summarize instead of mechanical truncation. */
   compactionModel?: string;
+  /** Reasoning effort level for models that support reasoning tokens. When unset, no reasoning parameters are sent. */
+  reasoningEffort?: ReasoningEffort;
 }
 
 export interface ToolSchema {
@@ -83,6 +88,7 @@ export interface ModelClient {
     messages: SessionMessage[];
     tools: ToolSchema[];
     maxTokens: number;
+    reasoningEffort?: ReasoningEffort;
     onStream?: (chunk: string) => void;
     signal?: AbortSignal;
   }): Promise<ModelResponse>;

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -4,6 +4,7 @@ export type {
   AssistantMessage,
   ModelClient,
   ModelResponse,
+  ReasoningEffort,
   SessionMessage,
   ToolCall,
   ToolDefinition,

--- a/packages/agent-sdk/src/model/client.ts
+++ b/packages/agent-sdk/src/model/client.ts
@@ -7,6 +7,7 @@ import type {
   AgentConfig,
   ModelClient,
   ModelResponse,
+  ReasoningEffort,
   SessionMessage,
   ToolCall,
   ToolSchema,
@@ -296,6 +297,18 @@ function normalizeBaseUrl(baseUrl: string): string {
   return trimmed;
 }
 
+/** Map reasoning effort level to a fraction of max_tokens for Anthropic budget_tokens. */
+function effortToBudgetFraction(effort: ReasoningEffort): number {
+  switch (effort) {
+    case "xhigh": return 0.95;
+    case "high": return 0.80;
+    case "medium": return 0.50;
+    case "low": return 0.20;
+    case "minimal": return 0.10;
+    case "none": return 0;
+  }
+}
+
 export class AnthropicModelClient implements ModelClient {
   private readonly client: Anthropic;
 
@@ -315,16 +328,33 @@ export class AnthropicModelClient implements ModelClient {
     messages: SessionMessage[];
     tools: ToolSchema[];
     maxTokens: number;
+    reasoningEffort?: ReasoningEffort;
     onStream?: (chunk: string) => void;
     signal?: AbortSignal;
   }): Promise<ModelResponse> {
-    const requestParams = {
+    const baseParams = {
       model: params.model,
       max_tokens: params.maxTokens,
       system: params.system,
       messages: toAnthropicMessages(params.messages),
       tools: params.tools as unknown as Anthropic.Messages.ToolUnion[],
     };
+
+    // Build thinking parameter for models that support extended thinking.
+    const thinkingParam =
+      params.reasoningEffort && params.reasoningEffort !== "none"
+        ? {
+            thinking: {
+              type: "enabled" as const,
+              budget_tokens: Math.max(
+                1,
+                Math.round(params.maxTokens * effortToBudgetFraction(params.reasoningEffort)),
+              ),
+            },
+          }
+        : {};
+
+    const requestParams = { ...baseParams, ...thinkingParam };
 
     if (params.onStream) {
       const onStream = params.onStream;
@@ -487,6 +517,7 @@ export class OpenAICompatibleModelClient implements ModelClient {
     messages: SessionMessage[];
     tools: ToolSchema[];
     maxTokens: number;
+    reasoningEffort?: ReasoningEffort;
     onStream?: (chunk: string) => void;
     signal?: AbortSignal;
   }): Promise<ModelResponse> {
@@ -514,18 +545,24 @@ export class OpenAICompatibleModelClient implements ModelClient {
 
     const useStream = params.onStream !== undefined;
 
+    const requestBody: Record<string, unknown> = {
+      model: params.model,
+      messages: toOpenAICompatibleMessages(params.system, params.messages),
+      tools: toOpenAICompatibleTools(params.tools),
+      tool_choice: "auto",
+      max_tokens: params.maxTokens,
+      stream: useStream,
+    };
+
+    if (params.reasoningEffort) {
+      requestBody.reasoning = { effort: params.reasoningEffort };
+    }
+
     const response = await withRetry(async () => {
       const httpResponse = await this.fetchImpl(`${this.baseUrl}/chat/completions`, {
         method: "POST",
         headers,
-        body: JSON.stringify({
-          model: params.model,
-          messages: toOpenAICompatibleMessages(params.system, params.messages),
-          tools: toOpenAICompatibleTools(params.tools),
-          tool_choice: "auto",
-          max_tokens: params.maxTokens,
-          stream: useStream,
-        }),
+        body: JSON.stringify(requestBody),
         ...(params.signal && { signal: params.signal }),
       });
 

--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 
 import dotenv from "dotenv";
 
-import type { AgentConfig } from "@minicode/agent-sdk";
+import type { AgentConfig, ReasoningEffort } from "@minicode/agent-sdk";
 
 /** User-level config directory: ~/.minicode */
 export const MINICODE_HOME = path.join(os.homedir(), ".minicode");
@@ -37,6 +37,7 @@ export function formatConfigForDisplay(config: AgentConfig): string {
     "enableToolOutputTruncation: " + (config.enableToolOutputTruncation ?? false),
     "compactionThreshold: " + (config.compactionThreshold ?? "(disabled)"),
     "compactionModel: " + (config.compactionModel ?? "(disabled — using mechanical compaction)"),
+    "reasoningEffort: " + (config.reasoningEffort ?? "(unset — no reasoning parameters sent)"),
   ];
   return lines.join("\n");
 }
@@ -63,6 +64,16 @@ const DEFAULT_COMMAND_DENYLIST: RegExp[] = [
   /\bchmod\s+-R\s+777\s+\//i,
 ];
 
+const VALID_REASONING_EFFORTS = new Set<ReasoningEffort>([
+  "xhigh", "high", "medium", "low", "minimal", "none",
+]);
+
+function parseReasoningEffort(value: string | undefined): ReasoningEffort | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim().toLowerCase() as ReasoningEffort;
+  return VALID_REASONING_EFFORTS.has(normalized) ? normalized : undefined;
+}
+
 interface AgentConfigFile {
   modelProvider?: string;
   model?: string;
@@ -84,6 +95,7 @@ interface AgentConfigFile {
   enableToolOutputTruncation?: boolean;
   compactionThreshold?: number;
   compactionModel?: string;
+  reasoningEffort?: string;
 }
 
 function parseNumber(value: string | undefined, fallback: number): number {
@@ -254,6 +266,12 @@ export async function loadAgentConfig(
     ...(process.env.COMPACTION_MODEL ?? fileConfig.compactionModel
       ? { compactionModel: process.env.COMPACTION_MODEL ?? fileConfig.compactionModel }
       : {}),
+    ...(() => {
+      const effort = parseReasoningEffort(
+        process.env.REASONING_EFFORT ?? fileConfig.reasoningEffort,
+      );
+      return effort ? { reasoningEffort: effort } : {};
+    })(),
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import process from "node:process";
 import { writeFile } from "node:fs/promises";
 import { createInterface } from "node:readline/promises";
 
-import { CodingAgent, Session, createModelClient } from "@minicode/agent-sdk";
+import { CodingAgent, Session, createModelClient, type ReasoningEffort } from "@minicode/agent-sdk";
 import { formatConfigForDisplay, loadAgentConfig } from "./agent/config.js";
 import {
   listSessions,
@@ -141,7 +141,7 @@ async function runInteractive(
     }
 
     if (trimmed === "/help") {
-      console.log('Commands: "/help", "/config", "/compact", "/save [label]", "/load [label]", "/sessions", "/exit"');
+      console.log('Commands: "/help", "/config", "/compact", "/reasoning [level]", "/save [label]", "/load [label]", "/sessions", "/exit"');
       console.log("Start with --verbose or -v to log prompts, responses, and tool calls.");
       continue;
     }
@@ -163,6 +163,29 @@ async function runInteractive(
         );
       } else {
         console.log(`Nothing to compact (${tokensBefore} tokens, ${session.getMessages().length} messages).`);
+      }
+      continue;
+    }
+
+    if (trimmed === "/reasoning" || trimmed.startsWith("/reasoning ")) {
+      const VALID_LEVELS: ReasoningEffort[] = ["xhigh", "high", "medium", "low", "minimal", "none"];
+      const arg = trimmed.slice("/reasoning".length).trim().toLowerCase();
+      if (arg.length === 0) {
+        const current = agent.getReasoningEffort() ?? "(unset)";
+        console.log(`Current reasoning effort: ${current}`);
+        console.log(`Valid levels: ${VALID_LEVELS.join(", ")}, off`);
+        continue;
+      }
+      if (arg === "off") {
+        agent.setReasoningEffort(undefined);
+        console.log("Reasoning effort disabled.");
+        continue;
+      }
+      if (VALID_LEVELS.includes(arg as ReasoningEffort)) {
+        agent.setReasoningEffort(arg as ReasoningEffort);
+        console.log(`Reasoning effort set to: ${arg}`);
+      } else {
+        console.log(`Invalid reasoning level "${arg}". Valid levels: ${VALID_LEVELS.join(", ")}, off`);
       }
       continue;
     }

--- a/src/ui/cli-ink.ts
+++ b/src/ui/cli-ink.ts
@@ -1,7 +1,7 @@
 import process from "node:process";
 
 import { CodingAgent, Session, createModelClient } from "@minicode/agent-sdk";
-import type { UiUpdate } from "@minicode/agent-sdk";
+import type { UiUpdate, ReasoningEffort } from "@minicode/agent-sdk";
 import { formatConfigForDisplay, loadAgentConfig } from "../agent/config.js";
 import {
   computeFileHashes,
@@ -150,7 +150,7 @@ export async function runInkCli(
       store.addItem({
         type: "system",
         content:
-          'Commands: "/help", "/config", "/compact", "/save [label]", "/load [label]", "/sessions", "/exit".',
+          'Commands: "/help", "/config", "/compact", "/reasoning [level]", "/save [label]", "/load [label]", "/sessions", "/exit".',
       });
       return;
     }
@@ -179,6 +179,34 @@ export async function runInkCli(
         store.addItem({
           type: "system",
           content: `Nothing to compact (${session.getTokenEstimate()} tokens, ${session.getMessages().length} messages).`,
+        });
+      }
+      return;
+    }
+
+    if (trimmed === "/reasoning" || trimmed.startsWith("/reasoning ")) {
+      const VALID_LEVELS: ReasoningEffort[] = ["xhigh", "high", "medium", "low", "minimal", "none"];
+      const arg = trimmed.slice("/reasoning".length).trim().toLowerCase();
+      if (arg.length === 0) {
+        const current = agent.getReasoningEffort() ?? "(unset)";
+        store.addItem({
+          type: "system",
+          content: `Current reasoning effort: ${current}\nValid levels: ${VALID_LEVELS.join(", ")}, off`,
+        });
+        return;
+      }
+      if (arg === "off") {
+        agent.setReasoningEffort(undefined);
+        store.addItem({ type: "system", content: "Reasoning effort disabled." });
+        return;
+      }
+      if (VALID_LEVELS.includes(arg as ReasoningEffort)) {
+        agent.setReasoningEffort(arg as ReasoningEffort);
+        store.addItem({ type: "system", content: `Reasoning effort set to: ${arg}` });
+      } else {
+        store.addItem({
+          type: "system",
+          content: `Invalid reasoning level "${arg}". Valid levels: ${VALID_LEVELS.join(", ")}, off`,
         });
       }
       return;

--- a/tests/reasoning-effort.test.ts
+++ b/tests/reasoning-effort.test.ts
@@ -1,0 +1,317 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  OpenAICompatibleModelClient,
+  CodingAgent,
+  Session,
+  ToolRegistry,
+} from "@minicode/agent-sdk";
+import type { AgentConfig, ModelResponse, ReasoningEffort } from "@minicode/agent-sdk";
+import { createTestAgentConfig } from "./test-utils.js";
+import { loadAgentConfig } from "../src/agent/config.js";
+
+// ---------------------------------------------------------------------------
+// Config: REASONING_EFFORT env var
+// ---------------------------------------------------------------------------
+
+test("loadAgentConfig parses REASONING_EFFORT env var", async () => {
+  const prev = process.env.REASONING_EFFORT;
+  try {
+    process.env.REASONING_EFFORT = "high";
+    const config = await loadAgentConfig("/tmp");
+    assert.equal(config.reasoningEffort, "high");
+  } finally {
+    if (prev === undefined) {
+      delete process.env.REASONING_EFFORT;
+    } else {
+      process.env.REASONING_EFFORT = prev;
+    }
+  }
+});
+
+test("loadAgentConfig ignores invalid REASONING_EFFORT values", async () => {
+  const prev = process.env.REASONING_EFFORT;
+  try {
+    process.env.REASONING_EFFORT = "ultra";
+    const config = await loadAgentConfig("/tmp");
+    assert.equal(config.reasoningEffort, undefined);
+  } finally {
+    if (prev === undefined) {
+      delete process.env.REASONING_EFFORT;
+    } else {
+      process.env.REASONING_EFFORT = prev;
+    }
+  }
+});
+
+test("loadAgentConfig leaves reasoningEffort undefined when env var is unset", async () => {
+  const prev = process.env.REASONING_EFFORT;
+  try {
+    delete process.env.REASONING_EFFORT;
+    const config = await loadAgentConfig("/tmp");
+    assert.equal(config.reasoningEffort, undefined);
+  } finally {
+    if (prev === undefined) {
+      delete process.env.REASONING_EFFORT;
+    } else {
+      process.env.REASONING_EFFORT = prev;
+    }
+  }
+});
+
+test("loadAgentConfig normalizes REASONING_EFFORT case", async () => {
+  const prev = process.env.REASONING_EFFORT;
+  try {
+    process.env.REASONING_EFFORT = "MEDIUM";
+    const config = await loadAgentConfig("/tmp");
+    assert.equal(config.reasoningEffort, "medium");
+  } finally {
+    if (prev === undefined) {
+      delete process.env.REASONING_EFFORT;
+    } else {
+      process.env.REASONING_EFFORT = prev;
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// OpenAI-compatible client: reasoning field in request body
+// ---------------------------------------------------------------------------
+
+test("openai-compatible client includes reasoning field when reasoningEffort is set", async () => {
+  let capturedBody = "";
+
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    capturedBody = String(init?.body ?? "");
+    return new Response(
+      JSON.stringify({
+        choices: [
+          {
+            finish_reason: "stop",
+            message: { content: "Hello", tool_calls: [] },
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+
+  await client.chat({
+    model: "test-model",
+    system: "System",
+    messages: [{ role: "user", content: "Hi" }],
+    tools: [],
+    maxTokens: 1024,
+    reasoningEffort: "high",
+  });
+
+  const parsed = JSON.parse(capturedBody) as Record<string, unknown>;
+  assert.deepEqual(parsed.reasoning, { effort: "high" });
+});
+
+test("openai-compatible client omits reasoning field when reasoningEffort is not set", async () => {
+  let capturedBody = "";
+
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    capturedBody = String(init?.body ?? "");
+    return new Response(
+      JSON.stringify({
+        choices: [
+          {
+            finish_reason: "stop",
+            message: { content: "Hello", tool_calls: [] },
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+
+  await client.chat({
+    model: "test-model",
+    system: "System",
+    messages: [{ role: "user", content: "Hi" }],
+    tools: [],
+    maxTokens: 1024,
+  });
+
+  const parsed = JSON.parse(capturedBody) as Record<string, unknown>;
+  assert.equal(parsed.reasoning, undefined);
+});
+
+test("openai-compatible client sends all valid effort levels", async () => {
+  const levels: ReasoningEffort[] = ["xhigh", "high", "medium", "low", "minimal", "none"];
+
+  for (const level of levels) {
+    let capturedBody = "";
+
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      capturedBody = String(init?.body ?? "");
+      return new Response(
+        JSON.stringify({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: { content: "Ok", tool_calls: [] },
+            },
+          ],
+          usage: { prompt_tokens: 5, completion_tokens: 2 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    };
+
+    const client = new OpenAICompatibleModelClient({
+      baseUrl: "http://localhost:1234/v1",
+      fetchImpl,
+    });
+
+    await client.chat({
+      model: "test-model",
+      system: "System",
+      messages: [{ role: "user", content: "Hi" }],
+      tools: [],
+      maxTokens: 1024,
+      reasoningEffort: level,
+    });
+
+    const parsed = JSON.parse(capturedBody) as Record<string, unknown>;
+    assert.deepEqual(parsed.reasoning, { effort: level }, `Expected reasoning.effort="${level}"`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// CodingAgent: get/set reasoning effort
+// ---------------------------------------------------------------------------
+
+test("CodingAgent.getReasoningEffort returns config value", () => {
+  const config: AgentConfig = {
+    ...createTestAgentConfig("/tmp"),
+    reasoningEffort: "medium",
+  };
+
+  const mockClient = {
+    async chat(): Promise<ModelResponse> {
+      return {
+        text: "done",
+        toolCalls: [],
+        stopReason: "end_turn",
+        usage: { inputTokens: 0, outputTokens: 0 },
+      };
+    },
+  };
+
+  const agent = new CodingAgent({
+    config,
+    modelClient: mockClient,
+    toolRegistry: new ToolRegistry([]),
+  });
+
+  assert.equal(agent.getReasoningEffort(), "medium");
+});
+
+test("CodingAgent.setReasoningEffort updates reasoning effort", () => {
+  const config = createTestAgentConfig("/tmp");
+
+  const mockClient = {
+    async chat(): Promise<ModelResponse> {
+      return {
+        text: "done",
+        toolCalls: [],
+        stopReason: "end_turn",
+        usage: { inputTokens: 0, outputTokens: 0 },
+      };
+    },
+  };
+
+  const agent = new CodingAgent({
+    config,
+    modelClient: mockClient,
+    toolRegistry: new ToolRegistry([]),
+  });
+
+  assert.equal(agent.getReasoningEffort(), undefined);
+
+  agent.setReasoningEffort("high");
+  assert.equal(agent.getReasoningEffort(), "high");
+
+  agent.setReasoningEffort("none");
+  assert.equal(agent.getReasoningEffort(), "none");
+
+  agent.setReasoningEffort(undefined);
+  assert.equal(agent.getReasoningEffort(), undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Agent loop passes reasoningEffort to model client
+// ---------------------------------------------------------------------------
+
+test("agent loop passes reasoningEffort to model client chat call", async () => {
+  let capturedReasoningEffort: ReasoningEffort | undefined;
+
+  const config: AgentConfig = {
+    ...createTestAgentConfig("/tmp"),
+    reasoningEffort: "low",
+  };
+
+  const mockClient = {
+    async chat(params: { reasoningEffort?: ReasoningEffort }): Promise<ModelResponse> {
+      capturedReasoningEffort = params.reasoningEffort;
+      return {
+        text: "Response",
+        toolCalls: [],
+        stopReason: "end_turn",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      };
+    },
+  };
+
+  const agent = new CodingAgent({
+    config,
+    modelClient: mockClient,
+    toolRegistry: new ToolRegistry([]),
+  });
+
+  await agent.runTurn("Hello");
+  assert.equal(capturedReasoningEffort, "low");
+});
+
+test("agent loop omits reasoningEffort when not configured", async () => {
+  let capturedParams: Record<string, unknown> = {};
+
+  const config = createTestAgentConfig("/tmp");
+
+  const mockClient = {
+    async chat(params: Record<string, unknown>): Promise<ModelResponse> {
+      capturedParams = params;
+      return {
+        text: "Response",
+        toolCalls: [],
+        stopReason: "end_turn",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      };
+    },
+  };
+
+  const agent = new CodingAgent({
+    config,
+    modelClient: mockClient,
+    toolRegistry: new ToolRegistry([]),
+  });
+
+  await agent.runTurn("Hello");
+  assert.equal(capturedParams.reasoningEffort, undefined);
+});


### PR DESCRIPTION
## Summary

Closes #37

- Adds a `reasoningEffort` config option supporting levels: `xhigh`, `high`, `medium`, `low`, `minimal`, `none`
- **OpenAI-compatible / OpenRouter**: sends `reasoning: { effort: "<level>" }` in the request body, matching the [OpenRouter reasoning tokens spec](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens)
- **Anthropic**: maps effort levels to `thinking.budget_tokens` as a percentage of `max_tokens` (e.g. `high` → 80%, `medium` → 50%)
- **LM Studio**: works via the OpenAI-compatible path — same `reasoning.effort` field
- New `REASONING_EFFORT` env var and `reasoningEffort` field in `agent.config.json`
- New `/reasoning [level]` slash command in both CLI UIs to switch levels at runtime (also supports `/reasoning off` to disable)
- Shown in `/config` output
- By default, no reasoning parameters are sent (backward compatible)

## Test plan

- [x] `npm run build` passes
- [x] All 186 tests pass (0 failures)
- [x] New tests cover: config parsing (valid, invalid, case normalization), OpenAI client request body (includes/omits `reasoning` field), agent getter/setter, agent loop forwarding

https://claude.ai/code/session_01VToRHjJfPryFshM2oFt31n