### PR TITLE
Add persistent config slash commands

### DIFF
--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -75,7 +75,7 @@ function parseReasoningEffort(value: string | undefined): ReasoningEffort | unde
   return VALID_REASONING_EFFORTS.has(normalized) ? normalized : undefined;
 }
 
-interface AgentConfigFile {
+export interface AgentConfigFile {
   modelProvider?: string;
   model?: string;
   maxSteps?: number;
@@ -125,7 +125,7 @@ function parseBoolean(value: string | undefined, fallback: boolean): boolean {
   return fallback;
 }
 
-async function loadConfigFile(configPath: string): Promise<AgentConfigFile> {
+export async function loadConfigFile(configPath: string): Promise<AgentConfigFile> {
   try {
     await access(configPath);
   } catch {

--- a/src/agent/editable-config.ts
+++ b/src/agent/editable-config.ts
@@ -1,0 +1,341 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { AgentConfig, ReasoningEffort } from "@minicode/agent-sdk";
+
+import { loadConfigFile, MINICODE_HOME, type AgentConfigFile } from "./config.js";
+
+export type EditableConfigScope = "workspace" | "global";
+type EditableConfigValue = string | number | boolean;
+type EditableConfigType = "string" | "number" | "boolean" | "enum";
+
+export interface EditableConfigDefinition {
+  key: keyof Pick<
+    AgentConfig,
+    | "modelProvider"
+    | "model"
+    | "maxSteps"
+    | "maxTokens"
+    | "maxContextTokens"
+    | "commandTimeoutMs"
+    | "maxFileSizeBytes"
+    | "confirmDestructive"
+    | "keepRecentMessages"
+    | "loopDetectionWindow"
+    | "maxToolOutputChars"
+    | "openAiBaseUrl"
+    | "enableFileReadDedup"
+    | "enableAdaptiveKeepRecent"
+    | "enableToolOutputTruncation"
+    | "compactionThreshold"
+    | "compactionModel"
+    | "reasoningEffort"
+    | "enableDynamicPrompt"
+  >;
+  fileKey: keyof AgentConfigFile;
+  envVar: string;
+  type: EditableConfigType;
+  description: string;
+  values?: readonly string[];
+}
+
+const REASONING_VALUES = [
+  "xhigh",
+  "high",
+  "medium",
+  "low",
+  "minimal",
+  "none",
+] as const satisfies readonly ReasoningEffort[];
+
+export const EDITABLE_CONFIG_DEFINITIONS: readonly EditableConfigDefinition[] = [
+  {
+    key: "modelProvider",
+    fileKey: "modelProvider",
+    envVar: "MODEL_PROVIDER",
+    type: "enum",
+    values: ["anthropic", "openai-compatible"],
+    description: "Provider backend used to create the model client",
+  },
+  {
+    key: "model",
+    fileKey: "model",
+    envVar: "MODEL",
+    type: "string",
+    description: "Default model id for new sessions",
+  },
+  {
+    key: "maxSteps",
+    fileKey: "maxSteps",
+    envVar: "MAX_STEPS",
+    type: "number",
+    description: "Maximum agent loop steps per turn",
+  },
+  {
+    key: "maxTokens",
+    fileKey: "maxTokens",
+    envVar: "MAX_TOKENS",
+    type: "number",
+    description: "Maximum completion tokens per model response",
+  },
+  {
+    key: "maxContextTokens",
+    fileKey: "maxContextTokens",
+    envVar: "MAX_CONTEXT_TOKENS",
+    type: "number",
+    description: "Estimated prompt-context budget before compaction",
+  },
+  {
+    key: "commandTimeoutMs",
+    fileKey: "commandTimeout",
+    envVar: "COMMAND_TIMEOUT_MS",
+    type: "number",
+    description: "Shell command timeout in milliseconds",
+  },
+  {
+    key: "maxFileSizeBytes",
+    fileKey: "maxFileSizeBytes",
+    envVar: "MAX_FILE_SIZE_BYTES",
+    type: "number",
+    description: "Maximum file size allowed for read/edit tools",
+  },
+  {
+    key: "confirmDestructive",
+    fileKey: "confirmDestructive",
+    envVar: "CONFIRM_DESTRUCTIVE",
+    type: "boolean",
+    description: "Whether destructive commands require confirmation",
+  },
+  {
+    key: "keepRecentMessages",
+    fileKey: "keepRecentMessages",
+    envVar: "KEEP_RECENT_MESSAGES",
+    type: "number",
+    description: "Recent messages preserved when trimming session history",
+  },
+  {
+    key: "loopDetectionWindow",
+    fileKey: "loopDetectionWindow",
+    envVar: "LOOP_DETECTION_WINDOW",
+    type: "number",
+    description: "Window size for repeated-tool-call loop detection",
+  },
+  {
+    key: "maxToolOutputChars",
+    fileKey: "maxToolOutputChars",
+    envVar: "MAX_TOOL_OUTPUT_CHARS",
+    type: "number",
+    description: "Maximum tool output retained before truncation",
+  },
+  {
+    key: "openAiBaseUrl",
+    fileKey: "openAiBaseUrl",
+    envVar: "OPENAI_BASE_URL",
+    type: "string",
+    description: "Base URL for OpenAI-compatible providers",
+  },
+  {
+    key: "enableFileReadDedup",
+    fileKey: "enableFileReadDedup",
+    envVar: "ENABLE_FILE_READ_DEDUP",
+    type: "boolean",
+    description: "Deduplicate repeated file reads in prompt context",
+  },
+  {
+    key: "enableAdaptiveKeepRecent",
+    fileKey: "enableAdaptiveKeepRecent",
+    envVar: "ENABLE_ADAPTIVE_KEEP_RECENT",
+    type: "boolean",
+    description: "Adjust recent-message retention based on context pressure",
+  },
+  {
+    key: "enableToolOutputTruncation",
+    fileKey: "enableToolOutputTruncation",
+    envVar: "ENABLE_TOOL_OUTPUT_TRUNCATION",
+    type: "boolean",
+    description: "Truncate oversized tool output before storing it in session history",
+  },
+  {
+    key: "compactionThreshold",
+    fileKey: "compactionThreshold",
+    envVar: "COMPACTION_THRESHOLD",
+    type: "number",
+    description: "Compaction threshold ratio used before a turn starts",
+  },
+  {
+    key: "compactionModel",
+    fileKey: "compactionModel",
+    envVar: "COMPACTION_MODEL",
+    type: "string",
+    description: "Optional model id used for LLM-based compaction",
+  },
+  {
+    key: "reasoningEffort",
+    fileKey: "reasoningEffort",
+    envVar: "REASONING_EFFORT",
+    type: "enum",
+    values: REASONING_VALUES,
+    description: "Reasoning effort sent to supported model providers",
+  },
+  {
+    key: "enableDynamicPrompt",
+    fileKey: "enableDynamicPrompt",
+    envVar: "ENABLE_DYNAMIC_PROMPT",
+    type: "boolean",
+    description: "Toggle project-aware dynamic prompt generation",
+  },
+] as const;
+
+const definitionByKey = new Map(
+  EDITABLE_CONFIG_DEFINITIONS.map((definition) => [definition.key, definition]),
+);
+
+export type EditableConfigKey = (typeof EDITABLE_CONFIG_DEFINITIONS)[number]["key"];
+
+function parseBoolean(value: string): boolean | undefined {
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(normalized)) {
+    return false;
+  }
+  return undefined;
+}
+
+function parseEditableValue(
+  definition: EditableConfigDefinition,
+  rawValue: string,
+): EditableConfigValue {
+  if (definition.type === "number") {
+    const value = Number(rawValue);
+    if (!Number.isFinite(value)) {
+      throw new Error(`Expected a number for "${definition.key}".`);
+    }
+    return value;
+  }
+
+  if (definition.type === "boolean") {
+    const value = parseBoolean(rawValue);
+    if (value === undefined) {
+      throw new Error(`Expected a boolean for "${definition.key}" (true/false, yes/no, on/off).`);
+    }
+    return value;
+  }
+
+  if (definition.type === "enum") {
+    const normalized = rawValue.trim().toLowerCase();
+    const match = definition.values?.find((value) => value.toLowerCase() === normalized);
+    if (!match) {
+      throw new Error(`Expected one of: ${definition.values?.join(", ")}`);
+    }
+    return match;
+  }
+
+  const trimmed = rawValue.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`Expected a non-empty value for "${definition.key}".`);
+  }
+  return trimmed;
+}
+
+function isEmptyConfigFile(config: AgentConfigFile): boolean {
+  return Object.keys(config).length === 0;
+}
+
+export function listEditableConfigDefinitions(): readonly EditableConfigDefinition[] {
+  return EDITABLE_CONFIG_DEFINITIONS;
+}
+
+export function isEditableConfigKey(value: string): value is EditableConfigKey {
+  return definitionByKey.has(value as EditableConfigKey);
+}
+
+export function getEditableConfigDefinition(key: EditableConfigKey): EditableConfigDefinition {
+  const definition = definitionByKey.get(key);
+  if (!definition) {
+    throw new Error(`Unknown editable config key "${key}".`);
+  }
+  return definition;
+}
+
+export function getEffectiveEditableConfigValue(
+  config: AgentConfig,
+  key: EditableConfigKey,
+): string {
+  return formatPersistedConfigValue(config[key]) as string;
+}
+
+export function formatPersistedConfigValue(value: unknown): string {
+  if (value === undefined) return "(unset)";
+  if (typeof value === "string") return value;
+  return String(value);
+}
+
+export function getConfigPathForScope(
+  cwd: string,
+  scope: EditableConfigScope,
+  minicodeHome = MINICODE_HOME,
+): string {
+  return scope === "global"
+    ? path.join(minicodeHome, "agent.config.json")
+    : path.resolve(cwd, "agent.config.json");
+}
+
+export async function loadPersistedConfigLayers(
+  cwd: string,
+  minicodeHome = MINICODE_HOME,
+): Promise<{ global: AgentConfigFile; workspace: AgentConfigFile }> {
+  const globalPath = getConfigPathForScope(cwd, "global", minicodeHome);
+  const workspacePath = getConfigPathForScope(cwd, "workspace", minicodeHome);
+  return {
+    global: await loadConfigFile(globalPath),
+    workspace: await loadConfigFile(workspacePath),
+  };
+}
+
+export async function setPersistedConfigValue(options: {
+  cwd: string;
+  key: EditableConfigKey;
+  rawValue: string;
+  scope?: EditableConfigScope;
+  minicodeHome?: string;
+}): Promise<{ path: string; storedValue: EditableConfigValue }> {
+  const scope = options.scope ?? "workspace";
+  const minicodeHome = options.minicodeHome ?? MINICODE_HOME;
+  const definition = getEditableConfigDefinition(options.key);
+  const configPath = getConfigPathForScope(options.cwd, scope, minicodeHome);
+  const nextFile = await loadConfigFile(configPath);
+  const storedValue = parseEditableValue(definition, options.rawValue);
+
+  nextFile[definition.fileKey] = storedValue as never;
+
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(configPath, JSON.stringify(nextFile, null, 2) + "\n", "utf8");
+
+  return { path: configPath, storedValue };
+}
+
+export async function unsetPersistedConfigValue(options: {
+  cwd: string;
+  key: EditableConfigKey;
+  scope?: EditableConfigScope;
+  minicodeHome?: string;
+}): Promise<{ path: string }> {
+  const scope = options.scope ?? "workspace";
+  const minicodeHome = options.minicodeHome ?? MINICODE_HOME;
+  const definition = getEditableConfigDefinition(options.key);
+  const configPath = getConfigPathForScope(options.cwd, scope, minicodeHome);
+  const nextFile = await loadConfigFile(configPath);
+
+  delete nextFile[definition.fileKey];
+
+  if (isEmptyConfigFile(nextFile)) {
+    await rm(configPath, { force: true });
+  } else {
+    await mkdir(path.dirname(configPath), { recursive: true });
+    await writeFile(configPath, JSON.stringify(nextFile, null, 2) + "\n", "utf8");
+  }
+
+  return { path: configPath };
+}

--- a/src/cli/config-slash-command.ts
+++ b/src/cli/config-slash-command.ts
@@ -1,0 +1,212 @@
+import process from "node:process";
+
+import type { AgentConfig } from "@minicode/agent-sdk";
+
+import { formatConfigForDisplay, MINICODE_HOME } from "../agent/config.js";
+import {
+  formatPersistedConfigValue,
+  getEditableConfigDefinition,
+  getEffectiveEditableConfigValue,
+  isEditableConfigKey,
+  listEditableConfigDefinitions,
+  loadPersistedConfigLayers,
+  setPersistedConfigValue,
+  unsetPersistedConfigValue,
+  type EditableConfigScope,
+} from "../agent/editable-config.js";
+
+export interface ConfigSlashCommandContext {
+  config: AgentConfig;
+  cwd?: string;
+  minicodeHome?: string;
+}
+
+export interface ConfigSlashCommandResult {
+  handled: boolean;
+  message?: string;
+}
+
+function parseScope(tokens: string[]): { scope: EditableConfigScope; args: string[] } {
+  const args = tokens.filter((token) => token !== "--global");
+  return {
+    scope: tokens.includes("--global") ? "global" : "workspace",
+    args,
+  };
+}
+
+function renderUsage(): string {
+  return [
+    'Usage:',
+    '  /config',
+    '  /config keys',
+    '  /config get <key>',
+    '  /config set <key> <value> [--global]',
+    '  /config unset <key> [--global]',
+  ].join("\n");
+}
+
+function renderEditableKeys(): string {
+  const lines = [
+    "Editable config keys (persisted in agent.config.json; environment variables still take precedence):",
+  ];
+
+  for (const definition of listEditableConfigDefinitions()) {
+    const valueHint = definition.type === "enum"
+      ? `<${definition.values?.join("|")}>`
+      : `<${definition.type}>`;
+    lines.push(
+      `  ${definition.key} ${valueHint} — ${definition.description} (env: ${definition.envVar})`,
+    );
+  }
+
+  lines.push("");
+  lines.push('Use "/config set <key> <value>" for workspace config or add "--global" for ~/.minicode/agent.config.json.');
+  lines.push("Secrets like API keys stay env-only for now.");
+  return lines.join("\n");
+}
+
+async function renderConfigValue(
+  key: string,
+  context: ConfigSlashCommandContext,
+): Promise<string> {
+  if (!isEditableConfigKey(key)) {
+    return `Unknown editable config key "${key}".\n\n${renderEditableKeys()}`;
+  }
+
+  const cwd = context.cwd ?? process.cwd();
+  const minicodeHome = context.minicodeHome ?? MINICODE_HOME;
+  const definition = getEditableConfigDefinition(key);
+  const layers = await loadPersistedConfigLayers(cwd, minicodeHome);
+  const envValue = process.env[definition.envVar];
+
+  return [
+    `${definition.key}`,
+    `  effective: ${getEffectiveEditableConfigValue(context.config, key)}`,
+    `  workspace file: ${formatPersistedConfigValue(layers.workspace[definition.fileKey])}`,
+    `  global file: ${formatPersistedConfigValue(layers.global[definition.fileKey])}`,
+    `  env override (${definition.envVar}): ${formatPersistedConfigValue(envValue)}`,
+  ].join("\n");
+}
+
+async function persistConfigValue(
+  key: string,
+  rawValue: string,
+  context: ConfigSlashCommandContext,
+  scope: EditableConfigScope,
+): Promise<string> {
+  if (!isEditableConfigKey(key)) {
+    return `Unknown editable config key "${key}".\n\n${renderEditableKeys()}`;
+  }
+
+  const cwd = context.cwd ?? process.cwd();
+  const minicodeHome = context.minicodeHome ?? MINICODE_HOME;
+  const definition = getEditableConfigDefinition(key);
+
+  try {
+    const result = await setPersistedConfigValue({
+      cwd,
+      key,
+      rawValue,
+      scope,
+      minicodeHome,
+    });
+    const lines = [
+      `Saved ${scope} config: ${key} = ${formatPersistedConfigValue(result.storedValue)}`,
+      `File: ${result.path}`,
+      "Restart minicode to pick up persisted config changes in a new session.",
+    ];
+    if (process.env[definition.envVar] !== undefined) {
+      lines.push(`Note: ${definition.envVar} is currently set and will override this persisted value until it is unset.`);
+    }
+    return lines.join("\n");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return `Failed to save config: ${message}`;
+  }
+}
+
+async function removeConfigValue(
+  key: string,
+  context: ConfigSlashCommandContext,
+  scope: EditableConfigScope,
+): Promise<string> {
+  if (!isEditableConfigKey(key)) {
+    return `Unknown editable config key "${key}".\n\n${renderEditableKeys()}`;
+  }
+
+  const cwd = context.cwd ?? process.cwd();
+  const minicodeHome = context.minicodeHome ?? MINICODE_HOME;
+  const definition = getEditableConfigDefinition(key);
+
+  await unsetPersistedConfigValue({
+    cwd,
+    key,
+    scope,
+    minicodeHome,
+  });
+
+  const lines = [
+    `Removed ${scope} persisted value for "${key}".`,
+    `File: ${scope === "global" ? `${minicodeHome}/agent.config.json` : `${cwd}/agent.config.json`}`,
+    "Restart minicode to ensure the updated config is applied in a new session.",
+  ];
+  if (process.env[definition.envVar] !== undefined) {
+    lines.push(`Note: ${definition.envVar} is still set in the environment, so the effective value may remain unchanged.`);
+  }
+  return lines.join("\n");
+}
+
+export async function handleConfigSlashCommand(
+  trimmed: string,
+  context: ConfigSlashCommandContext,
+): Promise<ConfigSlashCommandResult> {
+  if (!(trimmed === "/config" || trimmed.startsWith("/config "))) {
+    return { handled: false };
+  }
+
+  const rest = trimmed.slice("/config".length).trim();
+  if (rest.length === 0) {
+    return { handled: true, message: formatConfigForDisplay(context.config) };
+  }
+
+  const tokens = rest.split(/\s+/);
+  const { scope, args } = parseScope(tokens);
+  const [subcommand, ...subArgs] = args;
+
+  if (subcommand === "keys") {
+    return { handled: true, message: renderEditableKeys() };
+  }
+
+  if (subcommand === "get") {
+    if (subArgs.length !== 1) {
+      return { handled: true, message: renderUsage() };
+    }
+    return {
+      handled: true,
+      message: await renderConfigValue(subArgs[0]!, context),
+    };
+  }
+
+  if (subcommand === "set") {
+    if (subArgs.length < 2) {
+      return { handled: true, message: renderUsage() };
+    }
+    const [key, ...valueParts] = subArgs;
+    return {
+      handled: true,
+      message: await persistConfigValue(key!, valueParts.join(" "), context, scope),
+    };
+  }
+
+  if (subcommand === "unset") {
+    if (subArgs.length !== 1) {
+      return { handled: true, message: renderUsage() };
+    }
+    return {
+      handled: true,
+      message: await removeConfigValue(subArgs[0]!, context, scope),
+    };
+  }
+
+  return { handled: true, message: renderUsage() };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { writeFile } from "node:fs/promises";
 import { createInterface } from "node:readline/promises";
 
 import { CodingAgent, Session, createModelClient, type ModelClient, type ReasoningEffort } from "@minicode/agent-sdk";
-import { formatConfigForDisplay, loadAgentConfig } from "./agent/config.js";
+import { loadAgentConfig } from "./agent/config.js";
 import {
   listSessions,
   loadSession,
@@ -25,6 +25,7 @@ import {
   parseCliArgs,
   validateCliArgs,
 } from "./cli/args.js";
+import { handleConfigSlashCommand } from "./cli/config-slash-command.js";
 
 const EXIT_CODE_SUCCESS = 0;
 const EXIT_CODE_RUNTIME_ERROR = 1;
@@ -143,13 +144,14 @@ async function runInteractive(
     }
 
     if (trimmed === "/help") {
-      console.log('Commands: "/help", "/config", "/compact", "/reasoning [level]", "/models", "/model [name]", "/save [label]", "/load [label]", "/sessions", "/exit"');
+      console.log('Commands: "/help", "/config [keys|get|set|unset]", "/compact", "/reasoning [level]", "/models", "/model [name]", "/save [label]", "/load [label]", "/sessions", "/exit"');
       console.log("Start with --verbose or -v to log prompts, responses, and tool calls.");
       continue;
     }
 
-    if (trimmed === "/config") {
-      console.log("\n" + formatConfigForDisplay(config) + "\n");
+    const configCommand = await handleConfigSlashCommand(trimmed, { config });
+    if (configCommand.handled) {
+      console.log("\n" + (configCommand.message ?? "") + "\n");
       continue;
     }
 

--- a/src/ui/cli-ink.ts
+++ b/src/ui/cli-ink.ts
@@ -2,7 +2,8 @@ import process from "node:process";
 
 import { CodingAgent, Session, createModelClient } from "@minicode/agent-sdk";
 import type { UiUpdate, ReasoningEffort } from "@minicode/agent-sdk";
-import { formatConfigForDisplay, loadAgentConfig } from "../agent/config.js";
+import { loadAgentConfig } from "../agent/config.js";
+import { handleConfigSlashCommand } from "../cli/config-slash-command.js";
 import {
   computeFileHashes,
   getWorkspaceCacheDir,
@@ -155,15 +156,16 @@ export async function runInkCli(
       store.addItem({
         type: "system",
         content:
-          'Commands: "/help", "/config", "/compact", "/reasoning [level]", "/models", "/model [name]", "/save [label]", "/load [label]", "/sessions", "/exit".',
+          'Commands: "/help", "/config [keys|get|set|unset]", "/compact", "/reasoning [level]", "/models", "/model [name]", "/save [label]", "/load [label]", "/sessions", "/exit".',
       });
       return;
     }
 
-    if (trimmed === "/config") {
+    const configCommand = await handleConfigSlashCommand(trimmed, { config });
+    if (configCommand.handled) {
       store.addItem({
         type: "system",
-        content: formatConfigForDisplay(config),
+        content: configCommand.message ?? "",
       });
       return;
     }

--- a/tests/config-slash-command.test.ts
+++ b/tests/config-slash-command.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, test } from "node:test";
+
+import {
+  getConfigPathForScope,
+  setPersistedConfigValue,
+  unsetPersistedConfigValue,
+} from "../src/agent/editable-config.js";
+import { handleConfigSlashCommand } from "../src/cli/config-slash-command.js";
+import { createTestAgentConfig } from "./test-utils.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempPaths(): Promise<{ workspace: string; home: string }> {
+  const base = await mkdtemp(path.join(os.tmpdir(), "minicode-config-"));
+  const workspace = path.join(base, "workspace");
+  const home = path.join(base, "home");
+  tempDirs.push(base);
+  return { workspace, home };
+}
+
+test("setPersistedConfigValue writes mapped keys and unset removes empty config files", async () => {
+  const { workspace, home } = await createTempPaths();
+
+  const setResult = await setPersistedConfigValue({
+    cwd: workspace,
+    minicodeHome: home,
+    key: "commandTimeoutMs",
+    rawValue: "45000",
+  });
+
+  assert.equal(setResult.path, path.join(workspace, "agent.config.json"));
+  const file = JSON.parse(await readFile(setResult.path, "utf8")) as { commandTimeout: number };
+  assert.equal(file.commandTimeout, 45000);
+
+  await unsetPersistedConfigValue({
+    cwd: workspace,
+    minicodeHome: home,
+    key: "commandTimeoutMs",
+  });
+
+  await assert.rejects(access(setResult.path));
+});
+
+test("handleConfigSlashCommand persists workspace config and reports env overrides", async () => {
+  const { workspace, home } = await createTempPaths();
+  const config = createTestAgentConfig(workspace);
+  const previous = process.env.MAX_STEPS;
+
+  try {
+    process.env.MAX_STEPS = "120";
+    const result = await handleConfigSlashCommand("/config set maxSteps 64", {
+      config,
+      cwd: workspace,
+      minicodeHome: home,
+    });
+
+    assert.equal(result.handled, true);
+    assert.match(result.message ?? "", /Saved workspace config: maxSteps = 64/);
+    assert.match(result.message ?? "", /MAX_STEPS is currently set/);
+
+    const persisted = JSON.parse(
+      await readFile(path.join(workspace, "agent.config.json"), "utf8"),
+    ) as { maxSteps: number };
+    assert.equal(persisted.maxSteps, 64);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.MAX_STEPS;
+    } else {
+      process.env.MAX_STEPS = previous;
+    }
+  }
+});
+
+test("handleConfigSlashCommand supports --global and reports config layers with /config get", async () => {
+  const { workspace, home } = await createTempPaths();
+  const config = {
+    ...createTestAgentConfig(workspace),
+    modelProvider: "openai-compatible" as const,
+  };
+  const previous = process.env.MODEL_PROVIDER;
+
+  try {
+    process.env.MODEL_PROVIDER = "openai-compatible";
+    await setPersistedConfigValue({
+      cwd: workspace,
+      minicodeHome: home,
+      key: "modelProvider",
+      rawValue: "anthropic",
+      scope: "workspace",
+    });
+
+    const setGlobal = await handleConfigSlashCommand("/config set --global modelProvider openai-compatible", {
+      config,
+      cwd: workspace,
+      minicodeHome: home,
+    });
+    assert.match(setGlobal.message ?? "", /Saved global config: modelProvider = openai-compatible/);
+
+    const getResult = await handleConfigSlashCommand("/config get modelProvider", {
+      config,
+      cwd: workspace,
+      minicodeHome: home,
+    });
+
+    assert.equal(getResult.handled, true);
+    assert.match(getResult.message ?? "", /effective: openai-compatible/);
+    assert.match(getResult.message ?? "", /workspace file: anthropic/);
+    assert.match(getResult.message ?? "", /global file: openai-compatible/);
+    assert.match(getResult.message ?? "", /env override \(MODEL_PROVIDER\): openai-compatible/);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.MODEL_PROVIDER;
+    } else {
+      process.env.MODEL_PROVIDER = previous;
+    }
+  }
+});
+
+test("handleConfigSlashCommand rejects non-editable keys and keeps secrets env-only", async () => {
+  const { workspace, home } = await createTempPaths();
+  const result = await handleConfigSlashCommand("/config set openAiApiKey secret", {
+    config: createTestAgentConfig(workspace),
+    cwd: workspace,
+    minicodeHome: home,
+  });
+
+  assert.equal(result.handled, true);
+  assert.match(result.message ?? "", /Unknown editable config key "openAiApiKey"/);
+  assert.match(result.message ?? "", /Secrets like API keys stay env-only for now/);
+});
+
+test("getConfigPathForScope resolves workspace and global paths", () => {
+  const workspace = "/tmp/example-workspace";
+  const home = "/tmp/example-home";
+
+  assert.equal(
+    getConfigPathForScope(workspace, "workspace", home),
+    path.join(workspace, "agent.config.json"),
+  );
+  assert.equal(
+    getConfigPathForScope(workspace, "global", home),
+    path.join(home, "agent.config.json"),
+  );
+});


### PR DESCRIPTION
## Summary
- define a shared editable-config model for non-secret settings that persist to `agent.config.json`
- add `/config keys`, `/config get`, `/config set`, and `/config unset` for both CLI modes
- keep secrets env-only and surface precedence clearly when env vars override persisted values
- add persistence and slash-command tests around workspace/global scope and config-layer reporting

## Verification
- `PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm test && PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm run build`

Fixes #67
Fixes #70