### PR TITLE
Add manually triggered benchmark workflow and runner script

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,78 @@
+name: Benchmarks
+
+on:
+  workflow_dispatch:
+    inputs:
+      model_provider:
+        description: "Model provider (anthropic or openai-compatible)"
+        required: true
+        default: "anthropic"
+        type: choice
+        options:
+          - anthropic
+          - openai-compatible
+      model:
+        description: "Model name (e.g. claude-sonnet-4-20250514)"
+        required: true
+        default: "claude-sonnet-4-20250514"
+        type: string
+      category:
+        description: "Task category filter (leave empty to run all)"
+        required: false
+        default: ""
+        type: choice
+        options:
+          - ""
+          - navigation
+          - editing
+          - refactors
+          - debugging
+          - planning
+      variant:
+        description: "Variant label for the report"
+        required: false
+        default: "ci"
+        type: string
+
+jobs:
+  run-benchmarks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build SDK
+        run: npm run build --workspace=packages/agent-sdk
+
+      - name: Run benchmarks
+        env:
+          MODEL_PROVIDER: ${{ inputs.model_provider }}
+          MODEL: ${{ inputs.model }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
+        run: |
+          ARGS="--variant ${{ inputs.variant }} --out benchmark-report.json"
+          if [ -n "${{ inputs.category }}" ]; then
+            ARGS="$ARGS --category ${{ inputs.category }}"
+          fi
+          node --import tsx scripts/run-benchmarks.ts $ARGS
+
+      - name: Upload benchmark report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-report-${{ inputs.variant }}-${{ github.run_number }}
+          path: benchmark-report.json
+          retention-days: 90

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "lint": "eslint \"src/**/*.ts\" \"src/**/*.tsx\" \"tests/**/*.ts\" --max-warnings=0",
     "pretest": "npm run build --workspace=packages/agent-sdk && node scripts/build-web.mjs",
     "test": "node --test --import tsx \"tests/**/*.test.ts\"",
-    "verify-index": "node --import tsx test-programs/verify-index/verify.ts"
+    "verify-index": "node --import tsx test-programs/verify-index/verify.ts",
+    "benchmark": "node --import tsx scripts/run-benchmarks.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.76.0",

--- a/scripts/run-benchmarks.ts
+++ b/scripts/run-benchmarks.ts
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * CLI entry point for running benchmark tasks.
+ *
+ * Usage:
+ *   node --import tsx scripts/run-benchmarks.ts [options]
+ *
+ * Options:
+ *   --category <name>   Run only tasks in the given category
+ *   --task <id>         Run a single task by id (e.g. "navigation/find-symbol-definition")
+ *   --variant <label>   Variant label for the report (default: "ci")
+ *   --out <path>        Write the JSON report to a file
+ *
+ * Environment:
+ *   MODEL_PROVIDER, MODEL, OPENAI_BASE_URL, OPENAI_API_KEY, ANTHROPIC_API_KEY
+ *   — same as minicode runtime config.
+ */
+
+import path from "node:path";
+import { writeFile } from "node:fs/promises";
+
+import {
+  createModelClient,
+  createReadFileTool,
+  createWriteFileTool,
+  createEditFileTool,
+  createSearchTool,
+  createListFilesTool,
+  createRunCommandTool,
+} from "@minicode/agent-sdk";
+import type { AgentConfig, ToolDefinition } from "@minicode/agent-sdk";
+
+import { loadBenchmarkTasks, loadBenchmarkTask } from "../src/benchmark/task-loader.js";
+import { runBenchmarkSuite } from "../src/benchmark/runner.js";
+import { buildReport, formatReport } from "../src/benchmark/reporter.js";
+import type { BenchmarkTask } from "../src/benchmark/types.js";
+
+/* ------------------------------------------------------------------ */
+/*  CLI argument parsing                                               */
+/* ------------------------------------------------------------------ */
+
+export interface BenchmarkCLIArgs {
+  category?: string;
+  task?: string;
+  variant: string;
+  out?: string;
+}
+
+export function parseArgs(argv: string[]): BenchmarkCLIArgs {
+  const args: BenchmarkCLIArgs = { variant: "ci" };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === "--category" && next) {
+      args.category = next;
+      i++;
+    } else if (arg === "--task" && next) {
+      args.task = next;
+      i++;
+    } else if (arg === "--variant" && next) {
+      args.variant = next;
+      i++;
+    } else if (arg === "--out" && next) {
+      args.out = next;
+      i++;
+    }
+  }
+
+  return args;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Config builder                                                     */
+/* ------------------------------------------------------------------ */
+
+export function buildConfig(): AgentConfig {
+  const provider = (process.env.MODEL_PROVIDER ?? "openai-compatible") as
+    "anthropic" | "openai-compatible";
+  const model = process.env.MODEL ?? "test-model";
+
+  return {
+    modelProvider: provider,
+    model,
+    maxSteps: Number(process.env.MAX_STEPS ?? "50"),
+    maxTokens: Number(process.env.MAX_TOKENS ?? "4096"),
+    maxContextTokens: Number(process.env.MAX_CONTEXT_TOKENS ?? "40000"),
+    workspaceRoot: process.cwd(),
+    commandTimeoutMs: Number(process.env.COMMAND_TIMEOUT_MS ?? "30000"),
+    maxFileSizeBytes: Number(process.env.MAX_FILE_SIZE_BYTES ?? "1000000"),
+    commandDenylist: [],
+    confirmDestructive: false,
+    keepRecentMessages: Number(process.env.KEEP_RECENT_MESSAGES ?? "12"),
+    loopDetectionWindow: Number(process.env.LOOP_DETECTION_WINDOW ?? "6"),
+    maxToolOutputChars: Number(process.env.MAX_TOOL_OUTPUT_CHARS ?? "8000"),
+    openAiBaseUrl: process.env.OPENAI_BASE_URL ?? "http://localhost:1234/v1",
+    ...(process.env.OPENAI_API_KEY ? { openAiApiKey: process.env.OPENAI_API_KEY } : {}),
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Task loading                                                       */
+/* ------------------------------------------------------------------ */
+
+export async function loadTasks(
+  tasksDir: string,
+  args: BenchmarkCLIArgs,
+): Promise<BenchmarkTask[]> {
+  if (args.task) {
+    const single = await loadBenchmarkTask(tasksDir, args.task);
+    if (!single) {
+      throw new Error(`Task not found: ${args.task}`);
+    }
+    return [single];
+  }
+
+  let tasks = await loadBenchmarkTasks(tasksDir);
+
+  if (args.category) {
+    tasks = tasks.filter((t) => t.category === args.category);
+    if (tasks.length === 0) {
+      throw new Error(`No tasks found for category: ${args.category}`);
+    }
+  }
+
+  return tasks;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main                                                               */
+/* ------------------------------------------------------------------ */
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const config = buildConfig();
+  const tasksDir = path.resolve(process.cwd(), "benchmarks", "tasks");
+
+  console.log(`Benchmark runner starting...`);
+  console.log(`  Provider: ${config.modelProvider}`);
+  console.log(`  Model: ${config.model}`);
+  console.log(`  Variant: ${args.variant}`);
+
+  const tasks = await loadTasks(tasksDir, args);
+  console.log(`  Tasks: ${tasks.length}`);
+  console.log("");
+
+  const modelClient = createModelClient(config);
+  const tools: ToolDefinition[] = [
+    createReadFileTool(config),
+    createWriteFileTool(config),
+    createEditFileTool(config),
+    createSearchTool(config),
+    createListFilesTool(config),
+    createRunCommandTool(config),
+  ];
+
+  const traces = await runBenchmarkSuite(tasks, {
+    modelClient,
+    config,
+    tools,
+    variant: args.variant,
+    onTaskComplete: (taskId, trace) => {
+      const dur = (trace.durationMs / 1000).toFixed(1);
+      console.log(`  [done] ${taskId} (${dur}s, ${trace.toolCalls.length} tool calls)`);
+    },
+  });
+
+  const report = buildReport(tasks, traces, args.variant, config.model);
+  const formatted = formatReport(report);
+
+  console.log("");
+  console.log(formatted);
+
+  if (args.out) {
+    const outPath = path.resolve(args.out);
+    await writeFile(outPath, JSON.stringify(report, null, 2), "utf8");
+    console.log(`\nReport written to ${outPath}`);
+  }
+
+  // Exit with failure if any task failed
+  if (report.summary.failed > 0) {
+    process.exitCode = 1;
+  }
+}
+
+// Only run main when executed directly (not imported for testing)
+const isDirectRun = process.argv[1]?.endsWith("run-benchmarks.ts") ||
+                    process.argv[1]?.endsWith("run-benchmarks.js");
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error("Benchmark runner failed:", err);
+    process.exitCode = 1;
+  });
+}

--- a/tests/run-benchmarks.test.ts
+++ b/tests/run-benchmarks.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { test } from "node:test";
+
+import { parseArgs, buildConfig, loadTasks } from "../scripts/run-benchmarks.js";
+
+// ─── parseArgs ────────────────────────────────────────────────────
+
+test("parseArgs: defaults to variant 'ci' with no flags", () => {
+  const args = parseArgs([]);
+  assert.equal(args.variant, "ci");
+  assert.equal(args.category, undefined);
+  assert.equal(args.task, undefined);
+  assert.equal(args.out, undefined);
+});
+
+test("parseArgs: parses --variant flag", () => {
+  const args = parseArgs(["--variant", "nightly"]);
+  assert.equal(args.variant, "nightly");
+});
+
+test("parseArgs: parses --category flag", () => {
+  const args = parseArgs(["--category", "navigation"]);
+  assert.equal(args.category, "navigation");
+});
+
+test("parseArgs: parses --task flag", () => {
+  const args = parseArgs(["--task", "navigation/find-symbol-definition"]);
+  assert.equal(args.task, "navigation/find-symbol-definition");
+});
+
+test("parseArgs: parses --out flag", () => {
+  const args = parseArgs(["--out", "report.json"]);
+  assert.equal(args.out, "report.json");
+});
+
+test("parseArgs: parses all flags together", () => {
+  const args = parseArgs([
+    "--category", "editing",
+    "--variant", "v2",
+    "--out", "/tmp/report.json",
+  ]);
+  assert.equal(args.category, "editing");
+  assert.equal(args.variant, "v2");
+  assert.equal(args.out, "/tmp/report.json");
+});
+
+test("parseArgs: ignores unknown flags", () => {
+  const args = parseArgs(["--unknown", "value", "--variant", "test"]);
+  assert.equal(args.variant, "test");
+});
+
+// ─── buildConfig ──────────────────────────────────────────────────
+
+test("buildConfig: returns defaults when no env vars set", () => {
+  const originalProvider = process.env.MODEL_PROVIDER;
+  const originalModel = process.env.MODEL;
+  delete process.env.MODEL_PROVIDER;
+  delete process.env.MODEL;
+
+  try {
+    const config = buildConfig();
+    assert.equal(config.modelProvider, "openai-compatible");
+    assert.equal(config.model, "test-model");
+    assert.equal(config.maxSteps, 50);
+    assert.equal(config.maxTokens, 4096);
+    assert.equal(config.maxContextTokens, 40000);
+    assert.equal(config.confirmDestructive, false);
+  } finally {
+    if (originalProvider !== undefined) process.env.MODEL_PROVIDER = originalProvider;
+    if (originalModel !== undefined) process.env.MODEL = originalModel;
+  }
+});
+
+test("buildConfig: reads MODEL_PROVIDER and MODEL from env", () => {
+  const originalProvider = process.env.MODEL_PROVIDER;
+  const originalModel = process.env.MODEL;
+  process.env.MODEL_PROVIDER = "anthropic";
+  process.env.MODEL = "claude-test";
+
+  try {
+    const config = buildConfig();
+    assert.equal(config.modelProvider, "anthropic");
+    assert.equal(config.model, "claude-test");
+  } finally {
+    if (originalProvider !== undefined) {
+      process.env.MODEL_PROVIDER = originalProvider;
+    } else {
+      delete process.env.MODEL_PROVIDER;
+    }
+    if (originalModel !== undefined) {
+      process.env.MODEL = originalModel;
+    } else {
+      delete process.env.MODEL;
+    }
+  }
+});
+
+// ─── loadTasks ────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+async function setupTempTasks(): Promise<string> {
+  tmpDir = await mkdtemp(path.join(tmpdir(), "bench-cli-test-"));
+  await mkdir(path.join(tmpDir, "navigation", "find-foo"), { recursive: true });
+  await mkdir(path.join(tmpDir, "editing", "fix-bar"), { recursive: true });
+
+  await writeFile(
+    path.join(tmpDir, "navigation", "find-foo", "task.json"),
+    JSON.stringify({
+      title: "Find foo",
+      prompt: "Find foo",
+      rubric: { expectedOutputPatterns: ["foo"] },
+    }),
+  );
+  await writeFile(
+    path.join(tmpDir, "editing", "fix-bar", "task.json"),
+    JSON.stringify({
+      title: "Fix bar",
+      prompt: "Fix bar",
+      rubric: { expectedOutputPatterns: ["bar"] },
+    }),
+  );
+
+  return tmpDir;
+}
+
+test("loadTasks: loads all tasks when no filter", async () => {
+  const dir = await setupTempTasks();
+  try {
+    const tasks = await loadTasks(dir, { variant: "ci" });
+    assert.equal(tasks.length, 2);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadTasks: filters by category", async () => {
+  const dir = await setupTempTasks();
+  try {
+    const tasks = await loadTasks(dir, { variant: "ci", category: "navigation" });
+    assert.equal(tasks.length, 1);
+    assert.ok(tasks[0]);
+    assert.equal(tasks[0].category, "navigation");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadTasks: loads single task by id", async () => {
+  const dir = await setupTempTasks();
+  try {
+    const tasks = await loadTasks(dir, { variant: "ci", task: "navigation/find-foo" });
+    assert.equal(tasks.length, 1);
+    assert.ok(tasks[0]);
+    assert.equal(tasks[0].id, "navigation/find-foo");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadTasks: throws for unknown task id", async () => {
+  const dir = await setupTempTasks();
+  try {
+    await assert.rejects(
+      () => loadTasks(dir, { variant: "ci", task: "navigation/nonexistent" }),
+      { message: "Task not found: navigation/nonexistent" },
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadTasks: throws for unknown category", async () => {
+  const dir = await setupTempTasks();
+  try {
+    await assert.rejects(
+      () => loadTasks(dir, { variant: "ci", category: "nonexistent" }),
+      { message: "No tasks found for category: nonexistent" },
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "types": ["node"],
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "tests/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "tests/**/*.ts", "scripts/**/*.ts"],
   "exclude": ["dist", "node_modules", "packages", "src/web"]
 }


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` GitHub Actions workflow (`benchmarks.yml`) for running benchmark tasks on demand with configurable model provider, model name, category filter, and variant label
- Adds a CLI runner script (`scripts/run-benchmarks.ts`) that loads tasks, invokes the benchmark suite via `runBenchmarkSuite`, and outputs/saves the JSON report
- Adds `npm run benchmark` script to package.json
- Adds `scripts/` to tsconfig.json includes for type-checking coverage
- Uploads benchmark report as a GitHub Actions artifact (90-day retention)

## Workflow inputs
| Input | Description | Default |
|-------|-------------|---------|
| `model_provider` | `anthropic` or `openai-compatible` | `anthropic` |
| `model` | Model name | `claude-sonnet-4-20250514` |
| `category` | Filter to a single category (or all) | all |
| `variant` | Report label | `ci` |

## Test plan
- [x] 14 new tests covering `parseArgs`, `buildConfig`, and `loadTasks` — all pass
- [x] All 246 existing tests still pass
- [x] `npm run lint` passes with 0 warnings
- [x] `npm run build` passes clean

Closes #60

https://claude.ai/code/session_01XQi1eddjCBYjbVRsP5t7Lc