### PR TITLE
Add model selection to UI and CLI

### DIFF
--- a/packages/agent-sdk/src/agent/types.ts
+++ b/packages/agent-sdk/src/agent/types.ts
@@ -81,6 +81,12 @@ export interface ModelResponse {
   };
 }
 
+/** Describes a model available from the provider. */
+export interface ModelInfo {
+  id: string;
+  name?: string;
+}
+
 export interface ModelClient {
   chat(params: {
     model: string;
@@ -92,4 +98,7 @@ export interface ModelClient {
     onStream?: (chunk: string) => void;
     signal?: AbortSignal;
   }): Promise<ModelResponse>;
+
+  /** List models available from the provider. Returns empty array on failure. */
+  listModels?(): Promise<ModelInfo[]>;
 }

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -3,6 +3,7 @@ export type {
   AgentConfig,
   AssistantMessage,
   ModelClient,
+  ModelInfo,
   ModelResponse,
   ReasoningEffort,
   SessionMessage,

--- a/packages/agent-sdk/src/model/client.ts
+++ b/packages/agent-sdk/src/model/client.ts
@@ -6,6 +6,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import type {
   AgentConfig,
   ModelClient,
+  ModelInfo,
   ModelResponse,
   ReasoningEffort,
   SessionMessage,
@@ -381,6 +382,19 @@ export class AnthropicModelClient implements ModelClient {
 
     return parseResponse(response);
   }
+
+  async listModels(): Promise<ModelInfo[]> {
+    try {
+      const response = await this.client.models.list();
+      const models: ModelInfo[] = [];
+      for await (const model of response) {
+        models.push({ id: model.id, name: model.display_name ?? model.id });
+      }
+      return models;
+    } catch {
+      return [];
+    }
+  }
 }
 
 interface OpenAIStreamChunk {
@@ -586,6 +600,22 @@ export class OpenAICompatibleModelClient implements ModelClient {
     });
 
     return response;
+  }
+
+  async listModels(): Promise<ModelInfo[]> {
+    const headers: Record<string, string> = {};
+    const apiKey = this.apiKey?.trim();
+    if (apiKey && apiKey.length > 0) {
+      headers.Authorization = `Bearer ${apiKey}`;
+    }
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}/models`, { headers });
+      if (!response.ok) return [];
+      const payload = (await response.json()) as { data?: Array<{ id: string; name?: string }> };
+      return (payload.data ?? []).map((m) => ({ id: m.id, name: m.name ?? m.id }));
+    } catch {
+      return [];
+    }
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import process from "node:process";
 import { writeFile } from "node:fs/promises";
 import { createInterface } from "node:readline/promises";
 
-import { CodingAgent, Session, createModelClient, type ReasoningEffort } from "@minicode/agent-sdk";
+import { CodingAgent, Session, createModelClient, type ModelClient, type ReasoningEffort } from "@minicode/agent-sdk";
 import { formatConfigForDisplay, loadAgentConfig } from "./agent/config.js";
 import {
   listSessions,
@@ -37,6 +37,7 @@ function printBanner(): void {
 interface AgentRuntime {
   agent: CodingAgent;
   config: Awaited<ReturnType<typeof loadAgentConfig>>;
+  modelClient: ModelClient;
   toolRegistry: ReturnType<typeof createToolRegistry>;
   projectIndex: Awaited<ReturnType<typeof buildProjectIndex>> | undefined;
   buildAgent: (session?: Session) => CodingAgent;
@@ -78,7 +79,7 @@ async function createAgentRuntime(
     });
   }
 
-  return { agent: buildAgent(), config, toolRegistry, projectIndex, buildAgent };
+  return { agent: buildAgent(), config, modelClient, toolRegistry, projectIndex, buildAgent };
 }
 
 async function runInteractive(
@@ -90,7 +91,7 @@ async function runInteractive(
     (msg) => console.error(`  ${msg}`),
   );
   let { agent } = runtime;
-  const { config, buildAgent } = runtime;
+  const { config, modelClient, buildAgent } = runtime;
 
   printBanner();
   console.log(`Workspace: ${config.workspaceRoot}`);
@@ -141,7 +142,7 @@ async function runInteractive(
     }
 
     if (trimmed === "/help") {
-      console.log('Commands: "/help", "/config", "/compact", "/reasoning [level]", "/save [label]", "/load [label]", "/sessions", "/exit"');
+      console.log('Commands: "/help", "/config", "/compact", "/reasoning [level]", "/models", "/model [name]", "/save [label]", "/load [label]", "/sessions", "/exit"');
       console.log("Start with --verbose or -v to log prompts, responses, and tool calls.");
       continue;
     }
@@ -187,6 +188,41 @@ async function runInteractive(
       } else {
         console.log(`Invalid reasoning level "${arg}". Valid levels: ${VALID_LEVELS.join(", ")}, off`);
       }
+      continue;
+    }
+
+    if (trimmed === "/models") {
+      if (modelClient.listModels) {
+        console.log("Fetching models...");
+        const models = await modelClient.listModels();
+        if (models.length === 0) {
+          console.log("No models found (provider may not support listing).");
+        } else {
+          console.log(`Available models (${models.length}):`);
+          for (const m of models) {
+            const marker = m.id === config.model ? " (active)" : "";
+            console.log(`  ${m.id}${marker}`);
+          }
+        }
+      } else {
+        console.log("Current provider does not support listing models.");
+      }
+      continue;
+    }
+
+    if (trimmed.startsWith("/model ")) {
+      const newModel = trimmed.slice("/model ".length).trim();
+      if (newModel.length === 0) {
+        console.log(`Current model: ${config.model}`);
+        continue;
+      }
+      (config as { model: string }).model = newModel;
+      console.log(`Model switched to: ${newModel}`);
+      continue;
+    }
+
+    if (trimmed === "/model") {
+      console.log(`Current model: ${config.model}`);
       continue;
     }
 

--- a/src/serve/agent-bridge.ts
+++ b/src/serve/agent-bridge.ts
@@ -1,5 +1,5 @@
 import { CodingAgent, Session, createModelClient } from "@minicode/agent-sdk";
-import type { UiUpdate } from "@minicode/agent-sdk";
+import type { ModelInfo, UiUpdate } from "@minicode/agent-sdk";
 import { loadAgentConfig } from "../agent/config.js";
 import {
   computeFileHashes,
@@ -23,6 +23,7 @@ export type UiListener = (msg: ServerMessage) => void;
 export class AgentBridge {
   private agent!: CodingAgent;
   private config!: Awaited<ReturnType<typeof loadAgentConfig>>;
+  private modelClient!: ReturnType<typeof createModelClient>;
   private projectIndex: ProjectIndex | undefined;
   private buildAgent!: (session?: Session, onUiUpdate?: (event: UiUpdate) => void) => CodingAgent;
   private busy = false;
@@ -82,6 +83,7 @@ export class AgentBridge {
     };
 
     this.config = config;
+    this.modelClient = modelClient;
     this.projectIndex = projectIndex;
 
     this.buildAgent = (session?: Session, onUiUpdate?: (event: UiUpdate) => void): CodingAgent => {
@@ -385,6 +387,19 @@ export class AgentBridge {
     }
 
     return result;
+  }
+
+  // ── Model selection ──
+
+  async listModels(): Promise<ModelInfo[]> {
+    if (this.modelClient.listModels) {
+      return this.modelClient.listModels();
+    }
+    return [];
+  }
+
+  switchModel(modelId: string): void {
+    (this.config as { model: string }).model = modelId;
   }
 
   // ── Explain ──

--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -95,6 +95,23 @@ export function createRequestHandler(bridge: AgentBridge): (req: IncomingMessage
         return;
       }
 
+      if (pathname === "/api/models" && method === "GET") {
+        const models = await bridge.listModels();
+        sendJson(res, 200, { models, activeModel: config.model });
+        return;
+      }
+
+      if (pathname === "/api/model" && method === "POST") {
+        const body = JSON.parse(await readBody(req)) as { model?: string };
+        if (!body.model || typeof body.model !== "string") {
+          sendJson(res, 400, { error: "model is required" });
+          return;
+        }
+        bridge.switchModel(body.model);
+        sendJson(res, 200, { model: body.model });
+        return;
+      }
+
       if (pathname === "/api/config" && method === "GET") {
         sendJson(res, 200, { config: formatConfigForDisplay(config) });
         return;

--- a/src/serve/types.ts
+++ b/src/serve/types.ts
@@ -11,7 +11,12 @@ export interface ClientCancelMessage {
   type: "cancel";
 }
 
-export type ClientMessage = ClientChatMessage | ClientCancelMessage;
+export interface ClientSwitchModelMessage {
+  type: "switch_model";
+  model: string;
+}
+
+export type ClientMessage = ClientChatMessage | ClientCancelMessage | ClientSwitchModelMessage;
 
 // ── Server → Client ──
 
@@ -63,6 +68,11 @@ export interface ServerBusyMessage {
   type: "busy";
 }
 
+export interface ServerModelChangedMessage {
+  type: "model_changed";
+  model: string;
+}
+
 export type ServerMessage =
   | ServerTurnStartMessage
   | ServerThinkingMessage
@@ -72,4 +82,5 @@ export type ServerMessage =
   | ServerToolCallEndMessage
   | ServerTurnEndMessage
   | ServerErrorMessage
-  | ServerBusyMessage;
+  | ServerBusyMessage
+  | ServerModelChangedMessage;

--- a/src/serve/websocket.ts
+++ b/src/serve/websocket.ts
@@ -28,6 +28,13 @@ export function createWebSocketServer(
         });
       } else if (msg.type === "cancel") {
         bridge.cancel();
+      } else if (msg.type === "switch_model") {
+        bridge.switchModel(msg.model);
+        const changed: ServerMessage = { type: "model_changed", model: msg.model };
+        // Broadcast to all clients
+        for (const client of wss.clients) {
+          client.send(JSON.stringify(changed));
+        }
       }
     });
   });

--- a/src/ui/cli-ink.ts
+++ b/src/ui/cli-ink.ts
@@ -150,7 +150,7 @@ export async function runInkCli(
       store.addItem({
         type: "system",
         content:
-          'Commands: "/help", "/config", "/compact", "/reasoning [level]", "/save [label]", "/load [label]", "/sessions", "/exit".',
+          'Commands: "/help", "/config", "/compact", "/reasoning [level]", "/models", "/model [name]", "/save [label]", "/load [label]", "/sessions", "/exit".',
       });
       return;
     }
@@ -209,6 +209,42 @@ export async function runInkCli(
           content: `Invalid reasoning level "${arg}". Valid levels: ${VALID_LEVELS.join(", ")}, off`,
         });
       }
+      return;
+    }
+
+    if (trimmed === "/models") {
+      if (modelClient.listModels) {
+        store.addItem({ type: "system", content: "Fetching models..." });
+        const models = await modelClient.listModels();
+        if (models.length === 0) {
+          store.addItem({ type: "system", content: "No models found (provider may not support listing)." });
+        } else {
+          const lines = models.map((m) => {
+            const marker = m.id === config.model ? " (active)" : "";
+            return `  ${m.id}${marker}`;
+          });
+          store.addItem({ type: "system", content: `Available models (${models.length}):\n${lines.join("\n")}` });
+        }
+      } else {
+        store.addItem({ type: "system", content: "Current provider does not support listing models." });
+      }
+      return;
+    }
+
+    if (trimmed.startsWith("/model ")) {
+      const newModel = trimmed.slice("/model ".length).trim();
+      if (newModel.length === 0) {
+        store.addItem({ type: "system", content: `Current model: ${config.model}` });
+        return;
+      }
+      (config as { model: string }).model = newModel;
+      store.setConfig({ model: newModel, workspaceRoot: config.workspaceRoot, maxSteps: config.maxSteps, indexStatus: "" });
+      store.addItem({ type: "system", content: `Model switched to: ${newModel}` });
+      return;
+    }
+
+    if (trimmed === "/model") {
+      store.addItem({ type: "system", content: `Current model: ${config.model}` });
       return;
     }
 

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -30,6 +30,9 @@ const sendBtn = document.getElementById("send-btn") as HTMLButtonElement;
 const cancelBtn = document.getElementById("cancel-btn") as HTMLButtonElement;
 const statusBadge = document.getElementById("status-badge")!;
 const modelInfo = document.getElementById("model-info")!;
+const modelBtn = document.getElementById("model-btn")!;
+const modelDropdown = document.getElementById("model-dropdown")!;
+const modelList = document.getElementById("model-list")!;
 const sessionBtn = document.getElementById("session-btn")!;
 const sessionDropdown = document.getElementById("session-dropdown")!;
 const sessionList = document.getElementById("session-list")!;
@@ -83,7 +86,8 @@ async function fetchStatus(): Promise<void> {
   try {
     const res = await fetch("/api/status");
     const data = await res.json() as StatusResponse;
-    modelInfo.textContent = `${data.model} · ${data.provider}`;
+    modelInfo.textContent = `${data.model}`;
+    activeModel = data.model;
   } catch {
     // ignore
   }
@@ -172,6 +176,10 @@ function handleServerMessage(msg: ServerMessage): void {
 
     case "busy":
       addMessage("Agent is busy. Please wait for the current turn to finish.", "error");
+      break;
+
+    case "model_changed":
+      modelInfo.textContent = (msg as ServerMessage & { model: string }).model;
       break;
   }
 }
@@ -296,6 +304,60 @@ chatInput.addEventListener("keydown", (e: KeyboardEvent) => {
     chatForm.dispatchEvent(new Event("submit"));
   }
 });
+
+// -- Model selection --
+
+let activeModel = "";
+
+modelBtn.addEventListener("click", (e: Event) => {
+  e.stopPropagation();
+  const isOpen = !modelDropdown.classList.contains("hidden");
+  modelDropdown.classList.toggle("hidden");
+  // Close session dropdown if open
+  sessionDropdown.classList.add("hidden");
+  if (!isOpen) {
+    refreshModelList();
+  }
+});
+
+document.addEventListener("click", (e: Event) => {
+  if (!modelDropdown.contains(e.target as Node) && e.target !== modelBtn) {
+    modelDropdown.classList.add("hidden");
+  }
+});
+
+async function refreshModelList(): Promise<void> {
+  try {
+    const res = await fetch("/api/models");
+    const data = await res.json() as { models: Array<{ id: string; name?: string }>; activeModel: string };
+    activeModel = data.activeModel;
+
+    if (!data.models || data.models.length === 0) {
+      modelList.innerHTML = '<div class="dropdown-empty">No models available</div>';
+      return;
+    }
+
+    modelList.innerHTML = "";
+    for (const m of data.models) {
+      const el = document.createElement("div");
+      el.className = "model-item" + (m.id === activeModel ? " active" : "");
+      el.textContent = m.name ?? m.id;
+      el.title = m.id;
+      el.addEventListener("click", () => switchModel(m.id));
+      modelList.appendChild(el);
+    }
+  } catch {
+    modelList.innerHTML = '<div class="dropdown-empty">Failed to load models</div>';
+  }
+}
+
+function switchModel(modelId: string): void {
+  ws.send(JSON.stringify({ type: "switch_model", model: modelId }));
+  modelInfo.textContent = modelId;
+  activeModel = modelId;
+  modelDropdown.classList.add("hidden");
+  addMessage(`Model switched to: ${modelId}`, "thinking");
+}
 
 // -- Session management --
 

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -18,7 +18,14 @@
         <span id="status-badge" class="badge ready">ready</span>
       </div>
       <div class="header-right">
-        <span id="model-info"></span>
+        <div class="model-menu">
+          <button id="model-btn" class="header-btn" title="Switch model"><span id="model-info"></span> ▾</button>
+          <div id="model-dropdown" class="dropdown hidden">
+            <div id="model-list" class="dropdown-section">
+              <div class="dropdown-empty">Loading models...</div>
+            </div>
+          </div>
+        </div>
         <button id="graph-toggle" class="header-btn" title="Toggle graph pane">Graph</button>
         <div class="session-menu">
           <button id="session-btn" class="header-btn" title="Sessions">Sessions</button>

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -68,6 +68,47 @@ h1 {
   color: var(--text-dim);
 }
 
+/* Model menu */
+.model-menu {
+  position: relative;
+}
+
+#model-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+#model-dropdown {
+  max-height: 320px;
+}
+
+#model-list {
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.model-item {
+  padding: 6px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  transition: background 0.15s;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.model-item:hover {
+  background: var(--bg-hover);
+}
+
+.model-item.active {
+  color: var(--accent);
+  font-weight: 600;
+}
+
 /* Session menu */
 .session-menu {
   position: relative;

--- a/tests/model-selection.test.ts
+++ b/tests/model-selection.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createServer } from "node:http";
+import type { Server } from "node:http";
+
+import { OpenAICompatibleModelClient } from "@minicode/agent-sdk";
+import type { ModelInfo } from "@minicode/agent-sdk";
+import { createRequestHandler } from "../src/serve/server.js";
+import { AgentBridge } from "../src/serve/agent-bridge.js";
+import { createTestAgentConfig } from "./test-utils.js";
+
+// ── OpenAI-compatible listModels ──
+
+test("openai-compatible listModels fetches /models and parses response", async () => {
+  const fetchImpl: typeof fetch = async (input) => {
+    assert.ok(String(input).endsWith("/models"));
+    return new Response(
+      JSON.stringify({
+        data: [
+          { id: "model-a", name: "Model A" },
+          { id: "model-b" },
+        ],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+
+  const models = await client.listModels();
+  assert.equal(models.length, 2);
+  assert.equal(models[0]!.id, "model-a");
+  assert.equal(models[0]!.name, "Model A");
+  assert.equal(models[1]!.id, "model-b");
+  assert.equal(models[1]!.name, "model-b"); // falls back to id
+});
+
+test("openai-compatible listModels returns empty array on error", async () => {
+  const fetchImpl: typeof fetch = async () => {
+    return new Response("Server error", { status: 500 });
+  };
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+
+  const models = await client.listModels();
+  assert.deepEqual(models, []);
+});
+
+test("openai-compatible listModels returns empty array on network failure", async () => {
+  const fetchImpl: typeof fetch = async () => {
+    throw new Error("Connection refused");
+  };
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+
+  const models = await client.listModels();
+  assert.deepEqual(models, []);
+});
+
+// ── Serve API /api/models and /api/model ──
+
+class MockBridgeForModels extends AgentBridge {
+  constructor() {
+    super(() => {}, false);
+  }
+
+  override isBusy(): boolean {
+    return false;
+  }
+
+  override getConfig() {
+    return createTestAgentConfig("/tmp/test-workspace");
+  }
+
+  override async listModels(): Promise<ModelInfo[]> {
+    return [
+      { id: "model-x", name: "Model X" },
+      { id: "model-y", name: "Model Y" },
+    ];
+  }
+
+  override switchModel(modelId: string): void {
+    (this.getConfig() as { model: string }).model = modelId;
+  }
+
+  override async runTurn(message: string) {
+    return { text: `Echo: ${message}`, usage: { inputTokens: 1, outputTokens: 1 } };
+  }
+
+  override async listSess() { return []; }
+  override hasIndex() { return false; }
+}
+
+function startTestServer(bridge: AgentBridge): Promise<{ server: Server; port: number }> {
+  return new Promise((resolve) => {
+    const handler = createRequestHandler(bridge);
+    const server = createServer(handler);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address()!;
+      const port = typeof addr === "string" ? 0 : addr.port;
+      resolve({ server, port });
+    });
+  });
+}
+
+test("GET /api/models returns model list and active model", async () => {
+  const bridge = new MockBridgeForModels();
+  const { server, port } = await startTestServer(bridge);
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/api/models`);
+    assert.equal(res.status, 200);
+    const data = (await res.json()) as { models: ModelInfo[]; activeModel: string };
+    assert.equal(data.models.length, 2);
+    assert.equal(data.models[0]!.id, "model-x");
+    assert.equal(data.activeModel, "test-model");
+  } finally {
+    server.close();
+  }
+});
+
+test("POST /api/model switches the active model", async () => {
+  const bridge = new MockBridgeForModels();
+  const { server, port } = await startTestServer(bridge);
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/api/model`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "model-y" }),
+    });
+    assert.equal(res.status, 200);
+    const data = (await res.json()) as { model: string };
+    assert.equal(data.model, "model-y");
+  } finally {
+    server.close();
+  }
+});
+
+test("POST /api/model returns 400 when model is missing", async () => {
+  const bridge = new MockBridgeForModels();
+  const { server, port } = await startTestServer(bridge);
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/api/model`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    assert.equal(res.status, 400);
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
## Summary
- Add `listModels()` to `ModelClient` interface with implementations for OpenAI-compatible (fetches `/models` endpoint) and Anthropic (uses SDK `models.list()`) providers
- Add `/models` and `/model [name]` slash commands to both legacy CLI and Ink UI for listing available models and switching at runtime
- Add `GET /api/models` and `POST /api/model` REST endpoints, `switch_model` WebSocket message type, and `model_changed` broadcast for serve mode
- Add model selector dropdown to web UI header with active model highlighting
- Add 6 tests covering `listModels` parsing, error handling, and serve API endpoints

Closes #38

## Test plan
- [x] All 198 tests pass (6 new + 192 existing)
- [x] `npm run lint` passes with 0 warnings
- [x] `npm run build` compiles successfully
- [ ] Manual: verify `/models` and `/model <name>` in CLI
- [ ] Manual: verify model dropdown in web UI (`minicode serve`)

https://claude.ai/code/session_01XDFJiwGrnK8p8dz6dLKftE