### PR TITLE
Add context size indicator to web UI and CLI

### DIFF
--- a/packages/agent-sdk/src/agent/agent.ts
+++ b/packages/agent-sdk/src/agent/agent.ts
@@ -116,12 +116,18 @@ export type UiUpdateToolCallEnd = {
   result: string;
   elapsedMs: number;
 };
+export type UiUpdateContextStatus = {
+  type: "context_status";
+  contextTokens: number;
+  maxContextTokens: number;
+};
 export type UiUpdate =
   | UiUpdateThinking
   | UiUpdateStreamingChunk
   | UiUpdateStep
   | UiUpdateToolCallStart
-  | UiUpdateToolCallEnd;
+  | UiUpdateToolCallEnd
+  | UiUpdateContextStatus;
 
 /**
  * Compute an effective keepRecentMessages that scales proportionally
@@ -220,6 +226,13 @@ export class CodingAgent {
 
   getReasoningEffort(): AgentConfig["reasoningEffort"] {
     return this.config.reasoningEffort;
+  }
+
+  getContextStatus(): { contextTokens: number; maxContextTokens: number } {
+    return {
+      contextTokens: this.session.getTokenEstimate(),
+      maxContextTokens: this.config.maxContextTokens,
+    };
   }
 
   setReasoningEffort(effort: AgentConfig["reasoningEffort"]): void {
@@ -330,6 +343,15 @@ export class CodingAgent {
         this.config.maxContextTokens,
         effectiveKeepRecent,
       );
+
+      // Broadcast current context size so UIs can display a fill indicator.
+      if (this.onUiUpdate) {
+        this.onUiUpdate({
+          type: "context_status",
+          contextTokens: this.session.getTokenEstimate(),
+          maxContextTokens: this.config.maxContextTokens,
+        });
+      }
 
       // When enableDynamicPrompt is true (default), rebuild the system prompt
       // each step with the latest focus set so the code map dynamically adapts.

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -23,6 +23,7 @@ export {
   type UiUpdateStep,
   type UiUpdateToolCallStart,
   type UiUpdateToolCallEnd,
+  type UiUpdateContextStatus,
 } from "./agent/agent.js";
 
 // Session

--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -112,6 +112,12 @@ export function createRequestHandler(bridge: AgentBridge): (req: IncomingMessage
         return;
       }
 
+      if (pathname === "/api/context" && method === "GET") {
+        const status = bridge.getAgent().getContextStatus();
+        sendJson(res, 200, status);
+        return;
+      }
+
       if (pathname === "/api/config" && method === "GET") {
         sendJson(res, 200, { config: formatConfigForDisplay(config) });
         return;

--- a/src/serve/types.ts
+++ b/src/serve/types.ts
@@ -68,6 +68,12 @@ export interface ServerBusyMessage {
   type: "busy";
 }
 
+export interface ServerContextStatusMessage {
+  type: "context_status";
+  contextTokens: number;
+  maxContextTokens: number;
+}
+
 export interface ServerModelChangedMessage {
   type: "model_changed";
   model: string;
@@ -83,4 +89,5 @@ export type ServerMessage =
   | ServerTurnEndMessage
   | ServerErrorMessage
   | ServerBusyMessage
+  | ServerContextStatusMessage
   | ServerModelChangedMessage;

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -39,6 +39,8 @@ function AppInner({ store, onRunTurn, onCtrlC }: AppProps): React.ReactElement {
         maxSteps={state.maxSteps}
         inputTokens={state.inputTokens}
         outputTokens={state.outputTokens}
+        contextTokens={state.contextTokens}
+        maxContextTokens={state.maxContextTokens}
         workspaceRoot={state.workspaceRoot}
         indexStatus={state.indexStatus}
       />

--- a/src/ui/cli-ink.ts
+++ b/src/ui/cli-ink.ts
@@ -55,6 +55,7 @@ export async function runInkCli(
     maxSteps: config.maxSteps,
     indexStatus,
   });
+  store.setContextStatus(0, config.maxContextTokens);
   store.setPhase("idle");
 
   const toolRegistry = createToolRegistry(config, projectIndex);
@@ -92,6 +93,9 @@ export async function runInkCli(
             elapsedMs: event.elapsedMs,
           });
           store.setPhase("model_wait");
+          break;
+        case "context_status":
+          store.setContextStatus(event.contextTokens, event.maxContextTokens);
           break;
       }
     };

--- a/src/ui/components/header-bar.tsx
+++ b/src/ui/components/header-bar.tsx
@@ -8,6 +8,8 @@ interface HeaderBarProps {
   maxSteps: number;
   inputTokens: number;
   outputTokens: number;
+  contextTokens: number;
+  maxContextTokens: number;
   workspaceRoot: string;
   indexStatus: string;
 }
@@ -18,9 +20,18 @@ export function HeaderBar({
   maxSteps,
   inputTokens,
   outputTokens,
+  contextTokens,
+  maxContextTokens,
   workspaceRoot,
   indexStatus,
 }: HeaderBarProps): React.ReactElement {
+  const contextPct =
+    maxContextTokens > 0
+      ? Math.min(100, Math.round((contextTokens / maxContextTokens) * 100))
+      : 0;
+  const contextColor =
+    contextPct >= 80 ? c.red : contextPct >= 60 ? c.yellow : c.green;
+
   return (
     <Box flexDirection="column" borderStyle="single" paddingX={1}>
       <Box>
@@ -45,6 +56,13 @@ export function HeaderBar({
         <Text>  </Text>
         <Text>{c.dim("index:")} </Text>
         <Text>{indexStatus || "—"}</Text>
+        <Text>  </Text>
+        <Text>{c.dim("context:")} </Text>
+        <Text>{contextColor(`${contextPct}%`)}</Text>
+        <Text> </Text>
+        <Text dimColor>
+          (~{contextTokens.toLocaleString()}/{maxContextTokens.toLocaleString()})
+        </Text>
       </Box>
     </Box>
   );

--- a/src/ui/state/ui-store.ts
+++ b/src/ui/state/ui-store.ts
@@ -12,6 +12,8 @@ export interface UiStoreState {
   maxSteps: number;
   inputTokens: number;
   outputTokens: number;
+  contextTokens: number;
+  maxContextTokens: number;
   model: string;
   workspaceRoot: string;
   indexStatus: string;
@@ -25,6 +27,8 @@ const DEFAULT_STATE: UiStoreState = {
   maxSteps: 50,
   inputTokens: 0,
   outputTokens: 0,
+  contextTokens: 0,
+  maxContextTokens: 0,
   model: "",
   workspaceRoot: "",
   indexStatus: "",
@@ -77,6 +81,10 @@ export class UiStore {
 
   setTokenUsage(inputTokens: number, outputTokens: number): void {
     this.update({ inputTokens, outputTokens });
+  }
+
+  setContextStatus(contextTokens: number, maxContextTokens: number): void {
+    this.update({ contextTokens, maxContextTokens });
   }
 
   addItem(item: ActivityItem): void {

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -38,6 +38,8 @@ const sessionDropdown = document.getElementById("session-dropdown")!;
 const sessionList = document.getElementById("session-list")!;
 const saveBtn = document.getElementById("save-btn")!;
 const saveLabelInput = document.getElementById("save-label") as HTMLInputElement;
+const contextFill = document.getElementById("context-fill")!;
+const contextLabel = document.getElementById("context-label")!;
 
 let ws: WebSocket;
 let currentAssistantEl: HTMLElement | null = null;
@@ -53,6 +55,7 @@ function connect(): void {
   ws.onopen = () => {
     setStatus("ready");
     fetchStatus();
+    fetchContext();
   };
 
   ws.onclose = () => {
@@ -178,6 +181,13 @@ function handleServerMessage(msg: ServerMessage): void {
       addMessage("Agent is busy. Please wait for the current turn to finish.", "error");
       break;
 
+    case "context_status":
+      updateContextIndicator(
+        (msg as ServerMessage & { contextTokens: number }).contextTokens,
+        (msg as ServerMessage & { maxContextTokens: number }).maxContextTokens,
+      );
+      break;
+
     case "model_changed":
       modelInfo.textContent = (msg as ServerMessage & { model: string }).model;
       break;
@@ -263,6 +273,30 @@ function finalizeToolCall(name: string, result: string, elapsedMs: number): void
       ? result.slice(0, TOOL_RESULT_MAX) + `\n\n... (${result.length - TOOL_RESULT_MAX} more chars)`
       : result;
     resultEl.textContent = truncated;
+  }
+}
+
+function updateContextIndicator(contextTokens: number, maxContextTokens: number): void {
+  const pct = maxContextTokens > 0 ? Math.min(100, Math.round((contextTokens / maxContextTokens) * 100)) : 0;
+  contextFill.style.width = pct + "%";
+  contextFill.classList.remove("warn", "critical");
+  if (pct >= 80) {
+    contextFill.classList.add("critical");
+  } else if (pct >= 60) {
+    contextFill.classList.add("warn");
+  }
+  contextLabel.textContent = pct + "%";
+  const indicator = document.getElementById("context-indicator")!;
+  indicator.title = `Context: ~${contextTokens.toLocaleString()} / ${maxContextTokens.toLocaleString()} tokens (${pct}%)`;
+}
+
+async function fetchContext(): Promise<void> {
+  try {
+    const res = await fetch("/api/context");
+    const data = await res.json() as { contextTokens: number; maxContextTokens: number };
+    updateContextIndicator(data.contextTokens, data.maxContextTokens);
+  } catch {
+    // ignore
   }
 }
 

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -16,6 +16,12 @@
       <div class="header-left">
         <h1>minicode</h1>
         <span id="status-badge" class="badge ready">ready</span>
+        <div id="context-indicator" title="Context window usage">
+          <div id="context-bar">
+            <div id="context-fill"></div>
+          </div>
+          <span id="context-label">0%</span>
+        </div>
       </div>
       <div class="header-right">
         <div class="model-menu">

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -244,6 +244,45 @@ h1 {
   color: var(--yellow);
 }
 
+/* Context indicator */
+#context-indicator {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 12px;
+}
+
+#context-bar {
+  width: 80px;
+  height: 8px;
+  background: var(--bg-surface);
+  border-radius: 4px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+#context-fill {
+  height: 100%;
+  width: 0%;
+  background: var(--accent);
+  border-radius: 4px;
+  transition: width 0.3s ease, background-color 0.3s ease;
+}
+
+#context-fill.warn {
+  background: var(--yellow);
+}
+
+#context-fill.critical {
+  background: var(--red);
+}
+
+#context-label {
+  font-size: 11px;
+  color: var(--text-dim);
+  min-width: 28px;
+}
+
 .badge.error {
   background: rgba(247, 118, 142, 0.15);
   color: var(--red);

--- a/tests/context-indicator.test.ts
+++ b/tests/context-indicator.test.ts
@@ -1,0 +1,283 @@
+import assert from "node:assert/strict";
+import { test, afterEach } from "node:test";
+import type { Server } from "node:http";
+import { createServer } from "node:http";
+import { createRequestHandler } from "../src/serve/server.js";
+import { AgentBridge } from "../src/serve/agent-bridge.js";
+import type { UiUpdate } from "@minicode/agent-sdk";
+import type { ServerMessage } from "../src/serve/types.js";
+import {
+  CodingAgent,
+  ToolRegistry,
+} from "@minicode/agent-sdk";
+import type {
+  ModelClient,
+  ModelResponse,
+  SessionMessage,
+  ToolSchema,
+} from "@minicode/agent-sdk";
+import { UiStore } from "../src/ui/state/ui-store.js";
+import { createTestAgentConfig } from "./test-utils.js";
+
+// ── Mock model client ──
+
+class SequenceModelClient implements ModelClient {
+  private readonly responses: ModelResponse[];
+
+  constructor(responses: ModelResponse[]) {
+    this.responses = [...responses];
+  }
+
+  async chat(params: {
+    model: string;
+    system: string;
+    messages: SessionMessage[];
+    tools: ToolSchema[];
+    maxTokens: number;
+  }): Promise<ModelResponse> {
+    void params;
+    const next = this.responses.shift();
+    if (!next) throw new Error("No queued model response.");
+    return next;
+  }
+}
+
+// ── MockBridge for serve tests ──
+
+class MockBridge extends AgentBridge {
+  private _busy = false;
+  private _contextTokens = 1200;
+  private _maxContextTokens = 16000;
+
+  constructor() {
+    super(() => {}, false);
+  }
+
+  override isBusy(): boolean {
+    return this._busy;
+  }
+
+  override getConfig() {
+    return createTestAgentConfig("/tmp/test-workspace");
+  }
+
+  override getAgent() {
+    const ctx = { contextTokens: this._contextTokens, maxContextTokens: this._maxContextTokens };
+    return {
+      getContextStatus: () => ctx,
+    } as unknown as CodingAgent;
+  }
+
+  override async runTurn(message: string) {
+    this._busy = true;
+    this.emit({ type: "streaming_chunk", content: `Echo: ${message}` } as ServerMessage);
+    this._busy = false;
+    return { text: `Echo: ${message}`, usage: { inputTokens: 10, outputTokens: 5 } };
+  }
+
+  override async listSess() { return []; }
+  override async saveSess() { return { id: "s", label: "l", createdAt: "", savedAt: "", messageCount: 0 }; }
+  override async loadSess() { return null; }
+  override hasIndex(): boolean { return false; }
+
+  emit(msg: ServerMessage): void {
+    for (const fn of (this as unknown as { listeners: Set<(msg: ServerMessage) => void> }).listeners) {
+      fn(msg);
+    }
+  }
+
+  setContextState(tokens: number, max: number): void {
+    this._contextTokens = tokens;
+    this._maxContextTokens = max;
+  }
+}
+
+// ── Test harness ──
+
+let activeServer: Server | undefined;
+
+function startTestServer(bridge: MockBridge): Promise<string> {
+  const handler = createRequestHandler(bridge);
+  const server = createServer(handler);
+  activeServer = server;
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (typeof addr === "object" && addr) {
+        resolve(`http://127.0.0.1:${addr.port}`);
+      }
+    });
+  });
+}
+
+function stopTestServer(): Promise<void> {
+  return new Promise((resolve) => {
+    if (activeServer) {
+      activeServer.close(() => resolve());
+      activeServer = undefined;
+    } else {
+      resolve();
+    }
+  });
+}
+
+afterEach(async () => {
+  await stopTestServer();
+});
+
+// ── REST API: /api/context ──
+
+test("GET /api/context returns context token status", async () => {
+  const bridge = new MockBridge();
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/context`);
+  assert.equal(res.status, 200);
+
+  const body = (await res.json()) as { contextTokens: number; maxContextTokens: number };
+  assert.equal(body.contextTokens, 1200);
+  assert.equal(body.maxContextTokens, 16000);
+});
+
+test("GET /api/context reflects updated context state", async () => {
+  const bridge = new MockBridge();
+  bridge.setContextState(8000, 16000);
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/context`);
+  const body = (await res.json()) as { contextTokens: number; maxContextTokens: number };
+  assert.equal(body.contextTokens, 8000);
+  assert.equal(body.maxContextTokens, 16000);
+});
+
+// ── Agent emits context_status UiUpdate ──
+
+test("agent emits context_status UiUpdate during turn", async () => {
+  const config = createTestAgentConfig("/tmp/test-workspace");
+  const modelClient = new SequenceModelClient([
+    {
+      text: "done",
+      toolCalls: [],
+      stopReason: "end_turn",
+      usage: { inputTokens: 10, outputTokens: 5 },
+    },
+  ]);
+  const toolRegistry = new ToolRegistry([]);
+
+  const events: UiUpdate[] = [];
+  const agent = new CodingAgent({
+    config,
+    modelClient,
+    toolRegistry,
+    onUiUpdate: (event: UiUpdate) => events.push(event),
+  });
+
+  await agent.runTurn("hello");
+
+  const contextEvents = events.filter((e) => e.type === "context_status");
+  assert.ok(contextEvents.length >= 1, "should emit at least one context_status event");
+
+  const ev = contextEvents[0]!;
+  assert.equal(ev.type, "context_status");
+  assert.equal(typeof (ev as { contextTokens: number }).contextTokens, "number");
+  assert.equal((ev as { maxContextTokens: number }).maxContextTokens, config.maxContextTokens);
+});
+
+test("agent context_status tokens increase as messages are added", async () => {
+  const config = createTestAgentConfig("/tmp/test-workspace");
+  const modelClient = new SequenceModelClient([
+    {
+      text: "first",
+      toolCalls: [],
+      stopReason: "end_turn",
+      usage: { inputTokens: 10, outputTokens: 5 },
+    },
+    {
+      text: "second",
+      toolCalls: [],
+      stopReason: "end_turn",
+      usage: { inputTokens: 10, outputTokens: 5 },
+    },
+  ]);
+  const toolRegistry = new ToolRegistry([]);
+
+  const contextTokensPerTurn: number[] = [];
+  const agent = new CodingAgent({
+    config,
+    modelClient,
+    toolRegistry,
+    onUiUpdate: (event: UiUpdate) => {
+      if (event.type === "context_status") {
+        contextTokensPerTurn.push((event as { contextTokens: number }).contextTokens);
+      }
+    },
+  });
+
+  await agent.runTurn("hello");
+  await agent.runTurn("world");
+
+  assert.equal(contextTokensPerTurn.length, 2);
+  assert.ok(
+    contextTokensPerTurn[1]! > contextTokensPerTurn[0]!,
+    `context should grow: ${contextTokensPerTurn[0]} → ${contextTokensPerTurn[1]}`,
+  );
+});
+
+// ── CodingAgent.getContextStatus() ──
+
+test("agent getContextStatus returns current token estimate and max", async () => {
+  const config = createTestAgentConfig("/tmp/test-workspace");
+  const modelClient = new SequenceModelClient([
+    {
+      text: "done",
+      toolCalls: [],
+      stopReason: "end_turn",
+      usage: { inputTokens: 10, outputTokens: 5 },
+    },
+  ]);
+  const toolRegistry = new ToolRegistry([]);
+
+  const agent = new CodingAgent({ config, modelClient, toolRegistry });
+
+  // Before any turn, context should be empty
+  const before = agent.getContextStatus();
+  assert.equal(before.contextTokens, 0);
+  assert.equal(before.maxContextTokens, config.maxContextTokens);
+
+  await agent.runTurn("test message");
+
+  // After a turn, context should have some tokens
+  const after = agent.getContextStatus();
+  assert.ok(after.contextTokens > 0, "context should have tokens after a turn");
+  assert.equal(after.maxContextTokens, config.maxContextTokens);
+});
+
+// ── UiStore context status ──
+
+test("UiStore tracks context status via setContextStatus", () => {
+  const store = new UiStore();
+  assert.equal(store.getState().contextTokens, 0);
+  assert.equal(store.getState().maxContextTokens, 0);
+
+  store.setContextStatus(5000, 40000);
+  assert.equal(store.getState().contextTokens, 5000);
+  assert.equal(store.getState().maxContextTokens, 40000);
+});
+
+test("UiStore context status updates trigger listeners", () => {
+  const store = new UiStore();
+  let notified = false;
+  store.subscribe(() => { notified = true; });
+
+  store.setContextStatus(1000, 16000);
+  assert.ok(notified, "listener should have been called");
+  assert.equal(store.getState().contextTokens, 1000);
+});
+
+test("UiStore reset clears context status", () => {
+  const store = new UiStore();
+  store.setContextStatus(5000, 40000);
+  store.reset();
+  assert.equal(store.getState().contextTokens, 0);
+  assert.equal(store.getState().maxContextTokens, 0);
+});


### PR DESCRIPTION
## Summary
- Adds a color-coded context window usage indicator (green < 60%, yellow 60-80%, red > 80%) to both the web UI header bar and CLI header bar
- Agent emits `context_status` UiUpdate events after each agent step with current token estimate and max
- New `GET /api/context` REST endpoint for on-demand context status queries
- `CodingAgent.getContextStatus()` method exposes context fill programmatically

## Changes
- **Agent SDK** (`packages/agent-sdk/src/agent/agent.ts`): New `UiUpdateContextStatus` type, `getContextStatus()` method, emits `context_status` after trim each step
- **Web UI** (`src/web/index.html`, `style.css`, `app.ts`): Progress bar in header with percentage label, updates via WebSocket `context_status` messages and initial `/api/context` fetch
- **CLI** (`src/ui/components/header-bar.tsx`, `state/ui-store.ts`, `cli-ink.ts`, `app.tsx`): Context percentage and token counts in second header row, color-coded
- **Server** (`src/serve/server.ts`, `types.ts`): `/api/context` endpoint, `ServerContextStatusMessage` type
- **Tests** (`tests/context-indicator.test.ts`): 8 new tests covering agent events, REST endpoint, UiStore state management

## Test plan
- [x] All 254 tests pass (246 existing + 8 new)
- [x] `npm run build` passes
- [x] `npm run lint` passes with zero warnings
- [ ] Manual: run `minicode serve`, verify context bar appears in web UI header and updates during conversation
- [ ] Manual: run `minicode` CLI, verify context percentage appears in header bar

Closes #50

https://claude.ai/code/session_01EkPdXWZRydgvgFnw3wk6ha