### PR TITLE
[codex] Refresh docs to match current runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # minicode
 
-A lightweight coding agent optimized for **local models** — CLI-first with a built-in web UI. Provides AST-based intelligent context for smaller models running on consumer hardware.
+A graph-native coding agent and code exploration environment built around structural context optimization. It started as a way to make local models viable under tighter context budgets, and it now also works well with hosted frontier models through the same runtime, web UI, and OpenAI-compatible serve mode.
 
-_New Web UI interface with code dependency graph visualizer. Updates in real time as agent explores the codebase. Run `minicode serve` to interact over localhost._
+_Run `minicode serve` to get the web UI on localhost: chat, tool activity, session controls, model switching, symbol focus, annotations, and a live dependency graph._
 
 <img width="1723" height="920" alt="Screenshot 2026-03-26 at 6 30 23 PM" src="https://github.com/user-attachments/assets/499c8dc7-cc2b-4125-abd5-32b2fc9795ea" />
 
 
-Read operations dominate token usage in typical agent sessions; minicode addresses this by optimizing for **specific languages** — indexing your project at startup with language plugins (TypeScript/JavaScript built-in) and injecting a compact **code map** (signatures only) into the system prompt, plus symbol-level tools (`read_symbol`, `find_references`, `get_dependencies`) so the model reads only what it needs instead of entire files. This keeps prompts lean enough for smaller models in the 20B range, with faster inference and better attention over the relevant code.
+Read operations dominate token usage in typical agent sessions; minicode addresses this by optimizing for **specific languages**. It indexes your project at startup with language plugins, injects a compact **code map** (signatures only) into the system prompt, and exposes symbol-level tools (`read_symbol`, `find_references`, `get_dependencies`) so the model reads only what it needs instead of entire files. The deepest built-in indexing path today is for TypeScript and JavaScript, with plugins leaving room for more languages over time.
 
 ## Quick Start (LM Studio)
 
@@ -97,7 +97,7 @@ npm run install:global
 - **Web UI** — `minicode serve` starts an HTTP + WebSocket server with a bundled chat client, real-time streaming, session management, and project graph data endpoints
 - **OpenAI-compatible API** — any client that speaks the OpenAI protocol can use minicode as a backend at `/v1/chat/completions`
 - **Context optimization:** Code map in system prompt, `read_symbol`, `find_references`, `get_dependencies`
-- **Plugin system:** Extensible language support (TypeScript built-in)
+- **Plugin system:** Extensible language support (TypeScript/JavaScript built in today)
 
 ## Context Optimization
 
@@ -110,9 +110,9 @@ For the proposed reusable package architecture and public interfaces for a stand
 minicode reduces token usage by indexing your project and providing targeted tools:
 
 - **Code map** — A compact project skeleton (signatures only) is injected into the system prompt so the model can orient itself without reading full files.
-- `**read_symbol`** — Read a specific function or class by name, with referenced types.
-- `**find_references**` — Find all symbols that reference a given symbol.
-- `**get_dependencies**` — Get the dependency cone of a symbol.
+- `read_symbol` — Read a specific function or class by name, with referenced types.
+- `find_references` — Find all symbols that reference a given symbol.
+- `get_dependencies` — Get the dependency cone of a symbol.
 
 The index is cached in `~/.minicode/cache/<workspace-hash>/` for faster startup on subsequent runs. Caches are global and keyed by workspace path, so nothing is stored inside your project directories.
 
@@ -175,9 +175,9 @@ See [docs/PLUGIN_SPEC.md](docs/PLUGIN_SPEC.md) for the full specification. Quick
 
 Configuration can come from (later sources override earlier):
 
-1. `**~/.minicode/.env`** — User-level defaults (API keys, model, etc.)
-2. `**~/.minicode/agent.config.json**` — User-level JSON config
-3. **Project `.env`** and `**agent.config.json**` in workspace root
+1. `~/.minicode/.env` — User-level defaults (API keys, model, etc.)
+2. `~/.minicode/agent.config.json` — User-level JSON config
+3. Project `.env` and `agent.config.json` in workspace root
 4. Environment variables (highest precedence)
 
 Nothing is written inside your workspace; config and cache live under `~/.minicode/`.
@@ -192,18 +192,23 @@ Nothing is written inside your workspace; config and cache live under `~/.minico
 | `ANTHROPIC_API_KEY`     | Yes (Anthropic) | none                       | Required when `MODEL_PROVIDER=anthropic`                                                                                              |
 | `OPENAI_BASE_URL`       | No              | `http://localhost:1234/v1` | Base URL for OpenAI-compatible API (LM Studio, etc.)                                                                                  |
 | `OPENAI_API_KEY`        | No              | none                       | Optional for local servers; required if your endpoint enforces auth                                                                   |
+| `OPENROUTER_API_KEY`    | No              | none                       | Preferred key when `OPENAI_BASE_URL` points at OpenRouter; falls back to `OPENAI_API_KEY` if unset                                  |
 | `MAX_STEPS`             | No              | `50`                       | Max agent loop iterations per user turn                                                                                               |
 | `MAX_TOKENS`            | No              | `4096`                     | Max model output tokens per model call                                                                                                |
-| `MAX_CONTEXT_TOKENS`    | No              | `120000`                   | Approximate session history trimming target. For small models (e.g. 8k context), set lower (e.g. `6000`) to leave room for responses. |
-| `MAX_TOOL_OUTPUT_CHARS` | No              | `15000`                    | Max chars per tool result before truncation. Set to `0` to disable.                                                                   |
+| `MAX_CONTEXT_TOKENS`    | No              | `40000`                    | Approximate session history trimming target. For small models (e.g. 8k context), set lower (e.g. `6000`) to leave room for responses. |
+| `MAX_TOOL_OUTPUT_CHARS` | No              | `8000`                     | Max chars per tool result before truncation. Set to `0` to disable.                                                                   |
 | `WORKSPACE_ROOT`        | No              | current working directory  | Root directory tools are allowed to access                                                                                            |
 | `COMMAND_TIMEOUT_MS`    | No              | `30000`                    | Timeout for shell/search commands                                                                                                     |
 | `MAX_FILE_SIZE_BYTES`   | No              | `1000000`                  | Read limit for `read_file`                                                                                                            |
 | `CONFIRM_DESTRUCTIVE`   | No              | `true`                     | If `true`, blocks destructive shell commands unless confirmed                                                                         |
 | `KEEP_RECENT_MESSAGES`  | No              | `12`                       | Minimum number of latest messages kept during trimming                                                                                |
 | `LOOP_DETECTION_WINDOW` | No              | `6`                        | Window for repeated tool-call loop detection                                                                                          |
+| `ENABLE_FILE_READ_DEDUP` | No             | `true`                     | Reuses earlier `read_file` results within a turn when the same file slice is still in context                                        |
+| `ENABLE_ADAPTIVE_KEEP_RECENT` | No        | `true`                     | Scales `keepRecentMessages` down as context fills so trimming gets more aggressive when needed                                       |
+| `ENABLE_TOOL_OUTPUT_TRUNCATION` | No      | `true`                     | Enables content-aware truncation strategies for tool output instead of simple head-only clipping                                     |
 | `COMPACTION_THRESHOLD`  | No              | `0.8`                      | Context fullness ratio (0–1) at which auto-compaction triggers                                                                        |
 | `COMPACTION_MODEL`      | No              | none                       | Model for LLM-based compaction summaries. When set, `/compact` and auto-compaction use this model instead of mechanical truncation. Use a small, fast model (e.g. your local model). |
+| `REASONING_EFFORT`      | No              | unset                      | Reasoning level for providers that support it. Valid values: `xhigh`, `high`, `medium`, `low`, `minimal`, `none`                   |
 
 
 ### `agent.config.json`
@@ -216,7 +221,8 @@ Create `agent.config.json` in `~/.minicode/` for user-level defaults, or in the 
   "model": "zai-org/glm-4.7-flash",
   "maxSteps": 50,
   "maxTokens": 4096,
-  "maxContextTokens": 120000,
+  "maxContextTokens": 40000,
+  "maxToolOutputChars": 8000,
   "workspaceRoot": ".",
   "commandTimeout": 30000,
   "commandDenylist": [],
@@ -226,7 +232,10 @@ Create `agent.config.json` in `~/.minicode/` for user-level defaults, or in the 
   "loopDetectionWindow": 6,
   "openAiBaseUrl": "http://localhost:1234/v1",
   "openAiApiKey": "",
-  "compactionModel": ""
+  "enableFileReadDedup": true,
+  "enableAdaptiveKeepRecent": true,
+  "enableToolOutputTruncation": true,
+  "compactionThreshold": 0.8
 }
 ```
 
@@ -245,9 +254,14 @@ Field mapping:
 - `keepRecentMessages` ↔ `KEEP_RECENT_MESSAGES`
 - `loopDetectionWindow` ↔ `LOOP_DETECTION_WINDOW`
 - `openAiBaseUrl` ↔ `OPENAI_BASE_URL`
-- `openAiApiKey` ↔ `OPENAI_API_KEY`
+- `openAiApiKey` ↔ `OPENAI_API_KEY` / `OPENROUTER_API_KEY` (when using OpenRouter)
+- `maxToolOutputChars` ↔ `MAX_TOOL_OUTPUT_CHARS`
+- `enableFileReadDedup` ↔ `ENABLE_FILE_READ_DEDUP`
+- `enableAdaptiveKeepRecent` ↔ `ENABLE_ADAPTIVE_KEEP_RECENT`
+- `enableToolOutputTruncation` ↔ `ENABLE_TOOL_OUTPUT_TRUNCATION`
 - `compactionThreshold` ↔ `COMPACTION_THRESHOLD`
 - `compactionModel` ↔ `COMPACTION_MODEL`
+- `reasoningEffort` ↔ `REASONING_EFFORT`
 
 ## Usage
 
@@ -278,6 +292,19 @@ npm run dev -- --oneshot --json "Summarize TODOs"
 npm run dev -- --oneshot --out result.txt "Draft changelog"
 ```
 
+Interactive slash commands:
+
+- `/help`
+- `/config`
+- `/compact`
+- `/reasoning [level]`
+- `/models`
+- `/model [name]`
+- `/save [label]`
+- `/load [label]`
+- `/sessions`
+- `/exit`
+
 ### Exit codes
 
 - `0`: Success
@@ -289,7 +316,9 @@ npm run dev -- --oneshot --out result.txt "Draft changelog"
 - `npm run dev` - start the CLI in TypeScript mode
 - `npm run dev:ink` - start with Ink UI (same as `dev` when in a TTY; use to override `CLI_UI_MODE=legacy`)
 - `npm run build` - compile TypeScript to `dist/`
+- `npm run build:web` - build the bundled web client used by `minicode serve`
 - `npm start` - run compiled CLI
+- `npm run install:global` - build and `npm link` the CLI locally
 - `npm run lint` - run ESLint on TypeScript source and tests
 - `npm test` - run Node test suite
-
+- `npm run verify-index` - run the TypeScript index verification harness

--- a/docs/AGENT_RUNTIME.md
+++ b/docs/AGENT_RUNTIME.md
@@ -6,31 +6,36 @@ This document describes how the minicode agent runtime works end-to-end, from a 
 
 The runtime is primarily composed of:
 
-- `CodingAgent` (`src/agent/agent.ts`) — orchestrates one user turn over one or more model/tool steps.
-- `Session` (`src/session/session.ts`) — stores conversation history and handles context trimming.
-- `ToolRegistry` (`src/tools/registry.ts`) — exposes tool schemas and executes tool calls safely.
-- `ModelClient` implementations (`src/model/client.ts`) — transport for Anthropic or OpenAI-compatible providers.
-- Prompt builder (`src/prompt/system-prompt.ts`) — builds the system prompt from config, tools, and code map.
+- `CodingAgent` (`packages/agent-sdk/src/agent/agent.ts`) — orchestrates one user turn over one or more model/tool steps.
+- `Session` (`packages/agent-sdk/src/session/session.ts`) — stores conversation history and handles trimming and compaction.
+- SDK `ToolRegistry` (`packages/agent-sdk/src/tools/registry.ts`) — exposes the core file/shell tools and executes them safely.
+- minicode `createToolRegistry` (`src/tools/registry.ts`) — layers graph-aware tools on top of the SDK registry when a project index is available.
+- `ModelClient` implementations (`packages/agent-sdk/src/model/client.ts`) — transport for Anthropic or OpenAI-compatible providers.
+- Prompt builder (`packages/agent-sdk/src/prompt/system-prompt.ts`) — builds the system prompt from config, tools, and code map.
+- Config and indexing adapters (`src/agent/config.ts`, `src/indexer/project-index.ts`) — load runtime config and prepare the project index used by the CLI and serve mode.
 
 ## 2) Turn lifecycle (`CodingAgent.runTurn`)
 
 A single turn follows this sequence:
 
 1. Append user message to session.
-2. Build tool schemas from `ToolRegistry`.
-3. Build optional code map from project index.
-4. Build a system prompt that includes workspace context, available tools, and guidance.
-5. Loop up to `maxSteps`:
+2. Build tool schemas from the current tool registry.
+3. Loop up to `maxSteps`:
    - Enforce step limit guard.
-   - Trim session for context budget.
+   - Optionally auto-compact when context exceeds `compactionThreshold`.
+   - Trim session for context budget, with adaptive `keepRecentMessages` when enabled.
+   - Build a fresh system prompt, including the current code map and any focus-symbol boosts.
    - Call model with system prompt + session + tool schemas.
    - If no tool calls: return assistant text and finish turn.
    - If tool calls exist:
      - Persist assistant message/tool call metadata in session.
      - Execute each tool.
+     - Deduplicate repeated `read_file` calls within the same turn when enabled and the earlier file slice is still present in context.
+     - Apply content-aware tool output truncation when enabled.
+     - Record focus symbols from graph-aware tool calls so subsequent code maps stay aligned with the current area of work.
      - Append each tool result as a `role: "tool"` session message.
      - Continue loop for next model step.
-6. If step limit is reached, return a stop message to prevent infinite loops.
+4. If step limit is reached, return a stop message to prevent infinite loops.
 
 ## 3) Session and context management
 
@@ -40,15 +45,18 @@ The session tracks all message roles used by tool-using chat:
 - `assistant` (including tool-call intents)
 - `tool` (results tied to `toolCallId`)
 
-Before each model request, the runtime calls `session.trim(maxContextTokens, keepRecentMessages)` to keep the most recent messages while reducing approximate token load.
+Before each model request, the runtime may compact old messages and then calls `session.trim(maxContextTokens, keepRecentMessages)` to keep the most recent messages while reducing approximate token load.
 
 This keeps long-running conversations from exceeding model context while preserving near-term continuity.
 
 ## 4) Tool registration and execution
 
-`ToolRegistry.createDefault()` always registers core file/shell tools and conditionally adds code-intelligence tools when a `ProjectIndex` is available:
+At the SDK layer, `ToolRegistry.createDefault()` registers the core file/shell tools:
 
 - Core: `read_file`, `write_file`, `edit_file`, `search`, `list_files`, `run_command`
+
+At the minicode application layer, `src/tools/registry.ts` wraps those and conditionally adds code-intelligence tools when a `ProjectIndex` is available:
+
 - Indexed: `read_symbol`, `find_references`, `get_dependencies`, `search_code_map`
 
 Execution model:
@@ -67,6 +75,8 @@ Additional protections:
 
 - Step count hard limit (`maxSteps`)
 - Tool output truncation (`maxToolOutputChars`)
+- Optional file-read deduplication inside a turn
+- Compaction and trimming before prompts exceed the budget
 - Path/command guardrails enforced inside tool implementations and safety utilities
 
 ## 6) Progress, streaming, and UI updates

--- a/docs/AST_DEP_GRAPH_TOOLING.md
+++ b/docs/AST_DEP_GRAPH_TOOLING.md
@@ -108,11 +108,12 @@ A recursive walk captures `ts.isCallExpression` and `ts.isNewExpression` and emi
 
 If dependency edges are available, symbols are sorted by:
 
-1. Exported before non-exported,
-2. Higher inbound reference count (`edge.to`) first,
-3. Entry-point bias (`src/index.ts` or `*/index.ts`).
+1. Focus-boosted symbols first (when the agent has recently explored related symbols),
+2. Exported before non-exported,
+3. Higher inbound reference count (`edge.to`) first,
+4. Entry-point bias (`src/index.ts` or `*/index.ts`).
 
-This means highly connected API symbols and entry files survive truncation more often.
+Focus boosting expands one hop in both directions across the dependency graph, so the code map preferentially keeps the current working set and its immediate neighbors. Files containing boosted symbols are also sorted earlier in the map, which helps the relevant slice of the project survive truncation.
 
 ### 4.3 Injection into model context
 
@@ -120,7 +121,7 @@ This means highly connected API symbols and entry files survive truncation more 
 
 ## 5) How graph + code map power agent tools
 
-When a project index exists, `ToolRegistry.createDefault()` inserts graph-aware tools (`read_symbol`, `find_references`, `get_dependencies`, `search_code_map`) before generic file tools.
+When a project index exists, minicode's `createToolRegistry()` (`src/tools/registry.ts`) inserts graph-aware tools (`read_symbol`, `find_references`, `get_dependencies`, `search_code_map`) ahead of the SDK's generic file tools.
 
 ### 5.1 `read_symbol`
 

--- a/docs/CONTEXT_OPTIMIZATION.md
+++ b/docs/CONTEXT_OPTIMIZATION.md
@@ -1,14 +1,18 @@
-# Context Optimization for Local Models
+# Context Optimization for Agentic Coding
 
-minicode is optimized for local AI models with smaller context windows (20B+ parameter range like GLM-4.7). This document describes the context management strategies implemented to maximize effectiveness within tight token budgets.
+minicode's context strategy started with local AI models and smaller context windows, but the same techniques also help hosted frontier models by reducing latency, cost, and prompt bloat. This document describes the context-management strategies implemented in the current runtime.
 
 ## Default configuration
 
 | Parameter | Default | Purpose |
 |-----------|---------|---------|
 | `maxContextTokens` | `40,000` | Target token budget for session history before trimming |
-| `maxToolOutputChars` | `15,000` | Max characters per tool result before truncation |
+| `maxToolOutputChars` | `8,000` | Max characters per tool result before truncation |
 | `keepRecentMessages` | `12` | Minimum number of latest messages preserved during eviction |
+| `enableFileReadDedup` | `true` | Reuses earlier `read_file` results within a turn when the same slice is still in context |
+| `enableAdaptiveKeepRecent` | `true` | Scales the protected recent-message window down as context fills |
+| `enableToolOutputTruncation` | `true` | Uses tool-specific truncation strategies instead of simple head-only clipping |
+| `compactionThreshold` | `0.8` | Auto-compacts old messages once the session reaches 80% of the configured budget |
 
 These can be overridden via environment variables (`MAX_CONTEXT_TOKENS`, etc.), `~/.minicode/agent.config.json`, or a workspace-level `agent.config.json`.
 
@@ -16,7 +20,7 @@ These can be overridden via environment variables (`MAX_CONTEXT_TOKENS`, etc.), 
 
 Every message in a session — user messages, assistant responses, tool call metadata, and tool result outputs — is stored in a single `Session` array. The entire array is sent to the model on every step. There is no separate "context buffer" vs "session storage"; whatever survives trimming IS the context.
 
-A single `read_file` returning 15,000 characters consumes ~3,750 tokens. In a 40k budget, five or six such calls would consume half the context window.
+A single `read_file` returning 8,000 characters consumes roughly 2,000 tokens. In a 40k budget, repeated full-file reads still add up quickly, which is why the runtime tries to avoid them with symbol-aware tools, file-read dedup, and trimming/compaction.
 
 ## Optimization strategies
 
@@ -109,16 +113,31 @@ Now the code map dynamically adapts based on what the user is exploring:
 - `CodingAgent` (which references Session via `session.trim()`)
 - The files containing these symbols
 
-### 5. Tool output truncation (pre-existing)
+### 5. File-read deduplication
 
 **File:** `packages/agent-sdk/src/agent/agent.ts`
 
-After each tool executes, if the result exceeds `maxToolOutputChars` (default 15,000), it is hard-truncated with a suffix:
+When `enableFileReadDedup` is enabled, repeated `read_file` calls within the same turn are short-circuited if the exact same file slice is still present in the session context. Instead of re-inserting the full file contents, the agent gets a compact reminder that the file was already read earlier in the turn.
+
+This saves tokens in common agent loops where the model repeatedly re-reads the same file before editing.
+
+### 6. Tool output truncation
+
+**File:** `packages/agent-sdk/src/agent/agent.ts`
+
+When `enableToolOutputTruncation` is enabled, minicode uses tool-specific truncation strategies. The current behavior is:
+
+- `read_file` — never truncated, because exact file contents are needed for edits
+- `run_command` — preserves the tail, where errors and final status usually appear
+- `search` — keeps the head and appends a match-count footer
+- other tools — fall back to simple head truncation
+
+When truncation is disabled, the runtime falls back to a simple head-only clip at `maxToolOutputChars` (default 8,000):
 ```
 [... truncated, 5000 more chars ...]
 ```
 
-### 6. AST-indexed tools (pre-existing)
+### 7. AST-indexed tools
 
 **Files:** `src/tools/read-symbol.ts`, `src/tools/find-references.ts`, `src/tools/get-dependencies.ts`
 

--- a/docs/PLUGIN_SPEC.md
+++ b/docs/PLUGIN_SPEC.md
@@ -2,6 +2,8 @@
 
 This document describes how to create language plugins for minicode. Plugins enable the agent to index and navigate source code in languages beyond the built-in TypeScript/JavaScript support.
 
+> **Current repo state:** the shared SDK types live in the private workspace package `packages/agent-sdk`. The interfaces below reflect the actual runtime shape, but publishing the SDK as a standalone npm dependency is still a future packaging step.
+
 ---
 
 ## Overview
@@ -159,7 +161,8 @@ interface DependencyEdge {
 mkdir my-minicode-plugin
 cd my-minicode-plugin
 npm init -y
-npm install @minicode/agent-sdk  # or add as peer dependency
+# Today, develop against a local checkout of minicode or copied type definitions
+# from packages/agent-sdk until the SDK is published as a standalone package.
 ```
 
 ### 2. Implement the plugin
@@ -206,6 +209,8 @@ Your package must export the plugin. In `package.json`:
   }
 }
 ```
+
+If you are developing against the current repo state, point this at a local workspace copy instead of assuming the package is published.
 
 For local plugins (`.minicode/plugins/`), export a default or named `LanguagePlugin`:
 

--- a/docs/SDK_SPEC.md
+++ b/docs/SDK_SPEC.md
@@ -1,5 +1,7 @@
 # Agent Runtime SDK Specification (Draft)
 
+The repo now includes an extracted workspace package at `packages/agent-sdk`, but this document is still the broader design spec for where the packaging and public API could go next.
+
 This document proposes a reusable SDK extracted from minicode's existing runtime so the CLI can become one consumer among many (CLI, web app, CI bot, IDE extension, custom agent service).
 
 ## 1) Goals
@@ -301,10 +303,10 @@ const runtime = new AgentRuntime(
     model: "zai-org/glm-4.7-flash",
     maxSteps: 50,
     maxTokens: 4096,
-    maxContextTokens: 120000,
+    maxContextTokens: 40000,
     keepRecentMessages: 12,
     loopDetectionWindow: 6,
-    maxToolOutputChars: 15000,
+    maxToolOutputChars: 8000,
   },
   {
     modelClient: new OpenAICompatibleModelClient({

--- a/docs/WEB_SERVE.md
+++ b/docs/WEB_SERVE.md
@@ -27,6 +27,7 @@ The web UI provides a full chat interface for interacting with the agent:
 - **Thinking indicators** — the agent's intermediate reasoning is shown in dimmed italic text
 - **Markdown rendering** — agent responses render full markdown: code blocks with syntax highlighting, bold, lists, headers, blockquotes, and inline code
 - **Auto-resize input** — the textarea grows as you type, up to a max height
+- **Model picker** — fetch available provider models and switch the active one from the header without restarting the server
 
 ### Session Management
 
@@ -61,6 +62,8 @@ curl http://localhost:4567/v1/chat/completions \
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/api/status` | Agent status (ready/busy), workspace, model, provider |
+| `GET` | `/api/models` | Available provider models plus the active model |
+| `POST` | `/api/model` | Switch the active model (`{ model: string }`) |
 | `GET` | `/api/config` | Formatted agent configuration |
 | `POST` | `/api/chat` | Send a message, get response (non-streaming) |
 | `GET` | `/api/sessions` | List saved sessions |
@@ -74,6 +77,7 @@ Connect to `ws://localhost:4567` for real-time events during agent turns:
 **Client → Server:**
 - `{ type: "chat", message: "..." }` — send a message
 - `{ type: "cancel" }` — abort the current turn
+- `{ type: "switch_model", model: "..." }` — switch the active model for all connected clients
 
 **Server → Client:**
 - `turn_start` — agent began processing
@@ -85,6 +89,7 @@ Connect to `ws://localhost:4567` for real-time events during agent turns:
 - `turn_end` — agent finished (`text`, `usage`)
 - `error` — error message
 - `busy` — agent is already processing another turn
+- `model_changed` — confirms that the active model changed
 
 ---
 

--- a/docs/WEB_SERVE_VISION.md
+++ b/docs/WEB_SERVE_VISION.md
@@ -54,7 +54,7 @@ The current minicode architecture is well-suited for this:
 - Click on any node in the dependency graph and attach special instructions for the agent
 - Examples: "When you touch this function, be careful about X", "This class is being deprecated, prefer Y instead"
 - Turns the dependency graph into a **shared workspace** between human and agent
-- Annotations persisted per-project (e.g., `.minicode/annotations.json`) to survive across sessions
+- Today annotations are saved and restored with session save/load; longer-lived per-project persistence is still an open design direction
 
 ### Focus Pinning
 - Clicking a node "pins" it as a focus symbol
@@ -110,17 +110,20 @@ All of the above requires a server mode as the foundation.
 ### API Surface (Preliminary)
 
 **REST Endpoints:**
-- `POST /chat` — send a message, get streamed response
-- `GET /sessions` / `POST /sessions` — list, save, load sessions
-- `GET /config` — current agent configuration
-- `GET /status` — health check, project info
-- `GET /symbols` — list all indexed symbols
-- `GET /symbols/:id/dependencies` — dependency cone for a symbol
-- `GET /symbols/:id/references` — references to a symbol
-- `GET /code-map` — current code map (ranked symbols)
-- `GET /graph` — full dependency graph (nodes + edges)
-- `POST /focus` — pin/unpin symbols
-- `POST /annotations` — attach instructions to symbols
+- `POST /api/chat` — send a message, get a non-streaming response
+- `GET /api/sessions`, `POST /api/sessions/save`, `POST /api/sessions/load` — list, save, and load sessions
+- `GET /api/config` — current agent configuration
+- `GET /api/status` — health check, project info
+- `GET /api/models`, `POST /api/model` — list and switch models
+- `GET /api/symbols` — list all indexed symbols
+- `GET /api/symbols/:id/dependencies` — dependency cone for a symbol
+- `GET /api/symbols/:id/references` — references to a symbol
+- `GET /api/symbols/:id/source` — extracted source for one symbol
+- `GET /api/code-map` — current code map (ranked symbols)
+- `GET /api/graph` — full dependency graph (nodes + edges)
+- `GET /api/focus`, `POST /api/focus` — inspect and pin/unpin symbols
+- `GET /api/annotations`, `GET|POST|DELETE /api/symbols/:id/annotations...` — inspect and modify symbol annotations
+- `GET /api/symbols/:id/explain` — SSE stream for symbol explanation
 
 **OpenAI-Compatible API (`/v1/`):**
 - `POST /v1/chat/completions` — standard OpenAI Chat Completions format (streaming SSE + non-streaming)
@@ -135,6 +138,7 @@ All of the above requires a server mode as the foundation.
   - `streaming_chunk` — text response chunks
   - `tool_call_start` / `tool_call_end` — tool activity with timing
   - `step` — step counter
+- `switch_model` client messages and `model_changed` broadcasts for live model switching
 - Code map updates as focus changes
 - Graph updates after file modifications
 - Bidirectional for confirmations (destructive command approval)
@@ -167,8 +171,8 @@ All of the above requires a server mode as the foundation.
 
 1. ~~**API server + OpenAI compat + basic web chat**~~ **(IMPLEMENTED)** — `minicode serve` with REST + WebSocket for chat, sessions, config; OpenAI-compatible `/v1/chat/completions` endpoint for use with OpenWebUI etc.; bundled web chat client with dark theme, streaming responses, compact tool call pills, and session management UI
 2. ~~**Graph data endpoints**~~ **(IMPLEMENTED)** — REST endpoints exposing ProjectIndex data: `/api/symbols`, `/api/symbols/:name/dependencies`, `/api/symbols/:name/references`, `/api/code-map`, `/api/graph`, `/api/focus` (pin/unpin). 35 integration tests covering all endpoints.
-3. **Dependency graph UI** — interactive graph visualization with symbol inspection
+3. ~~**Dependency graph UI**~~ **(IMPLEMENTED)** — interactive graph visualization with symbol inspection, source view, pinning, and explain requests
 4. **Live code map view** — real-time agent perspective, steerable focus
 5. **Symbol prompts** — attach symbols to prompts, symbol bookmarks/workspaces
-6. **Symbol annotations** — click-to-annotate with agent instructions, persisted per-project
+6. ~~**Symbol annotations**~~ **(IMPLEMENTED, session-scoped)** — click-to-annotate with agent instructions, saved with sessions
 7. **Advanced features** — graph diffing, path highlighting, inline diffs, conversation-linked navigation, history replay

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -4,11 +4,18 @@ Reusable agent runtime SDK extracted from minicode. Provides everything needed t
 
 ## Installation
 
+This package currently lives as a private workspace package inside the minicode repo:
+
 ```bash
-npm install @minicode/agent-sdk
+git clone https://github.com/sean1588/minicode.git
+cd minicode
+npm install
+npm run build --workspace=packages/agent-sdk
 ```
 
-> **Note:** Requires Node.js >= 22.0.0
+> **Note:** `packages/agent-sdk/package.json` is currently marked `private`, so treat this README as documentation for the in-repo SDK surface rather than a published npm package.
+>
+> **Requires:** Node.js >= 22.0.0
 
 ## Quick Start
 
@@ -28,16 +35,20 @@ const config: AgentConfig = {
   model: "claude-sonnet-4-20250514",
   maxSteps: 20,
   maxTokens: 4096,
-  maxContextTokens: 100_000,
+  maxContextTokens: 40_000,
   workspaceRoot: process.cwd(),
   commandTimeoutMs: 30_000,
   maxFileSizeBytes: 1_000_000,
   commandDenylist: [/rm\s+-rf\s+\//],
   confirmDestructive: true,
-  keepRecentMessages: 10,
-  loopDetectionWindow: 10,
-  maxToolOutputChars: 12_000,
+  keepRecentMessages: 12,
+  loopDetectionWindow: 6,
+  maxToolOutputChars: 8_000,
   openAiBaseUrl: "",
+  enableFileReadDedup: true,
+  enableAdaptiveKeepRecent: true,
+  enableToolOutputTruncation: true,
+  compactionThreshold: 0.8,
 };
 
 // 2. Create the model client, tool registry, and agent
@@ -139,7 +150,15 @@ const agent = new CodingAgent({
 Register your own tools alongside or instead of the built-in ones:
 
 ```typescript
-import { ToolRegistry } from "@minicode/agent-sdk";
+import {
+  ToolRegistry,
+  createReadFileTool,
+  createWriteFileTool,
+  createEditFileTool,
+  createSearchTool,
+  createListFilesTool,
+  createRunCommandTool,
+} from "@minicode/agent-sdk";
 import type { ToolDefinition } from "@minicode/agent-sdk";
 
 const myTool: ToolDefinition = {
@@ -163,12 +182,18 @@ const myTool: ToolDefinition = {
 const registry = new ToolRegistry([myTool]);
 
 // Option B: Built-in tools + custom tools
-const builtIn = ToolRegistry.createDefault(config);
 const combined = new ToolRegistry([
-  ...builtIn.getToolSchemas().map(() => myTool), // just an example
+  createReadFileTool(config),
+  createWriteFileTool(config),
+  createEditFileTool(config),
+  createSearchTool(config),
+  createListFilesTool(config),
+  createRunCommandTool(config),
   myTool,
 ]);
 ```
+
+In practice, the simplest pattern is usually to create the built-in registry and wrap or extend it in your own application code. The SDK does not currently expose a public "appendTool" helper.
 
 ## Tool Hooks (Indexer Integration)
 
@@ -188,6 +213,10 @@ const toolRegistry = ToolRegistry.createDefault(config, {
   },
 });
 ```
+
+## Indexer boundary
+
+The SDK exports indexer and plugin _types_ such as `LanguagePlugin`, `IndexedSymbol`, and `DependencyEdge`, but it does not currently ship the full project indexer implementation that the minicode CLI uses for its TypeScript/JavaScript graph tools. In the current repo layout, the richer indexer lives in the top-level `src/indexer/` directory.
 
 ## Safety Guardrails
 


### PR DESCRIPTION
## Summary
- refresh the top-level README to match the current product shape, config defaults, slash commands, and TypeScript/JavaScript language-support story
- update the technical docs for the post-SDK-extraction code layout, newer context-optimization behavior, and the current `minicode serve` API/UI features
- clarify the current status of the in-repo agent SDK and plugin story so the docs stop implying the SDK is already published as a standalone package

## Why
Some of the docs had drifted behind the implementation as the project evolved from a more local-model/CLI-first tool into a broader graph-native runtime with a richer web UI, extracted SDK package, and newer context-management features. That made the docs undersell the product in some places and overstate or misstate behavior in others.

## Impact
- readers get the current defaults and config surface instead of stale values
- runtime and serve-mode docs now point at the right files, endpoints, and behavior
- plugin/SDK docs are more honest about what is available today versus what is still a future packaging step

## Validation
- checked the docs against the live implementation in `src/` and `packages/agent-sdk/`
- ran `git diff --check`
- re-grepped the doc set to verify the stale defaults and old API references were removed
