### PR TITLE
Fix unused import lint errors breaking CI

### DIFF
--- a/src/web/graph.ts
+++ b/src/web/graph.ts
@@ -3,7 +3,7 @@
 // Clicking a node expands its 1-hop neighbors. Walk the graph in real time.
 
 import { escapeHtml, renderMarkdownInto } from './utils.ts';
-import { KIND_COLORS, EDGE_STYLES, buildStylesheet } from '../shared/graph-styles.ts';
+import { KIND_COLORS, buildStylesheet } from '../shared/graph-styles.ts';
 
 declare const cytoscape: (opts: unknown) => CyInstance;
 declare const hljs: { highlightElement(el: HTMLElement): void };

--- a/tests/reasoning-effort.test.ts
+++ b/tests/reasoning-effort.test.ts
@@ -4,7 +4,6 @@ import { test } from "node:test";
 import {
   OpenAICompatibleModelClient,
   CodingAgent,
-  Session,
   ToolRegistry,
 } from "@minicode/agent-sdk";
 import type { AgentConfig, ModelResponse, ReasoningEffort } from "@minicode/agent-sdk";


### PR DESCRIPTION
## Summary
- Remove unused `EDGE_STYLES` import in `src/web/graph.ts`
- Remove unused `Session` import in `tests/reasoning-effort.test.ts`

These unused imports cause `@typescript-eslint/no-unused-vars` errors which fail the CI lint step (`--max-warnings=0`).

## Test plan
- [x] `npm run lint` passes with zero warnings
- [x] `npm run build` succeeds
- [x] `npm test` — all 186 tests pass

https://claude.ai/code/session_01BybymbPZWeVKBtoUJoayDj