### PR TITLE
Update app URL in request headers to minicode.seanholung.com

### DIFF
--- a/packages/agent-sdk/src/model/client.ts
+++ b/packages/agent-sdk/src/model/client.ts
@@ -537,7 +537,7 @@ export class OpenAICompatibleModelClient implements ModelClient {
   }): Promise<ModelResponse> {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
-      "HTTP-Referer": "https://github.com/sean1588/minicode",
+      "HTTP-Referer": "https://minicode.seanholung.com",
       "X-Title": "minicode",
     };
     const apiKey = this.apiKey?.trim();

--- a/tests/model-client-openai.test.ts
+++ b/tests/model-client-openai.test.ts
@@ -89,6 +89,47 @@ test("openai-compatible client sends tool schemas and parses tool calls", async 
   assert.equal(tools[0]?.type, "function");
 });
 
+test("openai-compatible client sends correct app URL in HTTP-Referer header", async () => {
+  let capturedHeaders: Record<string, string> = {};
+
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    const rawHeaders = init?.headers as Record<string, string> | undefined;
+    capturedHeaders = rawHeaders ?? {};
+    return new Response(
+      JSON.stringify({
+        choices: [
+          {
+            finish_reason: "stop",
+            message: { content: "hello", tool_calls: [] },
+          },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 3 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+
+  await client.chat({
+    model: "test-model",
+    system: "sys",
+    messages: [{ role: "user", content: "hi" }],
+    tools: [],
+    maxTokens: 64,
+  });
+
+  assert.equal(
+    capturedHeaders["HTTP-Referer"],
+    "https://minicode.seanholung.com",
+    "HTTP-Referer should point to minicode.seanholung.com",
+  );
+  assert.equal(capturedHeaders["X-Title"], "minicode");
+});
+
 test("createModelClient returns openai-compatible client", () => {
   const config: AgentConfig = {
     ...createTestAgentConfig("/tmp"),


### PR DESCRIPTION
## Summary
- Updates `HTTP-Referer` header in `OpenAICompatibleModelClient` from `https://github.com/sean1588/minicode` to `https://minicode.seanholung.com`
- Adds test verifying the correct header value is sent in API requests

## Test plan
- [x] New test `openai-compatible client sends correct app URL in HTTP-Referer header` passes
- [x] All 232 existing + new tests pass (`npm test`)
- [x] Lint clean (`npm run lint`)
- [x] Build succeeds (`npm run build`)

Fixes #56

https://claude.ai/code/session_01NooD1Dsx566uG9rxdZCo1u