### PR TITLE
Add benchmark harness for agent quality and efficiency

### DIFF
--- a/benchmarks/tasks/debugging/debug-runtime-bug/task.json
+++ b/benchmarks/tasks/debugging/debug-runtime-bug/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Debug a runtime configuration issue",
+  "prompt": "A user reports that setting MAX_CONTEXT_TOKENS in their .env has no effect. Trace the config loading path and identify where the environment variable is read and converted.",
+  "rubric": {
+    "expectedOutputPatterns": ["MAX_CONTEXT_TOKENS", "config", "env"],
+    "expectedFilesRead": ["config.ts"],
+    "maxToolCalls": 15
+  }
+}

--- a/benchmarks/tasks/debugging/diagnose-failing-test/task.json
+++ b/benchmarks/tasks/debugging/diagnose-failing-test/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Diagnose a failing test scenario",
+  "prompt": "Look at the agent test file. If the loop detection test was failing because the agent kept running past 3 repeated calls, where would you look to debug this? Identify the loop detection code path.",
+  "rubric": {
+    "expectedOutputPatterns": ["loop", "fingerprint", "detection"],
+    "expectedFilesRead": ["agent.ts"],
+    "maxToolCalls": 15
+  }
+}

--- a/benchmarks/tasks/debugging/diagnose-type-error/task.json
+++ b/benchmarks/tasks/debugging/diagnose-type-error/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Diagnose a TypeScript type error",
+  "prompt": "If you got a TypeScript error 'Property toolCalls does not exist on type SessionMessage', how would you fix it? Explain the type union and the correct way to access toolCalls.",
+  "rubric": {
+    "expectedOutputPatterns": ["AssistantMessage", "toolCalls", "role"],
+    "expectedFilesRead": ["types.ts"],
+    "maxToolCalls": 10
+  }
+}

--- a/benchmarks/tasks/debugging/root-cause-from-symptom/task.json
+++ b/benchmarks/tasks/debugging/root-cause-from-symptom/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Find root cause from symptom description",
+  "prompt": "A user reports that the code map is always empty even though their project has TypeScript files. What could cause buildProjectIndex to return no symbols? Trace the code path.",
+  "rubric": {
+    "expectedOutputPatterns": ["collectSourceFiles", "plugin", "extensions"],
+    "expectedFilesRead": ["project-index.ts"],
+    "maxToolCalls": 15
+  }
+}

--- a/benchmarks/tasks/debugging/websocket-connection-issue/task.json
+++ b/benchmarks/tasks/debugging/websocket-connection-issue/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Debug WebSocket connection issue",
+  "prompt": "If the web UI connects but never receives streaming updates, where would you look in the serve code to debug this? Identify the WebSocket message flow.",
+  "rubric": {
+    "expectedOutputPatterns": ["WebSocket", "ws", "stream"],
+    "expectedFilesRead": ["websocket.ts"],
+    "maxToolCalls": 15
+  }
+}

--- a/benchmarks/tasks/editing/add-config-field/task.json
+++ b/benchmarks/tasks/editing/add-config-field/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Add a new configuration field",
+  "prompt": "Add a new optional 'enableBenchmarkMode' boolean field to AgentConfig. Show what changes would be needed in the types file.",
+  "rubric": {
+    "expectedOutputPatterns": ["enableBenchmarkMode", "AgentConfig"],
+    "expectedFilesRead": ["types.ts"],
+    "maxToolCalls": 10
+  }
+}

--- a/benchmarks/tasks/editing/add-logging/task.json
+++ b/benchmarks/tasks/editing/add-logging/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Add debug logging to tool execution",
+  "prompt": "In the ToolRegistry class, add a console.error debug log that prints the tool name and execution time whenever a tool is executed. Only log if a verbose flag is passed.",
+  "rubric": {
+    "expectedOutputPatterns": ["ToolRegistry", "execute", "console"],
+    "expectedFilesRead": ["registry.ts"],
+    "maxToolCalls": 15
+  }
+}

--- a/benchmarks/tasks/editing/add-validation/task.json
+++ b/benchmarks/tasks/editing/add-validation/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Add input validation to a function",
+  "prompt": "In the read_file tool, add validation that rejects file paths containing '..' path traversal. Return an error message if detected.",
+  "rubric": {
+    "expectedOutputPatterns": ["\\.\\."],
+    "expectedFilesRead": ["read-file.ts"],
+    "maxToolCalls": 15
+  }
+}

--- a/benchmarks/tasks/editing/fix-small-bug/task.json
+++ b/benchmarks/tasks/editing/fix-small-bug/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Fix a missing null check",
+  "prompt": "In the code map generation, what happens if tokenBudget is 0 or negative? Identify the file and add a guard that returns an empty code map for invalid budgets.",
+  "rubric": {
+    "expectedOutputPatterns": ["budget", "code.?map"],
+    "expectedFilesRead": ["code-map.ts"],
+    "maxToolCalls": 15
+  }
+}

--- a/benchmarks/tasks/editing/rename-symbol/task.json
+++ b/benchmarks/tasks/editing/rename-symbol/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Safely rename a local variable",
+  "prompt": "In session.ts, find the trim() method. Rename the local variable 'estimate' to 'tokenEstimate' if one exists, or describe what local variables the trim method uses.",
+  "rubric": {
+    "expectedOutputPatterns": ["trim", "session"],
+    "expectedFilesRead": ["session.ts"],
+    "maxToolCalls": 10
+  }
+}

--- a/benchmarks/tasks/navigation/explain-feature-flow/task.json
+++ b/benchmarks/tasks/navigation/explain-feature-flow/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Explain the indexing flow",
+  "prompt": "Explain how the project indexing flow works, from buildProjectIndex through plugin loading to symbol extraction. Trace the code path.",
+  "rubric": {
+    "expectedOutputPatterns": ["buildProjectIndex", "plugin", "indexFile", "symbol"],
+    "expectedFilesRead": ["project-index.ts"],
+    "maxToolCalls": 15
+  }
+}

--- a/benchmarks/tasks/navigation/find-all-references/task.json
+++ b/benchmarks/tasks/navigation/find-all-references/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Find all references to buildProjectIndex",
+  "prompt": "Find all files that reference or call buildProjectIndex. List each file path.",
+  "rubric": {
+    "expectedOutputPatterns": ["buildProjectIndex", "project-index"],
+    "expectedSymbols": ["buildProjectIndex"],
+    "maxToolCalls": 10
+  }
+}

--- a/benchmarks/tasks/navigation/find-symbol-definition/task.json
+++ b/benchmarks/tasks/navigation/find-symbol-definition/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Find where CodingAgent is defined",
+  "prompt": "Find where the CodingAgent class is defined. Tell me the file path and line number.",
+  "rubric": {
+    "expectedOutputPatterns": ["CodingAgent", "agent\\.ts"],
+    "expectedFilesRead": ["agent.ts"],
+    "maxToolCalls": 10
+  }
+}

--- a/benchmarks/tasks/navigation/find-tool-registration/task.json
+++ b/benchmarks/tasks/navigation/find-tool-registration/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Find where tools are registered",
+  "prompt": "Find where the agent tools (read_file, write_file, etc.) are registered and assembled into a ToolRegistry. Give me the file and the function name.",
+  "rubric": {
+    "expectedOutputPatterns": ["createToolRegistry", "registry"],
+    "expectedFilesRead": ["registry.ts"],
+    "maxToolCalls": 10
+  }
+}

--- a/benchmarks/tasks/navigation/identify-module-deps/task.json
+++ b/benchmarks/tasks/navigation/identify-module-deps/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Identify dependencies of Session class",
+  "prompt": "What does the Session class depend on? List its imports and any types or modules it references.",
+  "rubric": {
+    "expectedOutputPatterns": ["Session", "session"],
+    "expectedFilesRead": ["session.ts"],
+    "maxToolCalls": 10
+  }
+}

--- a/benchmarks/tasks/planning/explain-context-trimming/task.json
+++ b/benchmarks/tasks/planning/explain-context-trimming/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Explain the context trimming strategy",
+  "prompt": "Explain how minicode manages context window limits. Describe the trimming phases, what gets removed first, and how compaction works.",
+  "rubric": {
+    "expectedOutputPatterns": ["trim", "compact", "phase", "token"],
+    "expectedFilesRead": ["session.ts"],
+    "maxToolCalls": 15
+  }
+}

--- a/benchmarks/tasks/planning/explain-indexing-pipeline/task.json
+++ b/benchmarks/tasks/planning/explain-indexing-pipeline/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Explain the indexing pipeline architecture",
+  "prompt": "Explain how indexing flows into prompt construction in minicode. Start from buildProjectIndex and trace through to where the code map appears in the system prompt.",
+  "rubric": {
+    "expectedOutputPatterns": ["buildProjectIndex", "code.?map", "system.?prompt"],
+    "expectedFilesRead": ["project-index.ts"],
+    "maxToolCalls": 15
+  }
+}

--- a/benchmarks/tasks/planning/explain-plugin-system/task.json
+++ b/benchmarks/tasks/planning/explain-plugin-system/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Explain how to add a new language plugin",
+  "prompt": "Explain step-by-step how to add a new language plugin to minicode. What interface must be implemented? Where are plugins loaded? How are they discovered?",
+  "rubric": {
+    "expectedOutputPatterns": ["LanguagePlugin", "indexFile", "extensions"],
+    "expectedFilesRead": ["plugin-loader.ts"],
+    "maxToolCalls": 15
+  }
+}

--- a/benchmarks/tasks/planning/identify-serve-codepath/task.json
+++ b/benchmarks/tasks/planning/identify-serve-codepath/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Identify the serve mode code path",
+  "prompt": "Trace the code path when a user runs 'minicode serve'. How does the HTTP server start? How are API routes registered? How does the WebSocket streaming work?",
+  "rubric": {
+    "expectedOutputPatterns": ["serve", "server", "route", "WebSocket"],
+    "expectedFilesRead": ["server.ts"],
+    "maxToolCalls": 15
+  }
+}

--- a/benchmarks/tasks/planning/plan-new-tool/task.json
+++ b/benchmarks/tasks/planning/plan-new-tool/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Plan adding a new tool to the agent",
+  "prompt": "Plan what would be needed to add a new 'run_tests' tool to minicode. Where would the tool be defined? How would it be registered? What safety considerations apply?",
+  "rubric": {
+    "expectedOutputPatterns": ["ToolDefinition", "registry", "execute"],
+    "expectedFilesRead": ["registry.ts"],
+    "maxToolCalls": 15
+  }
+}

--- a/benchmarks/tasks/refactors/add-required-argument/task.json
+++ b/benchmarks/tasks/refactors/add-required-argument/task.json
@@ -1,0 +1,8 @@
+{
+  "title": "Propagate a new required argument",
+  "prompt": "If the modelClient.chat() method required a new 'temperature' parameter, which call sites would need to be updated? List every file that calls chat().",
+  "rubric": {
+    "expectedOutputPatterns": ["chat", "agent"],
+    "maxToolCalls": 15
+  }
+}

--- a/benchmarks/tasks/refactors/consolidate-duplicates/task.json
+++ b/benchmarks/tasks/refactors/consolidate-duplicates/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Find and consolidate duplicate logic",
+  "prompt": "Find any duplicated logic between the TypeScript plugin's indexFile and resolveDependencies methods. Are there AST walking patterns that could be shared?",
+  "rubric": {
+    "expectedOutputPatterns": ["typescript", "AST", "plugin"],
+    "expectedFilesRead": ["typescript.ts"],
+    "maxToolCalls": 15
+  }
+}

--- a/benchmarks/tasks/refactors/extract-helper/task.json
+++ b/benchmarks/tasks/refactors/extract-helper/task.json
@@ -1,0 +1,8 @@
+{
+  "title": "Extract a shared helper function",
+  "prompt": "In the codebase, find places where file extension checking is done (checking if a file ends with .ts, .tsx, .js, .jsx). Propose extracting a shared helper function for this.",
+  "rubric": {
+    "expectedOutputPatterns": ["extension", "\\.ts"],
+    "maxToolCalls": 15
+  }
+}

--- a/benchmarks/tasks/refactors/move-logic-to-helper/task.json
+++ b/benchmarks/tasks/refactors/move-logic-to-helper/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Move repeated config logic to shared helper",
+  "prompt": "Find where .env file loading happens in the config system. Is the dotenv loading logic repeated anywhere? If so, propose how to consolidate it.",
+  "rubric": {
+    "expectedOutputPatterns": ["config", "env", "dotenv"],
+    "expectedFilesRead": ["config.ts"],
+    "maxToolCalls": 15
+  }
+}

--- a/benchmarks/tasks/refactors/update-shared-interface/task.json
+++ b/benchmarks/tasks/refactors/update-shared-interface/task.json
@@ -1,0 +1,9 @@
+{
+  "title": "Update a shared interface across files",
+  "prompt": "If we add a 'priority' field to the IndexedSymbol interface, which files would need to be updated? List all files that construct or destructure IndexedSymbol objects.",
+  "rubric": {
+    "expectedOutputPatterns": ["IndexedSymbol"],
+    "expectedSymbols": ["IndexedSymbol"],
+    "maxToolCalls": 15
+  }
+}

--- a/src/benchmark/evaluator.ts
+++ b/src/benchmark/evaluator.ts
@@ -1,0 +1,111 @@
+/**
+ * Evaluates a benchmark trace against a task's rubric.
+ */
+
+import type {
+  BenchmarkEvaluation,
+  BenchmarkRubric,
+  BenchmarkTrace,
+  EfficiencyMetrics,
+  EvaluationCheck,
+} from "./types.js";
+
+/**
+ * Evaluate a benchmark trace against the task rubric.
+ */
+export function evaluate(
+  taskId: string,
+  rubric: BenchmarkRubric,
+  trace: BenchmarkTrace,
+): BenchmarkEvaluation {
+  const checks: EvaluationCheck[] = [];
+
+  // 1. Check expected output patterns
+  if (rubric.expectedOutputPatterns) {
+    for (const pattern of rubric.expectedOutputPatterns) {
+      const regex = new RegExp(pattern, "i");
+      checks.push({
+        name: `output matches /${pattern}/i`,
+        passed: regex.test(trace.response),
+        detail: regex.test(trace.response)
+          ? undefined
+          : `Pattern not found in response`,
+      });
+    }
+  }
+
+  // 2. Check expected files read
+  if (rubric.expectedFilesRead) {
+    for (const expectedFile of rubric.expectedFilesRead) {
+      const found = trace.filesRead.some(
+        (f) => f === expectedFile || f.endsWith(expectedFile),
+      );
+      checks.push({
+        name: `read file ${expectedFile}`,
+        passed: found,
+        detail: found ? undefined : `File was not read during the run`,
+      });
+    }
+  }
+
+  // 3. Check expected symbols queried
+  if (rubric.expectedSymbols) {
+    for (const sym of rubric.expectedSymbols) {
+      const found = trace.symbolsQueried.some(
+        (s) => s === sym || s.includes(sym),
+      );
+      checks.push({
+        name: `queried symbol ${sym}`,
+        passed: found,
+        detail: found ? undefined : `Symbol was not queried`,
+      });
+    }
+  }
+
+  // 4. Check forbidden patterns
+  if (rubric.forbiddenPatterns) {
+    for (const pattern of rubric.forbiddenPatterns) {
+      const regex = new RegExp(pattern, "i");
+      const absent = !regex.test(trace.response);
+      checks.push({
+        name: `output does NOT match /${pattern}/i`,
+        passed: absent,
+        detail: absent ? undefined : `Forbidden pattern found in response`,
+      });
+    }
+  }
+
+  // 5. Efficiency metrics
+  const efficiency = computeEfficiency(rubric, trace);
+
+  const allChecksPassed = checks.every((c) => c.passed);
+
+  return {
+    taskId,
+    passed: allChecksPassed,
+    checks,
+    efficiency,
+  };
+}
+
+function computeEfficiency(
+  rubric: BenchmarkRubric,
+  trace: BenchmarkTrace,
+): EfficiencyMetrics {
+  const toolCallCount = trace.toolCalls.length;
+  const totalTokens = trace.usage.totalTokens;
+
+  const withinToolBudget =
+    rubric.maxToolCalls == null || toolCallCount <= rubric.maxToolCalls;
+  const withinTokenBudget =
+    rubric.maxTotalTokens == null || totalTokens <= rubric.maxTotalTokens;
+
+  return {
+    toolCallCount,
+    totalTokens,
+    durationMs: trace.durationMs,
+    filesReadCount: trace.filesRead.length,
+    symbolsQueriedCount: trace.symbolsQueried.length,
+    withinBudget: withinToolBudget && withinTokenBudget,
+  };
+}

--- a/src/benchmark/index.ts
+++ b/src/benchmark/index.ts
@@ -1,0 +1,27 @@
+export type {
+  BenchmarkCategory,
+  BenchmarkEvaluation,
+  BenchmarkReport,
+  BenchmarkResult,
+  BenchmarkRubric,
+  BenchmarkTask,
+  BenchmarkTrace,
+  CapturedToolCall,
+  EfficiencyMetrics,
+  EvaluationCheck,
+  ReportSummary,
+} from "./types.js";
+
+export { loadBenchmarkTask, loadBenchmarkTasks } from "./task-loader.js";
+export { evaluate } from "./evaluator.js";
+export {
+  runBenchmarkTask,
+  runBenchmarkSuite,
+  type RunnerOptions,
+} from "./runner.js";
+export {
+  buildReport,
+  buildReportFromEvaluations,
+  formatReport,
+  compareReports,
+} from "./reporter.js";

--- a/src/benchmark/reporter.ts
+++ b/src/benchmark/reporter.ts
@@ -1,0 +1,250 @@
+/**
+ * Generates benchmark reports from evaluation results and traces.
+ */
+
+import type {
+  BenchmarkEvaluation,
+  BenchmarkReport,
+  BenchmarkResult,
+  BenchmarkTrace,
+  ReportSummary,
+  BenchmarkTask,
+} from "./types.js";
+import { evaluate } from "./evaluator.js";
+
+/**
+ * Build a full benchmark report from tasks and their traces.
+ */
+export function buildReport(
+  tasks: BenchmarkTask[],
+  traces: BenchmarkTrace[],
+  variant: string,
+  model: string,
+): BenchmarkReport {
+  const taskMap = new Map(tasks.map((t) => [t.id, t]));
+
+  const results: BenchmarkResult[] = traces.map((trace) => {
+    const task = taskMap.get(trace.taskId);
+    if (!task) {
+      throw new Error(`No task definition found for trace: ${trace.taskId}`);
+    }
+    const evaluation = evaluate(task.id, task.rubric, trace);
+    return {
+      taskId: task.id,
+      category: task.category,
+      evaluation,
+      trace,
+    };
+  });
+
+  return {
+    variant,
+    model,
+    generatedAt: new Date().toISOString(),
+    results,
+    summary: computeSummary(results),
+  };
+}
+
+/**
+ * Build a report from pre-computed evaluations and traces.
+ */
+export function buildReportFromEvaluations(
+  evaluations: BenchmarkEvaluation[],
+  traces: BenchmarkTrace[],
+  tasks: BenchmarkTask[],
+  variant: string,
+  model: string,
+): BenchmarkReport {
+  const taskMap = new Map(tasks.map((t) => [t.id, t]));
+  const evalMap = new Map(evaluations.map((e) => [e.taskId, e]));
+
+  const results: BenchmarkResult[] = traces.map((trace) => {
+    const task = taskMap.get(trace.taskId);
+    const evaluation = evalMap.get(trace.taskId);
+    if (!task || !evaluation) {
+      throw new Error(`Missing task or evaluation for: ${trace.taskId}`);
+    }
+    return {
+      taskId: task.id,
+      category: task.category,
+      evaluation,
+      trace,
+    };
+  });
+
+  return {
+    variant,
+    model,
+    generatedAt: new Date().toISOString(),
+    results,
+    summary: computeSummary(results),
+  };
+}
+
+function computeSummary(results: BenchmarkResult[]): ReportSummary {
+  const total = results.length;
+  const passed = results.filter((r) => r.evaluation.passed).length;
+
+  // By category
+  const byCategory: ReportSummary["byCategory"] = {};
+  for (const r of results) {
+    const cat = r.category;
+    if (!byCategory[cat]) {
+      byCategory[cat] = { total: 0, passed: 0, passRate: 0 };
+    }
+    byCategory[cat].total += 1;
+    if (r.evaluation.passed) byCategory[cat].passed += 1;
+  }
+  for (const entry of Object.values(byCategory)) {
+    entry.passRate = entry.total > 0 ? entry.passed / entry.total : 0;
+  }
+
+  // Averages
+  const avgToolCalls =
+    total > 0
+      ? results.reduce(
+          (sum, r) => sum + r.evaluation.efficiency.toolCallCount,
+          0,
+        ) / total
+      : 0;
+  const avgTotalTokens =
+    total > 0
+      ? results.reduce(
+          (sum, r) => sum + r.evaluation.efficiency.totalTokens,
+          0,
+        ) / total
+      : 0;
+  const avgDurationMs =
+    total > 0
+      ? results.reduce(
+          (sum, r) => sum + r.evaluation.efficiency.durationMs,
+          0,
+        ) / total
+      : 0;
+
+  return {
+    totalTasks: total,
+    passed,
+    failed: total - passed,
+    passRate: total > 0 ? passed / total : 0,
+    byCategory,
+    avgToolCalls,
+    avgTotalTokens,
+    avgDurationMs,
+  };
+}
+
+/**
+ * Format a report as a human-readable string for terminal output.
+ */
+export function formatReport(report: BenchmarkReport): string {
+  const lines: string[] = [];
+
+  lines.push(`Benchmark Report: ${report.variant}`);
+  lines.push(`Model: ${report.model}`);
+  lines.push(`Generated: ${report.generatedAt}`);
+  lines.push("");
+
+  // Summary
+  const s = report.summary;
+  lines.push(
+    `Results: ${s.passed}/${s.totalTasks} passed (${(s.passRate * 100).toFixed(1)}%)`,
+  );
+  lines.push("");
+
+  // By category
+  lines.push("By category:");
+  for (const [cat, stats] of Object.entries(s.byCategory)) {
+    lines.push(
+      `  ${cat}: ${stats.passed}/${stats.total} (${(stats.passRate * 100).toFixed(1)}%)`,
+    );
+  }
+  lines.push("");
+
+  // Efficiency
+  lines.push("Efficiency (averages):");
+  lines.push(`  Tool calls: ${s.avgToolCalls.toFixed(1)}`);
+  lines.push(`  Total tokens: ${s.avgTotalTokens.toFixed(0)}`);
+  lines.push(`  Duration: ${s.avgDurationMs.toFixed(0)}ms`);
+  lines.push("");
+
+  // Per-task details
+  lines.push("Task details:");
+  for (const r of report.results) {
+    const status = r.evaluation.passed ? "PASS" : "FAIL";
+    lines.push(`  [${status}] ${r.taskId}`);
+    for (const check of r.evaluation.checks) {
+      const checkMark = check.passed ? "+" : "-";
+      const detail = check.detail ? ` (${check.detail})` : "";
+      lines.push(`    [${checkMark}] ${check.name}${detail}`);
+    }
+    const eff = r.evaluation.efficiency;
+    lines.push(
+      `    tools: ${eff.toolCallCount}, tokens: ${eff.totalTokens}, files: ${eff.filesReadCount}, symbols: ${eff.symbolsQueriedCount}`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Compare two reports side by side.
+ */
+export function compareReports(
+  baseline: BenchmarkReport,
+  candidate: BenchmarkReport,
+): string {
+  const lines: string[] = [];
+
+  lines.push(
+    `Comparison: "${baseline.variant}" vs "${candidate.variant}"`,
+  );
+  lines.push(`Models: ${baseline.model} vs ${candidate.model}`);
+  lines.push("");
+
+  const bs = baseline.summary;
+  const cs = candidate.summary;
+
+  lines.push("Overall:");
+  lines.push(
+    `  Pass rate: ${(bs.passRate * 100).toFixed(1)}% -> ${(cs.passRate * 100).toFixed(1)}% (${formatDelta(cs.passRate - bs.passRate, true)})`,
+  );
+  lines.push(
+    `  Avg tool calls: ${bs.avgToolCalls.toFixed(1)} -> ${cs.avgToolCalls.toFixed(1)} (${formatDelta(cs.avgToolCalls - bs.avgToolCalls, false)})`,
+  );
+  lines.push(
+    `  Avg tokens: ${bs.avgTotalTokens.toFixed(0)} -> ${cs.avgTotalTokens.toFixed(0)} (${formatDelta(cs.avgTotalTokens - bs.avgTotalTokens, false)})`,
+  );
+  lines.push(
+    `  Avg duration: ${bs.avgDurationMs.toFixed(0)}ms -> ${cs.avgDurationMs.toFixed(0)}ms (${formatDelta(cs.avgDurationMs - bs.avgDurationMs, false)})`,
+  );
+  lines.push("");
+
+  // Per-task comparison
+  const baseResults = new Map(baseline.results.map((r) => [r.taskId, r]));
+  lines.push("Per-task changes:");
+  for (const cr of candidate.results) {
+    const br = baseResults.get(cr.taskId);
+    if (!br) {
+      lines.push(`  [NEW] ${cr.taskId}: ${cr.evaluation.passed ? "PASS" : "FAIL"}`);
+      continue;
+    }
+    if (br.evaluation.passed !== cr.evaluation.passed) {
+      const change = cr.evaluation.passed ? "FIXED" : "REGRESSED";
+      lines.push(`  [${change}] ${cr.taskId}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function formatDelta(delta: number, higherIsBetter: boolean): string {
+  const sign = delta >= 0 ? "+" : "";
+  const formatted = `${sign}${delta.toFixed(1)}`;
+  if (Math.abs(delta) < 0.01) return "no change";
+  if (higherIsBetter) {
+    return delta > 0 ? `${formatted} better` : `${formatted} worse`;
+  }
+  return delta < 0 ? `${formatted} better` : `${formatted} worse`;
+}

--- a/src/benchmark/runner.ts
+++ b/src/benchmark/runner.ts
@@ -1,0 +1,153 @@
+/**
+ * Benchmark runner — executes tasks via the agent and captures traces.
+ *
+ * Uses CodingAgent directly (not the CLI subprocess) for full control
+ * over tool-call instrumentation and trace capture.
+ */
+
+import { execSync } from "node:child_process";
+
+import {
+  CodingAgent,
+  Session,
+  ToolRegistry,
+} from "@minicode/agent-sdk";
+import type {
+  AgentConfig,
+  ModelClient,
+  ToolDefinition,
+} from "@minicode/agent-sdk";
+
+import type {
+  BenchmarkTask,
+  BenchmarkTrace,
+  CapturedToolCall,
+} from "./types.js";
+
+export interface RunnerOptions {
+  /** Model client to use. */
+  modelClient: ModelClient;
+  /** Base agent config (workspace root will be overridden per task). */
+  config: AgentConfig;
+  /** Tool definitions to register. */
+  tools: ToolDefinition[];
+  /** Variant label for this run (e.g. "baseline"). */
+  variant: string;
+  /** Optional callback after each task completes. */
+  onTaskComplete?: (taskId: string, trace: BenchmarkTrace) => void;
+}
+
+function getGitCommitSha(): string {
+  try {
+    return execSync("git rev-parse HEAD", { encoding: "utf8" }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+const STRUCTURAL_TOOLS = new Set([
+  "read_symbol",
+  "find_references",
+  "get_dependencies",
+  "search_code_map",
+]);
+
+/**
+ * Run a single benchmark task and return the captured trace.
+ */
+export async function runBenchmarkTask(
+  task: BenchmarkTask,
+  options: RunnerOptions,
+): Promise<BenchmarkTrace> {
+  const captured: CapturedToolCall[] = [];
+  const filesRead = new Set<string>();
+  const symbolsQueried = new Set<string>();
+
+  // Wrap each tool to capture calls
+  const instrumentedTools: ToolDefinition[] = options.tools.map((tool) => ({
+    ...tool,
+    execute: async (input: Record<string, unknown>) => {
+      const start = performance.now();
+      const output = await tool.execute(input);
+      const durationMs = performance.now() - start;
+
+      captured.push({
+        name: tool.name,
+        input,
+        output:
+          output.length > 2000 ? output.slice(0, 2000) + "…[truncated]" : output,
+        durationMs,
+      });
+
+      // Track files read
+      if (tool.name === "read_file" || tool.name === "read_symbol") {
+        const filePath = input.path ?? input.file_path ?? input.filePath;
+        if (typeof filePath === "string") filesRead.add(filePath);
+      }
+
+      // Track symbol queries
+      if (STRUCTURAL_TOOLS.has(tool.name)) {
+        const sym =
+          input.symbol ?? input.symbolName ?? input.name ?? input.query;
+        if (typeof sym === "string") symbolsQueried.add(sym);
+      }
+
+      return output;
+    },
+  }));
+
+  const registry = new ToolRegistry(instrumentedTools);
+  const session = new Session();
+
+  const agent = new CodingAgent({
+    config: options.config,
+    modelClient: options.modelClient,
+    toolRegistry: registry,
+    session,
+  });
+
+  const startedAt = new Date().toISOString();
+  const start = performance.now();
+
+  const { text, usage } = await agent.runTurn(task.prompt);
+
+  const durationMs = performance.now() - start;
+
+  const trace: BenchmarkTrace = {
+    taskId: task.id,
+    model: options.config.model,
+    variant: options.variant,
+    commitSha: getGitCommitSha(),
+    response: text,
+    toolCalls: captured,
+    filesRead: [...filesRead],
+    symbolsQueried: [...symbolsQueried],
+    usage: {
+      inputTokens: usage?.inputTokens ?? 0,
+      outputTokens: usage?.outputTokens ?? 0,
+      totalTokens: (usage?.inputTokens ?? 0) + (usage?.outputTokens ?? 0),
+    },
+    durationMs,
+    startedAt,
+  };
+
+  options.onTaskComplete?.(task.id, trace);
+  return trace;
+}
+
+/**
+ * Run all provided benchmark tasks sequentially.
+ */
+export async function runBenchmarkSuite(
+  tasks: BenchmarkTask[],
+  options: RunnerOptions,
+): Promise<BenchmarkTrace[]> {
+  const traces: BenchmarkTrace[] = [];
+
+  for (const task of tasks) {
+    const trace = await runBenchmarkTask(task, options);
+    traces.push(trace);
+  }
+
+  return traces;
+}

--- a/src/benchmark/task-loader.ts
+++ b/src/benchmark/task-loader.ts
@@ -1,0 +1,109 @@
+/**
+ * Loads benchmark tasks from the benchmarks/tasks/ directory.
+ *
+ * Each task lives in a category subdirectory and contains:
+ *   - task.json   — task metadata, prompt, and rubric
+ */
+
+import { readFile, readdir, stat } from "node:fs/promises";
+import path from "node:path";
+import type { BenchmarkCategory, BenchmarkTask } from "./types.js";
+
+const VALID_CATEGORIES = new Set<BenchmarkCategory>([
+  "navigation",
+  "editing",
+  "refactors",
+  "debugging",
+  "planning",
+]);
+
+interface TaskFile {
+  title: string;
+  prompt: string;
+  workspaceRoot?: string | undefined;
+  rubric: {
+    expectedOutputPatterns?: string[] | undefined;
+    expectedFilesRead?: string[] | undefined;
+    expectedSymbols?: string[] | undefined;
+    forbiddenPatterns?: string[] | undefined;
+    maxToolCalls?: number | undefined;
+    maxTotalTokens?: number | undefined;
+    customEvaluator?: string | undefined;
+  };
+}
+
+function isValidCategory(name: string): name is BenchmarkCategory {
+  return VALID_CATEGORIES.has(name as BenchmarkCategory);
+}
+
+/**
+ * Load all benchmark tasks from the given base directory.
+ * Expects: `<baseDir>/<category>/<task-name>/task.json`
+ */
+export async function loadBenchmarkTasks(
+  baseDir: string,
+): Promise<BenchmarkTask[]> {
+  const tasks: BenchmarkTask[] = [];
+  const entries = await readdir(baseDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !isValidCategory(entry.name)) continue;
+
+    const category = entry.name as BenchmarkCategory;
+    const categoryDir = path.join(baseDir, category);
+    const taskDirs = await readdir(categoryDir, { withFileTypes: true });
+
+    for (const taskDir of taskDirs) {
+      if (!taskDir.isDirectory()) continue;
+
+      const taskJsonPath = path.join(categoryDir, taskDir.name, "task.json");
+      const exists = await stat(taskJsonPath)
+        .then(() => true)
+        .catch(() => false);
+      if (!exists) continue;
+
+      const raw = await readFile(taskJsonPath, "utf8");
+      const parsed: TaskFile = JSON.parse(raw) as TaskFile;
+
+      tasks.push({
+        id: `${category}/${taskDir.name}`,
+        title: parsed.title,
+        category,
+        prompt: parsed.prompt,
+        workspaceRoot: parsed.workspaceRoot,
+        rubric: parsed.rubric,
+      });
+    }
+  }
+
+  return tasks.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/**
+ * Load a single benchmark task by its id (e.g. "navigation/find-symbol-definition").
+ */
+export async function loadBenchmarkTask(
+  baseDir: string,
+  taskId: string,
+): Promise<BenchmarkTask | undefined> {
+  const taskJsonPath = path.join(baseDir, taskId, "task.json");
+  const exists = await stat(taskJsonPath)
+    .then(() => true)
+    .catch(() => false);
+  if (!exists) return undefined;
+
+  const raw = await readFile(taskJsonPath, "utf8");
+  const parsed: TaskFile = JSON.parse(raw) as TaskFile;
+
+  const [category] = taskId.split("/");
+  if (!category || !isValidCategory(category)) return undefined;
+
+  return {
+    id: taskId,
+    title: parsed.title,
+    category,
+    prompt: parsed.prompt,
+    workspaceRoot: parsed.workspaceRoot,
+    rubric: parsed.rubric,
+  };
+}

--- a/src/benchmark/types.ts
+++ b/src/benchmark/types.ts
@@ -1,0 +1,148 @@
+/**
+ * Benchmark harness types for measuring agent quality, efficiency,
+ * and structural-tool usage across repeatable tasks.
+ */
+
+/** Categories of benchmark tasks. */
+export type BenchmarkCategory =
+  | "navigation"
+  | "editing"
+  | "refactors"
+  | "debugging"
+  | "planning";
+
+/** A single benchmark task definition loaded from disk. */
+export interface BenchmarkTask {
+  /** Unique identifier, e.g. "navigation/find-symbol-definition". */
+  id: string;
+  /** Human-readable title. */
+  title: string;
+  /** Category for grouping results. */
+  category: BenchmarkCategory;
+  /** The prompt sent to the agent. */
+  prompt: string;
+  /** Optional workspace root override (relative to repo root). Defaults to fixture or repo root. */
+  workspaceRoot?: string | undefined;
+  /** Rubric for evaluating the result. */
+  rubric: BenchmarkRubric;
+}
+
+/** Evaluation rubric for a benchmark task. */
+export interface BenchmarkRubric {
+  /** Keywords or patterns that MUST appear in the agent's final response. */
+  expectedOutputPatterns?: string[] | undefined;
+  /** Files the agent should have read during the task. */
+  expectedFilesRead?: string[] | undefined;
+  /** Symbols the agent should have queried via structural tools. */
+  expectedSymbols?: string[] | undefined;
+  /** If set, the agent's response must NOT match these patterns (negative checks). */
+  forbiddenPatterns?: string[] | undefined;
+  /** Maximum number of tool calls allowed for an efficiency pass. */
+  maxToolCalls?: number | undefined;
+  /** Maximum total tokens (input + output) allowed for an efficiency pass. */
+  maxTotalTokens?: number | undefined;
+  /** Custom evaluator function name (for advanced checks). */
+  customEvaluator?: string | undefined;
+}
+
+/** A single tool call captured during a benchmark run. */
+export interface CapturedToolCall {
+  name: string;
+  input: Record<string, unknown>;
+  output: string;
+  durationMs: number;
+}
+
+/** Full trace of a single benchmark run. */
+export interface BenchmarkTrace {
+  /** Task that was run. */
+  taskId: string;
+  /** Model used. */
+  model: string;
+  /** Config variant label (e.g. "baseline", "v2-prompt"). */
+  variant: string;
+  /** Git commit SHA of the codebase under test. */
+  commitSha: string;
+  /** Agent's final text response. */
+  response: string;
+  /** Ordered list of tool calls made during the run. */
+  toolCalls: CapturedToolCall[];
+  /** Files that were read (extracted from tool calls). */
+  filesRead: string[];
+  /** Symbols queried via structural tools. */
+  symbolsQueried: string[];
+  /** Token usage. */
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+  };
+  /** Wall-clock duration of the full run in milliseconds. */
+  durationMs: number;
+  /** Timestamp when the run started. */
+  startedAt: string;
+}
+
+/** Result of evaluating a single benchmark run against its rubric. */
+export interface BenchmarkEvaluation {
+  taskId: string;
+  /** Overall pass/fail. */
+  passed: boolean;
+  /** Individual check results. */
+  checks: EvaluationCheck[];
+  /** Efficiency metrics. */
+  efficiency: EfficiencyMetrics;
+}
+
+export interface EvaluationCheck {
+  name: string;
+  passed: boolean;
+  detail?: string | undefined;
+}
+
+export interface EfficiencyMetrics {
+  toolCallCount: number;
+  totalTokens: number;
+  durationMs: number;
+  filesReadCount: number;
+  symbolsQueriedCount: number;
+  /** Whether the run stayed within the rubric's efficiency bounds. */
+  withinBudget: boolean;
+}
+
+/** Aggregated results across multiple benchmark runs. */
+export interface BenchmarkReport {
+  /** Label for this run (e.g. "baseline", "v2-prompt"). */
+  variant: string;
+  /** Model used. */
+  model: string;
+  /** When the report was generated. */
+  generatedAt: string;
+  /** Per-task results. */
+  results: BenchmarkResult[];
+  /** Aggregate summary. */
+  summary: ReportSummary;
+}
+
+export interface BenchmarkResult {
+  taskId: string;
+  category: BenchmarkCategory;
+  evaluation: BenchmarkEvaluation;
+  trace: BenchmarkTrace;
+}
+
+export interface ReportSummary {
+  totalTasks: number;
+  passed: number;
+  failed: number;
+  passRate: number;
+  /** Breakdown by category. */
+  byCategory: Record<
+    string,
+    { total: number; passed: number; passRate: number }
+  >;
+  /** Aggregate efficiency. */
+  avgToolCalls: number;
+  avgTotalTokens: number;
+  avgDurationMs: number;
+}

--- a/tests/benchmark-harness.test.ts
+++ b/tests/benchmark-harness.test.ts
@@ -1,0 +1,634 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { test } from "node:test";
+
+import type {
+  ModelClient,
+  ModelResponse,
+  SessionMessage,
+  ToolDefinition,
+  ToolSchema,
+} from "@minicode/agent-sdk";
+
+import { loadBenchmarkTasks, loadBenchmarkTask } from "../src/benchmark/task-loader.js";
+import { evaluate } from "../src/benchmark/evaluator.js";
+import { runBenchmarkTask } from "../src/benchmark/runner.js";
+import {
+  buildReport,
+  formatReport,
+  compareReports,
+} from "../src/benchmark/reporter.js";
+import type {
+  BenchmarkRubric,
+  BenchmarkTask,
+  BenchmarkTrace,
+} from "../src/benchmark/types.js";
+import { createTestAgentConfig } from "./test-utils.js";
+
+// ─── Helpers ───────────────────────────────────────────────────
+
+async function createTempTaskDir(): Promise<string> {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), "bench-test-"));
+  await mkdir(path.join(tmpDir, "navigation", "find-foo"), { recursive: true });
+  await mkdir(path.join(tmpDir, "editing", "fix-bar"), { recursive: true });
+
+  await writeFile(
+    path.join(tmpDir, "navigation", "find-foo", "task.json"),
+    JSON.stringify({
+      title: "Find foo",
+      prompt: "Find where foo is defined",
+      rubric: {
+        expectedOutputPatterns: ["foo"],
+        maxToolCalls: 5,
+      },
+    }),
+  );
+
+  await writeFile(
+    path.join(tmpDir, "editing", "fix-bar", "task.json"),
+    JSON.stringify({
+      title: "Fix bar",
+      prompt: "Fix the bar function",
+      rubric: {
+        expectedOutputPatterns: ["bar"],
+        expectedFilesRead: ["bar.ts"],
+        forbiddenPatterns: ["error"],
+        maxToolCalls: 10,
+        maxTotalTokens: 5000,
+      },
+    }),
+  );
+
+  return tmpDir;
+}
+
+function makeTrace(overrides: Partial<BenchmarkTrace> = {}): BenchmarkTrace {
+  return {
+    taskId: "navigation/find-foo",
+    model: "test-model",
+    variant: "baseline",
+    commitSha: "abc123",
+    response: "Found foo in src/foo.ts at line 10.",
+    toolCalls: [
+      { name: "search", input: { query: "foo" }, output: "src/foo.ts:10", durationMs: 50 },
+      { name: "read_file", input: { path: "src/foo.ts" }, output: "function foo() {}", durationMs: 30 },
+    ],
+    filesRead: ["src/foo.ts"],
+    symbolsQueried: [],
+    usage: { inputTokens: 500, outputTokens: 100, totalTokens: 600 },
+    durationMs: 200,
+    startedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+class MockModelClient implements ModelClient {
+  private readonly response: string;
+
+  constructor(response: string) {
+    this.response = response;
+  }
+
+  async chat(params: {
+    model: string;
+    system: string;
+    messages: SessionMessage[];
+    tools: ToolSchema[];
+    maxTokens: number;
+  }): Promise<ModelResponse> {
+    void params;
+    return {
+      text: this.response,
+      toolCalls: [],
+      stopReason: "end_turn",
+      usage: { inputTokens: 100, outputTokens: 50 },
+    };
+  }
+}
+
+class ToolCallingMockClient implements ModelClient {
+  private callCount = 0;
+
+  async chat(params: {
+    model: string;
+    system: string;
+    messages: SessionMessage[];
+    tools: ToolSchema[];
+    maxTokens: number;
+  }): Promise<ModelResponse> {
+    void params;
+    this.callCount += 1;
+    if (this.callCount === 1) {
+      return {
+        text: "Let me search for that.",
+        toolCalls: [{ id: "t1", name: "echo_tool", input: { value: "hello" } }],
+        stopReason: "tool_use",
+        usage: { inputTokens: 100, outputTokens: 50 },
+      };
+    }
+    return {
+      text: "Found: echo:hello",
+      toolCalls: [],
+      stopReason: "end_turn",
+      usage: { inputTokens: 150, outputTokens: 60 },
+    };
+  }
+}
+
+// ─── Task Loader Tests ─────────────────────────────────────────
+
+test("loadBenchmarkTasks loads tasks from directory structure", async () => {
+  const tmpDir = await createTempTaskDir();
+  try {
+    const tasks = await loadBenchmarkTasks(tmpDir);
+    assert.equal(tasks.length, 2);
+    const first = tasks[0]!;
+    const second = tasks[1]!;
+    assert.equal(first.id, "editing/fix-bar");
+    assert.equal(second.id, "navigation/find-foo");
+    assert.equal(first.category, "editing");
+    assert.equal(second.category, "navigation");
+    assert.equal(second.prompt, "Find where foo is defined");
+  } finally {
+    await rm(tmpDir, { recursive: true });
+  }
+});
+
+test("loadBenchmarkTasks returns empty array for empty directory", async () => {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), "bench-empty-"));
+  try {
+    const tasks = await loadBenchmarkTasks(tmpDir);
+    assert.equal(tasks.length, 0);
+  } finally {
+    await rm(tmpDir, { recursive: true });
+  }
+});
+
+test("loadBenchmarkTasks ignores invalid category directories", async () => {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), "bench-invalid-"));
+  await mkdir(path.join(tmpDir, "invalid-category", "task1"), { recursive: true });
+  await writeFile(
+    path.join(tmpDir, "invalid-category", "task1", "task.json"),
+    JSON.stringify({ title: "X", prompt: "X", rubric: {} }),
+  );
+  try {
+    const tasks = await loadBenchmarkTasks(tmpDir);
+    assert.equal(tasks.length, 0);
+  } finally {
+    await rm(tmpDir, { recursive: true });
+  }
+});
+
+test("loadBenchmarkTask loads a single task by id", async () => {
+  const tmpDir = await createTempTaskDir();
+  try {
+    const task = await loadBenchmarkTask(tmpDir, "navigation/find-foo");
+    assert.ok(task);
+    assert.equal(task.title, "Find foo");
+    assert.equal(task.category, "navigation");
+  } finally {
+    await rm(tmpDir, { recursive: true });
+  }
+});
+
+test("loadBenchmarkTask returns undefined for missing task", async () => {
+  const tmpDir = await createTempTaskDir();
+  try {
+    const task = await loadBenchmarkTask(tmpDir, "navigation/nonexistent");
+    assert.equal(task, undefined);
+  } finally {
+    await rm(tmpDir, { recursive: true });
+  }
+});
+
+// ─── Evaluator Tests ───────────────────────────────────────────
+
+test("evaluate passes when all expected patterns match", () => {
+  const rubric: BenchmarkRubric = {
+    expectedOutputPatterns: ["foo", "line \\d+"],
+  };
+  const trace = makeTrace({ response: "Found foo at line 10" });
+  const result = evaluate("test/task", rubric, trace);
+  assert.equal(result.passed, true);
+  assert.equal(result.checks.length, 2);
+  assert.ok(result.checks.every((c) => c.passed));
+});
+
+test("evaluate fails when expected pattern is missing", () => {
+  const rubric: BenchmarkRubric = {
+    expectedOutputPatterns: ["bar"],
+  };
+  const trace = makeTrace({ response: "Found foo at line 10" });
+  const result = evaluate("test/task", rubric, trace);
+  assert.equal(result.passed, false);
+  assert.equal(result.checks[0]!.passed, false);
+  assert.ok(result.checks[0]!.detail?.includes("Pattern not found"));
+});
+
+test("evaluate checks expected files read", () => {
+  const rubric: BenchmarkRubric = {
+    expectedFilesRead: ["src/foo.ts", "src/bar.ts"],
+  };
+  const trace = makeTrace({ filesRead: ["src/foo.ts"] });
+  const result = evaluate("test/task", rubric, trace);
+  assert.equal(result.passed, false);
+  assert.equal(result.checks[0]!.passed, true);
+  assert.equal(result.checks[1]!.passed, false);
+});
+
+test("evaluate checks expected symbols queried", () => {
+  const rubric: BenchmarkRubric = {
+    expectedSymbols: ["buildProjectIndex"],
+  };
+  const trace = makeTrace({ symbolsQueried: ["buildProjectIndex"] });
+  const result = evaluate("test/task", rubric, trace);
+  assert.equal(result.passed, true);
+});
+
+test("evaluate checks forbidden patterns", () => {
+  const rubric: BenchmarkRubric = {
+    forbiddenPatterns: ["error"],
+  };
+  const traceOk = makeTrace({ response: "All good" });
+  const traceBad = makeTrace({ response: "There was an error" });
+
+  assert.equal(evaluate("t", rubric, traceOk).passed, true);
+  assert.equal(evaluate("t", rubric, traceBad).passed, false);
+});
+
+test("evaluate computes efficiency metrics", () => {
+  const rubric: BenchmarkRubric = {
+    maxToolCalls: 3,
+    maxTotalTokens: 1000,
+  };
+  const trace = makeTrace({
+    toolCalls: [
+      { name: "a", input: {}, output: "", durationMs: 10 },
+      { name: "b", input: {}, output: "", durationMs: 10 },
+    ],
+    usage: { inputTokens: 400, outputTokens: 200, totalTokens: 600 },
+  });
+  const result = evaluate("t", rubric, trace);
+  assert.equal(result.efficiency.toolCallCount, 2);
+  assert.equal(result.efficiency.totalTokens, 600);
+  assert.equal(result.efficiency.withinBudget, true);
+});
+
+test("evaluate marks over-budget when tool calls exceed limit", () => {
+  const rubric: BenchmarkRubric = { maxToolCalls: 1 };
+  const trace = makeTrace({
+    toolCalls: [
+      { name: "a", input: {}, output: "", durationMs: 10 },
+      { name: "b", input: {}, output: "", durationMs: 10 },
+    ],
+  });
+  const result = evaluate("t", rubric, trace);
+  assert.equal(result.efficiency.withinBudget, false);
+});
+
+test("evaluate marks over-budget when tokens exceed limit", () => {
+  const rubric: BenchmarkRubric = { maxTotalTokens: 100 };
+  const trace = makeTrace({
+    usage: { inputTokens: 500, outputTokens: 100, totalTokens: 600 },
+  });
+  const result = evaluate("t", rubric, trace);
+  assert.equal(result.efficiency.withinBudget, false);
+});
+
+test("evaluate passes with empty rubric", () => {
+  const rubric: BenchmarkRubric = {};
+  const trace = makeTrace();
+  const result = evaluate("t", rubric, trace);
+  assert.equal(result.passed, true);
+  assert.equal(result.checks.length, 0);
+  assert.equal(result.efficiency.withinBudget, true);
+});
+
+// ─── Runner Tests ──────────────────────────────────────────────
+
+test("runBenchmarkTask captures trace with tool calls", async () => {
+  const task: BenchmarkTask = {
+    id: "navigation/test-task",
+    title: "Test task",
+    category: "navigation",
+    prompt: "Find the thing",
+    rubric: {},
+  };
+
+  const echoTool: ToolDefinition = {
+    name: "echo_tool",
+    description: "Echoes a value",
+    inputSchema: {
+      type: "object",
+      properties: { value: { type: "string" } },
+      required: ["value"],
+    },
+    execute: async (input) => `echo:${String(input.value)}`,
+  };
+
+  const config = createTestAgentConfig(process.cwd());
+  const trace = await runBenchmarkTask(task, {
+    modelClient: new ToolCallingMockClient(),
+    config,
+    tools: [echoTool],
+    variant: "test",
+  });
+
+  assert.equal(trace.taskId, "navigation/test-task");
+  assert.equal(trace.variant, "test");
+  assert.equal(trace.toolCalls.length, 1);
+  assert.equal(trace.toolCalls[0]!.name, "echo_tool");
+  assert.equal(trace.toolCalls[0]!.output, "echo:hello");
+  assert.ok(trace.durationMs >= 0);
+  assert.ok(trace.usage.totalTokens > 0);
+});
+
+test("runBenchmarkTask captures trace without tool calls", async () => {
+  const task: BenchmarkTask = {
+    id: "planning/simple",
+    title: "Simple task",
+    category: "planning",
+    prompt: "Explain something",
+    rubric: {},
+  };
+
+  const config = createTestAgentConfig(process.cwd());
+  const trace = await runBenchmarkTask(task, {
+    modelClient: new MockModelClient("Here is my explanation about foo."),
+    config,
+    tools: [],
+    variant: "baseline",
+  });
+
+  assert.equal(trace.response, "Here is my explanation about foo.");
+  assert.equal(trace.toolCalls.length, 0);
+  assert.equal(trace.variant, "baseline");
+});
+
+test("runBenchmarkTask calls onTaskComplete callback", async () => {
+  const task: BenchmarkTask = {
+    id: "nav/cb-test",
+    title: "Callback test",
+    category: "navigation",
+    prompt: "Do something",
+    rubric: {},
+  };
+
+  let callbackTaskId: string | undefined;
+  const config = createTestAgentConfig(process.cwd());
+  await runBenchmarkTask(task, {
+    modelClient: new MockModelClient("done"),
+    config,
+    tools: [],
+    variant: "v1",
+    onTaskComplete: (taskId) => {
+      callbackTaskId = taskId;
+    },
+  });
+
+  assert.equal(callbackTaskId, "nav/cb-test");
+});
+
+test("runBenchmarkTask tracks files read from read_file tool", async () => {
+  const task: BenchmarkTask = {
+    id: "nav/file-track",
+    title: "File tracking test",
+    category: "navigation",
+    prompt: "Read a file",
+    rubric: {},
+  };
+
+  let callCount = 0;
+  const mockClient: ModelClient = {
+    async chat(params) {
+      void params;
+      callCount += 1;
+      if (callCount === 1) {
+        return {
+          text: "Reading file",
+          toolCalls: [{ id: "t1", name: "read_file", input: { path: "src/main.ts" } }],
+          stopReason: "tool_use" as const,
+          usage: { inputTokens: 100, outputTokens: 50 },
+        };
+      }
+      return {
+        text: "Found it",
+        toolCalls: [],
+        stopReason: "end_turn" as const,
+        usage: { inputTokens: 100, outputTokens: 50 },
+      };
+    },
+  };
+
+  const readFileTool: ToolDefinition = {
+    name: "read_file",
+    description: "Read a file",
+    inputSchema: {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+    },
+    execute: async () => "file contents here",
+  };
+
+  const config = createTestAgentConfig(process.cwd());
+  const trace = await runBenchmarkTask(task, {
+    modelClient: mockClient,
+    config,
+    tools: [readFileTool],
+    variant: "v1",
+  });
+
+  assert.ok(trace.filesRead.includes("src/main.ts"));
+});
+
+test("runBenchmarkTask tracks symbols from structural tools", async () => {
+  const task: BenchmarkTask = {
+    id: "nav/sym-track",
+    title: "Symbol tracking test",
+    category: "navigation",
+    prompt: "Find references",
+    rubric: {},
+  };
+
+  let callCount = 0;
+  const mockClient: ModelClient = {
+    async chat(params) {
+      void params;
+      callCount += 1;
+      if (callCount === 1) {
+        return {
+          text: "Looking up symbol",
+          toolCalls: [{ id: "t1", name: "read_symbol", input: { symbol: "CodingAgent" } }],
+          stopReason: "tool_use" as const,
+          usage: { inputTokens: 100, outputTokens: 50 },
+        };
+      }
+      return {
+        text: "Found CodingAgent",
+        toolCalls: [],
+        stopReason: "end_turn" as const,
+        usage: { inputTokens: 100, outputTokens: 50 },
+      };
+    },
+  };
+
+  const readSymbolTool: ToolDefinition = {
+    name: "read_symbol",
+    description: "Read a symbol",
+    inputSchema: {
+      type: "object",
+      properties: { symbol: { type: "string" } },
+      required: ["symbol"],
+    },
+    execute: async () => "class CodingAgent { ... }",
+  };
+
+  const config = createTestAgentConfig(process.cwd());
+  const trace = await runBenchmarkTask(task, {
+    modelClient: mockClient,
+    config,
+    tools: [readSymbolTool],
+    variant: "v1",
+  });
+
+  assert.ok(trace.symbolsQueried.includes("CodingAgent"));
+});
+
+// ─── Reporter Tests ────────────────────────────────────────────
+
+test("buildReport generates correct summary", () => {
+  const tasks: BenchmarkTask[] = [
+    {
+      id: "navigation/find-foo",
+      title: "Find foo",
+      category: "navigation",
+      prompt: "Find foo",
+      rubric: { expectedOutputPatterns: ["foo"] },
+    },
+    {
+      id: "editing/fix-bar",
+      title: "Fix bar",
+      category: "editing",
+      prompt: "Fix bar",
+      rubric: { expectedOutputPatterns: ["bar"] },
+    },
+  ];
+
+  const traces: BenchmarkTrace[] = [
+    makeTrace({ taskId: "navigation/find-foo", response: "Found foo" }),
+    makeTrace({ taskId: "editing/fix-bar", response: "No match here" }),
+  ];
+
+  const report = buildReport(tasks, traces, "baseline", "test-model");
+
+  assert.equal(report.summary.totalTasks, 2);
+  assert.equal(report.summary.passed, 1);
+  assert.equal(report.summary.failed, 1);
+  assert.equal(report.summary.passRate, 0.5);
+  const navStats = report.summary.byCategory["navigation"];
+  assert.ok(navStats);
+  assert.equal(navStats.passed, 1);
+  const editStats = report.summary.byCategory["editing"];
+  assert.ok(editStats);
+  assert.equal(editStats.passed, 0);
+});
+
+test("buildReport throws for unknown task id in trace", () => {
+  assert.throws(
+    () => buildReport([], [makeTrace({ taskId: "unknown/task" })], "v1", "m"),
+    /No task definition found/,
+  );
+});
+
+test("formatReport produces readable output", () => {
+  const tasks: BenchmarkTask[] = [
+    {
+      id: "navigation/find-foo",
+      title: "Find foo",
+      category: "navigation",
+      prompt: "Find foo",
+      rubric: { expectedOutputPatterns: ["foo"] },
+    },
+  ];
+  const traces = [makeTrace({ taskId: "navigation/find-foo", response: "Found foo" })];
+  const report = buildReport(tasks, traces, "baseline", "test-model");
+  const output = formatReport(report);
+
+  assert.ok(output.includes("Benchmark Report: baseline"));
+  assert.ok(output.includes("Model: test-model"));
+  assert.ok(output.includes("1/1 passed"));
+  assert.ok(output.includes("[PASS] navigation/find-foo"));
+});
+
+test("compareReports shows improvements and regressions", () => {
+  const tasks: BenchmarkTask[] = [
+    {
+      id: "navigation/find-foo",
+      title: "Find foo",
+      category: "navigation",
+      prompt: "Find foo",
+      rubric: { expectedOutputPatterns: ["foo"] },
+    },
+  ];
+
+  const baseTraces = [makeTrace({ taskId: "navigation/find-foo", response: "no match" })];
+  const candTraces = [makeTrace({ taskId: "navigation/find-foo", response: "Found foo" })];
+
+  const baseline = buildReport(tasks, baseTraces, "baseline", "test-model");
+  const candidate = buildReport(tasks, candTraces, "v2", "test-model");
+
+  const comparison = compareReports(baseline, candidate);
+  assert.ok(comparison.includes("baseline"));
+  assert.ok(comparison.includes("v2"));
+  assert.ok(comparison.includes("FIXED"));
+});
+
+test("compareReports detects regressions", () => {
+  const tasks: BenchmarkTask[] = [
+    {
+      id: "navigation/find-foo",
+      title: "Find foo",
+      category: "navigation",
+      prompt: "Find foo",
+      rubric: { expectedOutputPatterns: ["foo"] },
+    },
+  ];
+
+  const baseTraces = [makeTrace({ taskId: "navigation/find-foo", response: "Found foo here" })];
+  const candTraces = [makeTrace({ taskId: "navigation/find-foo", response: "no match" })];
+
+  const baseline = buildReport(tasks, baseTraces, "baseline", "test-model");
+  const candidate = buildReport(tasks, candTraces, "v2", "test-model");
+
+  const comparison = compareReports(baseline, candidate);
+  assert.ok(comparison.includes("REGRESSED"));
+});
+
+// ─── Integration: Load real tasks from benchmarks/ ─────────────
+
+test("loads real benchmark tasks from benchmarks/tasks/", async () => {
+  const tasksDir = path.resolve(import.meta.dirname, "..", "benchmarks", "tasks");
+  const tasks = await loadBenchmarkTasks(tasksDir);
+
+  assert.ok(tasks.length >= 20, `Expected at least 20 tasks, got ${tasks.length}`);
+
+  // Verify each task has required fields
+  for (const task of tasks) {
+    assert.ok(task.id, "task must have an id");
+    assert.ok(task.title, "task must have a title");
+    assert.ok(task.prompt, "task must have a prompt");
+    assert.ok(task.category, "task must have a category");
+    assert.ok(task.rubric, "task must have a rubric");
+  }
+
+  // Check categories are covered
+  const categories = new Set(tasks.map((t) => t.category));
+  assert.ok(categories.has("navigation"));
+  assert.ok(categories.has("editing"));
+  assert.ok(categories.has("refactors"));
+  assert.ok(categories.has("debugging"));
+  assert.ok(categories.has("planning"));
+});


### PR DESCRIPTION
## Summary

Implements the benchmark harness foundation requested in #13:

- **Task schema & loader** — `benchmarks/tasks/<category>/<name>/task.json` structure with typed loader that discovers tasks by category
- **Runner** — Executes tasks via `CodingAgent` with instrumented tool wrappers that capture full traces (tool calls, files read, symbols queried, token usage, wall-clock timing)
- **Evaluator** — Checks traces against rubrics: expected output patterns, expected files read, expected symbol queries, forbidden patterns, and efficiency budgets (max tool calls, max tokens)
- **Reporter** — Human-readable terminal output with per-task details, category breakdowns, efficiency averages, and side-by-side variant comparison (detects fixes and regressions)
- **25 initial benchmark tasks** across 5 categories (5 each): navigation, editing, refactors, debugging, planning
- **25 new tests** covering task loading, evaluation logic, runner instrumentation, reporting, and integration with the real task suite

### Architecture

```
src/benchmark/
  types.ts        — All benchmark types (task, rubric, trace, evaluation, report)
  task-loader.ts  — Loads tasks from benchmarks/tasks/ directory
  runner.ts       — Executes tasks with trace capture
  evaluator.ts    — Evaluates traces against rubrics
  reporter.ts     — Generates reports and comparisons
  index.ts        — Public API exports

benchmarks/tasks/
  navigation/     — 5 tasks (find definitions, references, deps, flows, registration)
  editing/        — 5 tasks (validation, bug fixes, renames, logging, config)
  refactors/      — 5 tasks (extract helpers, update interfaces, consolidate, propagate)
  debugging/      — 5 tasks (type errors, failing tests, runtime bugs, root cause, websocket)
  planning/       — 5 tasks (indexing pipeline, plugins, serve, trimming, new tools)
```

Closes #13

## Test plan

- [x] All 223 tests pass (198 existing + 25 new)
- [x] `npm run lint` passes with zero warnings
- [x] `npm run build` compiles cleanly
- [x] Task loader correctly discovers all 25 tasks across 5 categories
- [x] Evaluator correctly handles pass/fail for patterns, files, symbols, forbidden patterns, and budgets
- [x] Runner captures tool calls, file reads, symbol queries, and token usage
- [x] Reporter generates readable output and comparison between variants

https://claude.ai/code/session_01Ns7FV1PppKUjTroLk3NBTe