### PR TITLE
Add find_path tool for dependency graph path finding

### DIFF
--- a/packages/agent-sdk/src/indexer/types.ts
+++ b/packages/agent-sdk/src/indexer/types.ts
@@ -84,6 +84,12 @@ export interface ProjectIndex {
   getDependencyCone(symbolName: string, depth?: number): IndexedSymbol[];
   getCodeMap(tokenBudget?: number, focusSymbols?: Set<string>): CodeMapResult;
 
+  /** Find the shortest path between two symbols in the dependency graph. Returns the ordered list of symbols along the path, or empty array if no path exists. */
+  findPath(fromSymbol: string, toSymbol: string, maxDepth?: number): IndexedSymbol[];
+
+  /** Trace a symbol back to its entry point(s) — symbols with no inbound edges. Returns paths from the symbol to each reachable entry point. */
+  findPathToEntryPoint(symbolName: string, maxDepth?: number): IndexedSymbol[][];
+
   /** Re-index a file after it has been modified. Updates symbols and dependency edges. */
   reindexFile(filePath: string, content: string): void;
 }

--- a/src/indexer/project-index.ts
+++ b/src/indexer/project-index.ts
@@ -53,6 +53,31 @@ function buildAdjacencyFrom(edges: DependencyEdge[]): Map<string, DependencyEdge
   return map;
 }
 
+function buildAdjacencyTo(edges: DependencyEdge[]): Map<string, DependencyEdge[]> {
+  const map = new Map<string, DependencyEdge[]>();
+  for (const edge of edges) {
+    const list = map.get(edge.to);
+    if (list) {
+      list.push(edge);
+    } else {
+      map.set(edge.to, [edge]);
+    }
+  }
+  return map;
+}
+
+function resolveSymbol(
+  name: string,
+  symbols: Map<string, IndexedSymbol>,
+): IndexedSymbol | undefined {
+  const direct = symbols.get(name);
+  if (direct) return direct;
+  for (const sym of symbols.values()) {
+    if (sym.name === name || sym.qualifiedName === name) return sym;
+  }
+  return undefined;
+}
+
 export function createProjectIndex(
   symbols: Map<string, IndexedSymbol>,
   files: Map<string, IndexedSymbol[]>,
@@ -72,12 +97,7 @@ export function createProjectIndex(
     workspaceRoot,
 
     getSymbol(name: string): IndexedSymbol | undefined {
-      const direct = symbols.get(name);
-      if (direct) return direct;
-      for (const sym of symbols.values()) {
-        if (sym.name === name || sym.qualifiedName === name) return sym;
-      }
-      return undefined;
+      return resolveSymbol(name, symbols);
     },
 
     getSymbolsInFile(filePath: string): IndexedSymbol[] {
@@ -85,9 +105,7 @@ export function createProjectIndex(
     },
 
     getDependencyCone(symbolName: string, depth = 2): IndexedSymbol[] {
-      const target = symbols.get(symbolName) ?? [...symbols.values()].find(
-        (s) => s.name === symbolName || s.qualifiedName === symbolName,
-      );
+      const target = resolveSymbol(symbolName, symbols);
       if (!target) return [];
 
       const result = new Map<string, IndexedSymbol>();
@@ -100,9 +118,7 @@ export function createProjectIndex(
           const outEdges = adjacencyFrom.get(from);
           if (!outEdges) continue;
           for (const edge of outEdges) {
-            const dep = symbols.get(edge.to) ?? [...symbols.values()].find(
-              (s) => s.qualifiedName === edge.to || s.name === edge.to,
-            );
+            const dep = resolveSymbol(edge.to, symbols);
             if (dep && !result.has(dep.qualifiedName)) {
               result.set(dep.qualifiedName, dep);
               next.add(dep.qualifiedName);
@@ -113,6 +129,121 @@ export function createProjectIndex(
       }
 
       return [...result.values()];
+    },
+
+    findPath(fromSymbol: string, toSymbol: string, maxDepth = 10): IndexedSymbol[] {
+      const from = resolveSymbol(fromSymbol, symbols);
+      const to = resolveSymbol(toSymbol, symbols);
+      if (!from || !to) return [];
+
+      // BFS over both outgoing and incoming edges (undirected search)
+      const adjacencyTo = buildAdjacencyTo(dependencyEdges);
+      const visited = new Set<string>();
+      const parent = new Map<string, string>();
+      const queue: { name: string; depth: number }[] = [
+        { name: from.qualifiedName, depth: 0 },
+      ];
+      visited.add(from.qualifiedName);
+
+      while (queue.length > 0) {
+        const current = queue.shift()!;
+        if (current.name === to.qualifiedName) {
+          // Reconstruct path
+          const path: IndexedSymbol[] = [];
+          let node: string | undefined = to.qualifiedName;
+          while (node !== undefined) {
+            const sym = resolveSymbol(node, symbols);
+            if (sym) path.unshift(sym);
+            node = parent.get(node);
+          }
+          return path;
+        }
+
+        if (current.depth >= maxDepth) continue;
+
+        // Follow outgoing edges
+        const outEdges = adjacencyFrom.get(current.name) ?? [];
+        for (const edge of outEdges) {
+          const target = resolveSymbol(edge.to, symbols);
+          if (target && !visited.has(target.qualifiedName)) {
+            visited.add(target.qualifiedName);
+            parent.set(target.qualifiedName, current.name);
+            queue.push({ name: target.qualifiedName, depth: current.depth + 1 });
+          }
+        }
+
+        // Follow incoming edges (reverse direction)
+        const inEdges = adjacencyTo.get(current.name) ?? [];
+        for (const edge of inEdges) {
+          const source = resolveSymbol(edge.from, symbols);
+          if (source && !visited.has(source.qualifiedName)) {
+            visited.add(source.qualifiedName);
+            parent.set(source.qualifiedName, current.name);
+            queue.push({ name: source.qualifiedName, depth: current.depth + 1 });
+          }
+        }
+      }
+
+      return [];
+    },
+
+    findPathToEntryPoint(symbolName: string, maxDepth = 20): IndexedSymbol[][] {
+      const target = resolveSymbol(symbolName, symbols);
+      if (!target) return [];
+
+      // Build reverse adjacency: who calls/references this symbol?
+      const adjacencyTo = buildAdjacencyTo(dependencyEdges);
+
+      // Find entry points: symbols that have no inbound edges
+      const hasInbound = new Set<string>();
+      for (const edge of dependencyEdges) {
+        hasInbound.add(edge.to);
+      }
+
+      // If the target itself is already an entry point (no inbound edges), nothing to trace
+      if (!hasInbound.has(target.qualifiedName)) return [];
+
+      // DFS from target following inbound edges back to entry points
+      const paths: IndexedSymbol[][] = [];
+      const currentPath: IndexedSymbol[] = [target];
+      const visiting = new Set<string>([target.qualifiedName]);
+
+      function dfs(node: string, depth: number): void {
+        if (depth >= maxDepth) return;
+
+        const inEdges = adjacencyTo.get(node) ?? [];
+        const callers = inEdges
+          .map((e) => resolveSymbol(e.from, symbols))
+          .filter((s): s is IndexedSymbol => s != null && !visiting.has(s.qualifiedName));
+
+        if (callers.length === 0) {
+          // Dead end going backwards — this is as far as we can trace
+          if (currentPath.length > 1) {
+            paths.push([...currentPath].reverse());
+          }
+          return;
+        }
+
+        for (const caller of callers) {
+          // If this caller is an entry point (no inbound edges), record the path
+          if (!hasInbound.has(caller.qualifiedName)) {
+            currentPath.push(caller);
+            paths.push([...currentPath].reverse());
+            currentPath.pop();
+            continue;
+          }
+
+          visiting.add(caller.qualifiedName);
+          currentPath.push(caller);
+          dfs(caller.qualifiedName, depth + 1);
+          currentPath.pop();
+          visiting.delete(caller.qualifiedName);
+        }
+      }
+
+      dfs(target.qualifiedName, 0);
+
+      return paths.slice(0, 10);
     },
 
     getCodeMap(tokenBudget?: number, focusSymbols?: Set<string>): CodeMapResult {

--- a/src/tools/find-path.ts
+++ b/src/tools/find-path.ts
@@ -1,0 +1,90 @@
+import type { ToolDefinition } from "@minicode/agent-sdk";
+import { expectNonEmptyString, expectOptionalNumber } from "@minicode/agent-sdk";
+import type { ProjectIndex } from "../indexer/types.js";
+
+export function createFindPathTool(
+  projectIndex: ProjectIndex,
+): ToolDefinition {
+  return {
+    name: "find_path",
+    description:
+      "Find the path between two symbols in the dependency graph, or trace a symbol back to its entry point. Use to understand execution flow and how a function gets called.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        from: {
+          type: "string",
+          description:
+            "Symbol name or qualified name to start from.",
+        },
+        to: {
+          type: "string",
+          description:
+            "Symbol name or qualified name to reach. If omitted, traces back to entry point(s).",
+        },
+        max_depth: {
+          type: "number",
+          description:
+            "Maximum search depth. Default 10 for path finding, 20 for entry point tracing.",
+        },
+      },
+      required: ["from"],
+      additionalProperties: false,
+    },
+    execute: async (input: Record<string, unknown>): Promise<string> => {
+      const from = expectNonEmptyString(input, "from");
+      const to = typeof input.to === "string" && input.to.length > 0 ? input.to : undefined;
+      const maxDepth = expectOptionalNumber(input, "max_depth");
+
+      const fromSymbol = projectIndex.getSymbol(from);
+      if (!fromSymbol) {
+        return `Symbol "${from}" not found in the project index.`;
+      }
+
+      if (to) {
+        // Path between two symbols
+        const toSymbol = projectIndex.getSymbol(to);
+        if (!toSymbol) {
+          return `Symbol "${to}" not found in the project index.`;
+        }
+
+        const path = projectIndex.findPath(from, to, maxDepth ?? 10);
+        if (path.length === 0) {
+          return `No path found between "${from}" and "${to}".`;
+        }
+
+        const lines = path.map((s, i) => {
+          const arrow = i < path.length - 1 ? " ->" : "";
+          return `${i + 1}. [${s.kind}] ${s.qualifiedName} (${s.filePath}:${s.startLine})${arrow}`;
+        });
+
+        return [
+          `# Path from ${fromSymbol.qualifiedName} to ${toSymbol.qualifiedName} (${path.length} symbols)`,
+          "",
+          ...lines,
+        ].join("\n");
+      } else {
+        // Trace to entry point(s)
+        const paths = projectIndex.findPathToEntryPoint(from, maxDepth ?? 20);
+
+        if (paths.length === 0) {
+          return `No entry point paths found for "${from}". It may itself be an entry point.`;
+        }
+
+        const sections = paths.map((p, pi) => {
+          const lines = p.map((s, i) => {
+            const arrow = i < p.length - 1 ? " ->" : "";
+            return `  ${i + 1}. [${s.kind}] ${s.qualifiedName} (${s.filePath}:${s.startLine})${arrow}`;
+          });
+          return [`## Path ${pi + 1}`, ...lines].join("\n");
+        });
+
+        return [
+          `# Entry point paths for ${fromSymbol.qualifiedName} (${paths.length} path${paths.length === 1 ? "" : "s"})`,
+          "",
+          ...sections,
+        ].join("\n\n");
+      }
+    },
+  };
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -12,6 +12,7 @@ import type { ProjectIndex } from "../indexer/types.js";
 import { createFindReferencesTool } from "./find-references.js";
 import { createGetDependenciesTool } from "./get-dependencies.js";
 import { createReadSymbolTool } from "./read-symbol.js";
+import { createFindPathTool } from "./find-path.js";
 import { createSearchCodeMapTool } from "./search-code-map.js";
 
 export { ToolRegistry };
@@ -46,7 +47,8 @@ export function createToolRegistry(
     tools.splice(1, 0, createReadSymbolTool(config, projectIndex));
     tools.splice(2, 0, createFindReferencesTool(projectIndex));
     tools.splice(3, 0, createGetDependenciesTool(projectIndex));
-    tools.splice(4, 0, createSearchCodeMapTool(projectIndex));
+    tools.splice(4, 0, createFindPathTool(projectIndex));
+    tools.splice(5, 0, createSearchCodeMapTool(projectIndex));
   }
 
   return new ToolRegistry(tools);

--- a/tests/find-path.test.ts
+++ b/tests/find-path.test.ts
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "node:test";
+
+import { createProjectIndex } from "../src/indexer/project-index.js";
+import { createFindPathTool } from "../src/tools/find-path.js";
+import type { DependencyEdge, IndexedSymbol } from "../src/indexer/types.js";
+
+function makeSymbol(name: string, kind: "function" | "class" | "method" = "function"): IndexedSymbol {
+  return {
+    name,
+    qualifiedName: name,
+    kind,
+    filePath: "test.ts",
+    startLine: 1,
+    endLine: 5,
+    signature: `function ${name}()`,
+    exported: true,
+    dependencies: [],
+  };
+}
+
+function buildTestIndex(symbols: IndexedSymbol[], edges: DependencyEdge[]) {
+  const symMap = new Map<string, IndexedSymbol>();
+  const fileMap = new Map<string, IndexedSymbol[]>();
+  for (const sym of symbols) {
+    symMap.set(sym.qualifiedName, sym);
+    const existing = fileMap.get(sym.filePath) ?? [];
+    existing.push(sym);
+    fileMap.set(sym.filePath, existing);
+  }
+  return createProjectIndex(symMap, fileMap, edges, [], new Map(), "/tmp/test");
+}
+
+test("findPath returns path between two connected symbols", () => {
+  const symbols = [makeSymbol("a"), makeSymbol("b"), makeSymbol("c")];
+  const edges: DependencyEdge[] = [
+    { from: "a", to: "b", kind: "calls" },
+    { from: "b", to: "c", kind: "calls" },
+  ];
+  const index = buildTestIndex(symbols, edges);
+
+  const result = index.findPath("a", "c");
+  assert.equal(result.length, 3);
+  assert.equal(result[0]!.qualifiedName, "a");
+  assert.equal(result[1]!.qualifiedName, "b");
+  assert.equal(result[2]!.qualifiedName, "c");
+});
+
+test("findPath returns empty array when no path exists", () => {
+  const symbols = [makeSymbol("a"), makeSymbol("b")];
+  const edges: DependencyEdge[] = [];
+  const index = buildTestIndex(symbols, edges);
+
+  const result = index.findPath("a", "b");
+  assert.equal(result.length, 0);
+});
+
+test("findPath returns direct path for adjacent symbols", () => {
+  const symbols = [makeSymbol("a"), makeSymbol("b")];
+  const edges: DependencyEdge[] = [{ from: "a", to: "b", kind: "calls" }];
+  const index = buildTestIndex(symbols, edges);
+
+  const result = index.findPath("a", "b");
+  assert.equal(result.length, 2);
+  assert.equal(result[0]!.qualifiedName, "a");
+  assert.equal(result[1]!.qualifiedName, "b");
+});
+
+test("findPath finds path via reverse edges", () => {
+  const symbols = [makeSymbol("a"), makeSymbol("b"), makeSymbol("c")];
+  // Only edge is b->a and b->c, so path from a to c goes a<-b->c
+  const edges: DependencyEdge[] = [
+    { from: "b", to: "a", kind: "calls" },
+    { from: "b", to: "c", kind: "calls" },
+  ];
+  const index = buildTestIndex(symbols, edges);
+
+  const result = index.findPath("a", "c");
+  assert.equal(result.length, 3);
+  assert.equal(result[0]!.qualifiedName, "a");
+  assert.equal(result[1]!.qualifiedName, "b");
+  assert.equal(result[2]!.qualifiedName, "c");
+});
+
+test("findPath respects maxDepth", () => {
+  const symbols = [makeSymbol("a"), makeSymbol("b"), makeSymbol("c"), makeSymbol("d")];
+  const edges: DependencyEdge[] = [
+    { from: "a", to: "b", kind: "calls" },
+    { from: "b", to: "c", kind: "calls" },
+    { from: "c", to: "d", kind: "calls" },
+  ];
+  const index = buildTestIndex(symbols, edges);
+
+  // maxDepth 1 should not find a path from a to d (3 hops away)
+  const result = index.findPath("a", "d", 1);
+  assert.equal(result.length, 0);
+
+  // maxDepth 3 should find it
+  const result2 = index.findPath("a", "d", 3);
+  assert.equal(result2.length, 4);
+});
+
+test("findPath returns empty for unknown symbols", () => {
+  const symbols = [makeSymbol("a")];
+  const index = buildTestIndex(symbols, []);
+
+  assert.equal(index.findPath("a", "nonexistent").length, 0);
+  assert.equal(index.findPath("nonexistent", "a").length, 0);
+});
+
+test("findPathToEntryPoint traces back to entry points", () => {
+  const symbols = [makeSymbol("entry"), makeSymbol("middle"), makeSymbol("leaf")];
+  const edges: DependencyEdge[] = [
+    { from: "entry", to: "middle", kind: "calls" },
+    { from: "middle", to: "leaf", kind: "calls" },
+  ];
+  const index = buildTestIndex(symbols, edges);
+
+  const paths = index.findPathToEntryPoint("leaf");
+  assert.ok(paths.length > 0);
+  // The path should go from entry -> middle -> leaf
+  const firstPath = paths[0]!;
+  assert.equal(firstPath[0]!.qualifiedName, "entry");
+  assert.equal(firstPath[firstPath.length - 1]!.qualifiedName, "leaf");
+});
+
+test("findPathToEntryPoint returns empty for entry point symbols", () => {
+  const symbols = [makeSymbol("entry"), makeSymbol("other")];
+  const edges: DependencyEdge[] = [
+    { from: "entry", to: "other", kind: "calls" },
+  ];
+  const index = buildTestIndex(symbols, edges);
+
+  // "entry" has no inbound edges, so it IS an entry point
+  const paths = index.findPathToEntryPoint("entry");
+  // Should return empty or self-referential since it's already an entry point
+  assert.equal(paths.length, 0);
+});
+
+test("findPathToEntryPoint returns empty for unknown symbols", () => {
+  const index = buildTestIndex([], []);
+  const paths = index.findPathToEntryPoint("nonexistent");
+  assert.equal(paths.length, 0);
+});
+
+test("find_path tool returns path between two symbols", async () => {
+  const symbols = [makeSymbol("a"), makeSymbol("b"), makeSymbol("c")];
+  const edges: DependencyEdge[] = [
+    { from: "a", to: "b", kind: "calls" },
+    { from: "b", to: "c", kind: "calls" },
+  ];
+  const index = buildTestIndex(symbols, edges);
+  const tool = createFindPathTool(index);
+
+  const result = await tool.execute({ from: "a", to: "c" });
+  assert.ok(result.includes("# Path from a to c"));
+  assert.ok(result.includes("3 symbols"));
+  assert.ok(result.includes("[function] a"));
+  assert.ok(result.includes("[function] b"));
+  assert.ok(result.includes("[function] c"));
+});
+
+test("find_path tool traces to entry points when 'to' is omitted", async () => {
+  const symbols = [makeSymbol("entry"), makeSymbol("middle"), makeSymbol("leaf")];
+  const edges: DependencyEdge[] = [
+    { from: "entry", to: "middle", kind: "calls" },
+    { from: "middle", to: "leaf", kind: "calls" },
+  ];
+  const index = buildTestIndex(symbols, edges);
+  const tool = createFindPathTool(index);
+
+  const result = await tool.execute({ from: "leaf" });
+  assert.ok(result.includes("Entry point paths for leaf"));
+  assert.ok(result.includes("[function] entry"));
+});
+
+test("find_path tool returns error for unknown symbol", async () => {
+  const index = buildTestIndex([], []);
+  const tool = createFindPathTool(index);
+
+  const result = await tool.execute({ from: "nonexistent" });
+  assert.ok(result.includes("not found"));
+});
+
+test("find_path tool returns error when target symbol not found", async () => {
+  const symbols = [makeSymbol("a")];
+  const index = buildTestIndex(symbols, []);
+  const tool = createFindPathTool(index);
+
+  const result = await tool.execute({ from: "a", to: "nonexistent" });
+  assert.ok(result.includes("not found"));
+});
+
+test("find_path tool reports no path when symbols are disconnected", async () => {
+  const symbols = [makeSymbol("a"), makeSymbol("b")];
+  const index = buildTestIndex(symbols, []);
+  const tool = createFindPathTool(index);
+
+  const result = await tool.execute({ from: "a", to: "b" });
+  assert.ok(result.includes("No path found"));
+});
+
+test("find_path tool works with real project index", async () => {
+  const { buildProjectIndex } = await import("../src/indexer/project-index.js");
+  const root = path.resolve(import.meta.dirname, "..");
+  const projectIndex = await buildProjectIndex(root);
+  const tool = createFindPathTool(projectIndex);
+
+  // Find path between two known symbols
+  const result = await tool.execute({
+    from: "createModelClient",
+    to: "AgentConfig",
+  });
+  assert.ok(result.includes("# Path from createModelClient to AgentConfig"));
+  assert.ok(result.includes("symbols"));
+});


### PR DESCRIPTION
## Summary

- Adds a `find_path` tool that finds the shortest path between any two symbols in the dependency graph using bidirectional BFS (follows both outgoing and incoming edges)
- Supports entry point tracing mode: when `to` is omitted, traces a symbol back through its callers to find how it gets invoked from top-level entry points
- Adds `findPath` and `findPathToEntryPoint` methods to the `ProjectIndex` interface and implementation
- Registers the new tool in the tool registry alongside existing graph tools
- Includes 14 new tests covering both modes, edge cases, maxDepth limits, and real project index integration

## Test plan

- [x] All 269 tests pass (`npm test`)
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Path finding between connected symbols returns correct ordered path
- [x] Disconnected symbols return empty result
- [x] Reverse edge traversal works (finds paths via incoming edges)
- [x] `maxDepth` limit is respected
- [x] Entry point tracing finds paths from leaf symbols back to entry points
- [x] Entry point symbols correctly return empty (already at entry)
- [x] Unknown symbols return appropriate error messages
- [x] Integration test with real project index passes

Fixes #49

https://claude.ai/code/session_01YAXRVR5JBJsT1Bbk4dKGGg