### PR TITLE
Sort models alphabetically across selectors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
   saveIndex,
 } from "./indexer/cache.js";
 import { buildProjectIndex } from "./indexer/project-index.js";
+import { sortModelsAlphabetically } from "./model-utils.js";
 import { createToolRegistry } from "./tools/registry.js";
 import {
   CliUsageError,
@@ -194,7 +195,7 @@ async function runInteractive(
     if (trimmed === "/models") {
       if (modelClient.listModels) {
         console.log("Fetching models...");
-        const models = await modelClient.listModels();
+        const models = sortModelsAlphabetically(await modelClient.listModels());
         if (models.length === 0) {
           console.log("No models found (provider may not support listing).");
         } else {

--- a/src/model-utils.ts
+++ b/src/model-utils.ts
@@ -1,0 +1,23 @@
+import type { ModelInfo } from "@minicode/agent-sdk";
+
+function getModelDisplayName(model: ModelInfo): string {
+  return (model.name ?? model.id).trim();
+}
+
+export function sortModelsAlphabetically(models: ModelInfo[]): ModelInfo[] {
+  return [...models].sort((left, right) => {
+    const byDisplayName = getModelDisplayName(left).localeCompare(getModelDisplayName(right), undefined, {
+      sensitivity: "base",
+      numeric: true,
+    });
+
+    if (byDisplayName !== 0) {
+      return byDisplayName;
+    }
+
+    return left.id.localeCompare(right.id, undefined, {
+      sensitivity: "base",
+      numeric: true,
+    });
+  });
+}

--- a/src/serve/agent-bridge.ts
+++ b/src/serve/agent-bridge.ts
@@ -9,6 +9,7 @@ import {
 } from "../indexer/cache.js";
 import { buildProjectIndex } from "../indexer/project-index.js";
 import type { ProjectIndex } from "../indexer/types.js";
+import { sortModelsAlphabetically } from "../model-utils.js";
 import { createToolRegistry } from "../tools/registry.js";
 import {
   listSessions,
@@ -393,7 +394,7 @@ export class AgentBridge {
 
   async listModels(): Promise<ModelInfo[]> {
     if (this.modelClient.listModels) {
-      return this.modelClient.listModels();
+      return sortModelsAlphabetically(await this.modelClient.listModels());
     }
     return [];
   }

--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -8,6 +8,7 @@ import { AgentBridge } from "./agent-bridge.js";
 import { createWebSocketServer } from "./websocket.js";
 import { handleChatCompletions, handleModels } from "./openai-compat.js";
 import { formatConfigForDisplay } from "../agent/config.js";
+import { sortModelsAlphabetically } from "../model-utils.js";
 import type { ServerMessage } from "./types.js";
 import type { WebSocketServer } from "ws";
 
@@ -96,7 +97,7 @@ export function createRequestHandler(bridge: AgentBridge): (req: IncomingMessage
       }
 
       if (pathname === "/api/models" && method === "GET") {
-        const models = await bridge.listModels();
+        const models = sortModelsAlphabetically(await bridge.listModels());
         sendJson(res, 200, { models, activeModel: config.model });
         return;
       }

--- a/src/ui/cli-ink.ts
+++ b/src/ui/cli-ink.ts
@@ -10,6 +10,7 @@ import {
   saveIndex,
 } from "../indexer/cache.js";
 import { buildProjectIndex } from "../indexer/project-index.js";
+import { sortModelsAlphabetically } from "../model-utils.js";
 import {
   listSessions,
   loadSession,
@@ -219,7 +220,7 @@ export async function runInkCli(
     if (trimmed === "/models") {
       if (modelClient.listModels) {
         store.addItem({ type: "system", content: "Fetching models..." });
-        const models = await modelClient.listModels();
+        const models = sortModelsAlphabetically(await modelClient.listModels());
         if (models.length === 0) {
           store.addItem({ type: "system", content: "No models found (provider may not support listing)." });
         } else {

--- a/tests/model-selection.test.ts
+++ b/tests/model-selection.test.ts
@@ -83,8 +83,9 @@ class MockBridgeForModels extends AgentBridge {
 
   override async listModels(): Promise<ModelInfo[]> {
     return [
-      { id: "model-x", name: "Model X" },
-      { id: "model-y", name: "Model Y" },
+      { id: "model-z", name: "Zulu" },
+      { id: "model-a", name: "Alpha" },
+      { id: "model-m" },
     ];
   }
 
@@ -120,8 +121,11 @@ test("GET /api/models returns model list and active model", async () => {
     const res = await fetch(`http://127.0.0.1:${port}/api/models`);
     assert.equal(res.status, 200);
     const data = (await res.json()) as { models: ModelInfo[]; activeModel: string };
-    assert.equal(data.models.length, 2);
-    assert.equal(data.models[0]!.id, "model-x");
+    assert.equal(data.models.length, 3);
+    assert.deepEqual(
+      data.models.map((model) => model.id),
+      ["model-a", "model-m", "model-z"],
+    );
     assert.equal(data.activeModel, "test-model");
   } finally {
     server.close();

--- a/tests/model-utils.test.ts
+++ b/tests/model-utils.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { ModelInfo } from "@minicode/agent-sdk";
+import { sortModelsAlphabetically } from "../src/model-utils.js";
+
+test("sortModelsAlphabetically sorts by display name without mutating input", () => {
+  const models: ModelInfo[] = [
+    { id: "zeta-2", name: "Zeta 2" },
+    { id: "alpha-10", name: "alpha 10" },
+    { id: "alpha-2", name: "Alpha 2" },
+    { id: "beta-id" },
+  ];
+
+  const sorted = sortModelsAlphabetically(models);
+
+  assert.deepEqual(
+    sorted.map((model) => model.id),
+    ["alpha-2", "alpha-10", "beta-id", "zeta-2"],
+  );
+  assert.deepEqual(
+    models.map((model) => model.id),
+    ["zeta-2", "alpha-10", "alpha-2", "beta-id"],
+  );
+});
+
+test("sortModelsAlphabetically uses id as a stable tiebreaker", () => {
+  const models: ModelInfo[] = [
+    { id: "gpt-4.1-b", name: "GPT-4.1" },
+    { id: "gpt-4.1-a", name: "GPT-4.1" },
+  ];
+
+  const sorted = sortModelsAlphabetically(models);
+
+  assert.deepEqual(
+    sorted.map((model) => model.id),
+    ["gpt-4.1-a", "gpt-4.1-b"],
+  );
+});


### PR DESCRIPTION
## Summary
- add a shared model-sorting helper based on display name with a stable id tiebreaker
- apply the ordering to the serve API and both CLI model-list commands
- add targeted tests for the helper and `/api/models` ordering

## Verification
- `PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm test`
- `PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm run build`

Fixes #71