### PR TITLE
Add web settings modal and config API

### DIFF
--- a/src/agent/editable-config.ts
+++ b/src/agent/editable-config.ts
@@ -39,6 +39,25 @@ export interface EditableConfigDefinition {
   values?: readonly string[];
 }
 
+export interface StructuredConfigEntry {
+  key: EditableConfigKey;
+  type: EditableConfigType;
+  description: string;
+  envVar: string;
+  values?: readonly string[];
+  effectiveValue: string | number | boolean | null;
+  workspaceValue: string | number | boolean | null;
+  globalValue: string | number | boolean | null;
+  envValue: string | null;
+  overriddenByEnv: boolean;
+}
+
+export interface StructuredConfigPayload {
+  workspaceConfigPath: string;
+  globalConfigPath: string;
+  entries: StructuredConfigEntry[];
+}
+
 const REASONING_VALUES = [
   "xhigh",
   "high",
@@ -239,6 +258,14 @@ function parseEditableValue(
   return trimmed;
 }
 
+function normalizePersistedValue(value: unknown): string | number | boolean | null {
+  if (value === undefined) return null;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  return null;
+}
+
 function isEmptyConfigFile(config: AgentConfigFile): boolean {
   return Object.keys(config).length === 0;
 }
@@ -268,6 +295,7 @@ export function getEffectiveEditableConfigValue(
 
 export function formatPersistedConfigValue(value: unknown): string {
   if (value === undefined) return "(unset)";
+  if (value === null) return "(unset)";
   if (typeof value === "string") return value;
   return String(value);
 }
@@ -291,6 +319,37 @@ export async function loadPersistedConfigLayers(
   return {
     global: await loadConfigFile(globalPath),
     workspace: await loadConfigFile(workspacePath),
+  };
+}
+
+export async function buildStructuredConfigPayload(
+  config: AgentConfig,
+  cwd: string,
+  minicodeHome = MINICODE_HOME,
+): Promise<StructuredConfigPayload> {
+  const paths = {
+    workspaceConfigPath: getConfigPathForScope(cwd, "workspace", minicodeHome),
+    globalConfigPath: getConfigPathForScope(cwd, "global", minicodeHome),
+  };
+  const layers = await loadPersistedConfigLayers(cwd, minicodeHome);
+
+  return {
+    ...paths,
+    entries: EDITABLE_CONFIG_DEFINITIONS.map((definition) => {
+      const envValue = process.env[definition.envVar];
+      return {
+        key: definition.key,
+        type: definition.type,
+        description: definition.description,
+        envVar: definition.envVar,
+        ...(definition.values ? { values: definition.values } : {}),
+        effectiveValue: normalizePersistedValue(config[definition.key]),
+        workspaceValue: normalizePersistedValue(layers.workspace[definition.fileKey]),
+        globalValue: normalizePersistedValue(layers.global[definition.fileKey]),
+        envValue: envValue ?? null,
+        overriddenByEnv: envValue !== undefined,
+      };
+    }),
   };
 }
 
@@ -338,4 +397,53 @@ export async function unsetPersistedConfigValue(options: {
   }
 
   return { path: configPath };
+}
+
+export async function applyPersistedConfigUpdates(options: {
+  cwd: string;
+  updates: Record<string, string | number | boolean | null>;
+  scope?: EditableConfigScope;
+  minicodeHome?: string;
+}): Promise<{
+  path: string;
+  saved: Array<{ key: EditableConfigKey; value: string | number | boolean | null }>;
+}> {
+  const scope = options.scope ?? "workspace";
+  const minicodeHome = options.minicodeHome ?? MINICODE_HOME;
+  const cwd = options.cwd;
+
+  const planned = Object.entries(options.updates).map(([rawKey, value]) => {
+    if (!isEditableConfigKey(rawKey)) {
+      throw new Error(`Unknown editable config key "${rawKey}".`);
+    }
+    return { key: rawKey, value };
+  });
+
+  const saved: Array<{ key: EditableConfigKey; value: string | number | boolean | null }> = [];
+  for (const item of planned) {
+    if (item.value === null) {
+      await unsetPersistedConfigValue({
+        cwd,
+        key: item.key,
+        scope,
+        minicodeHome,
+      });
+      saved.push({ key: item.key, value: null });
+      continue;
+    }
+
+    await setPersistedConfigValue({
+      cwd,
+      key: item.key,
+      rawValue: String(item.value),
+      scope,
+      minicodeHome,
+    });
+    saved.push({ key: item.key, value: item.value });
+  }
+
+  return {
+    path: getConfigPathForScope(cwd, scope, minicodeHome),
+    saved,
+  };
 }

--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -8,6 +8,7 @@ import { AgentBridge } from "./agent-bridge.js";
 import { createWebSocketServer } from "./websocket.js";
 import { handleChatCompletions, handleModels } from "./openai-compat.js";
 import { formatConfigForDisplay } from "../agent/config.js";
+import { applyPersistedConfigUpdates, buildStructuredConfigPayload } from "../agent/editable-config.js";
 import { sortModelsAlphabetically } from "../model-utils.js";
 import type { ServerMessage } from "./types.js";
 import type { WebSocketServer } from "ws";
@@ -68,6 +69,7 @@ async function serveStatic(res: ServerResponse, urlPath: string): Promise<void> 
 /** Create the HTTP request handler. Exported for testing. */
 export function createRequestHandler(bridge: AgentBridge): (req: IncomingMessage, res: ServerResponse) => void {
   const config = bridge.getConfig();
+  const configCwd = config.workspaceRoot;
 
   return (req: IncomingMessage, res: ServerResponse) => {
     const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
@@ -120,7 +122,50 @@ export function createRequestHandler(bridge: AgentBridge): (req: IncomingMessage
       }
 
       if (pathname === "/api/config" && method === "GET") {
-        sendJson(res, 200, { config: formatConfigForDisplay(config) });
+        const structured = await buildStructuredConfigPayload(config, configCwd);
+        sendJson(res, 200, {
+          config: formatConfigForDisplay(config),
+          settings: structured,
+          restartRequired: true,
+          secretsUiSupported: false,
+        });
+        return;
+      }
+
+      if (pathname === "/api/config" && method === "POST") {
+        const body = JSON.parse(await readBody(req)) as {
+          scope?: "workspace" | "global";
+          updates?: Record<string, string | number | boolean | null>;
+        };
+        if (!body.updates || typeof body.updates !== "object") {
+          sendJson(res, 400, { error: "updates object is required" });
+          return;
+        }
+        if (body.scope && body.scope !== "workspace" && body.scope !== "global") {
+          sendJson(res, 400, { error: `Invalid scope "${body.scope}". Use "workspace" or "global".` });
+          return;
+        }
+
+        try {
+          const result = await applyPersistedConfigUpdates({
+            cwd: configCwd,
+            scope: body.scope ?? "workspace",
+            updates: body.updates,
+          });
+          const structured = await buildStructuredConfigPayload(config, configCwd);
+          sendJson(res, 200, {
+            ok: true,
+            scope: body.scope ?? "workspace",
+            path: result.path,
+            saved: result.saved,
+            restartRequired: true,
+            message: "Persisted config updated. Restart minicode to apply changes to new sessions.",
+            settings: structured,
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Failed to update config";
+          sendJson(res, 400, { error: message });
+        }
         return;
       }
 

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -23,6 +23,46 @@ interface SessionMeta {
   messageCount: number;
 }
 
+type SettingsScope = "workspace" | "global";
+type SettingsValue = string | number | boolean | null;
+type SettingsFieldType = "string" | "number" | "boolean" | "enum";
+
+interface SettingsEntry {
+  key: string;
+  type: SettingsFieldType;
+  description: string;
+  envVar: string;
+  values?: readonly string[];
+  effectiveValue: SettingsValue;
+  workspaceValue: SettingsValue;
+  globalValue: SettingsValue;
+  envValue: string | null;
+  overriddenByEnv: boolean;
+}
+
+interface SettingsPayload {
+  workspaceConfigPath: string;
+  globalConfigPath: string;
+  entries: SettingsEntry[];
+}
+
+interface ConfigResponse {
+  config: string;
+  settings: SettingsPayload;
+  restartRequired: boolean;
+  secretsUiSupported: boolean;
+}
+
+interface ConfigSaveResponse {
+  ok: boolean;
+  scope: SettingsScope;
+  path: string;
+  saved: Array<{ key: string; value: SettingsValue }>;
+  restartRequired: boolean;
+  message: string;
+  settings: SettingsPayload;
+}
+
 const messagesEl = document.getElementById("messages")!;
 const chatForm = document.getElementById("chat-form") as HTMLFormElement;
 const chatInput = document.getElementById("chat-input") as HTMLTextAreaElement;
@@ -40,11 +80,23 @@ const saveBtn = document.getElementById("save-btn")!;
 const saveLabelInput = document.getElementById("save-label") as HTMLInputElement;
 const contextFill = document.getElementById("context-fill")!;
 const contextLabel = document.getElementById("context-label")!;
+const settingsBtn = document.getElementById("settings-btn") as HTMLButtonElement;
+const settingsModal = document.getElementById("settings-modal")!;
+const settingsBackdrop = document.getElementById("settings-backdrop")!;
+const settingsCloseBtn = document.getElementById("settings-close") as HTMLButtonElement;
+const settingsScopeSelect = document.getElementById("settings-scope") as HTMLSelectElement;
+const settingsPath = document.getElementById("settings-path")!;
+const settingsList = document.getElementById("settings-list")!;
+const settingsBanner = document.getElementById("settings-banner")!;
+const settingsSaveBtn = document.getElementById("settings-save") as HTMLButtonElement;
+const settingsResetBtn = document.getElementById("settings-reset") as HTMLButtonElement;
 
 let ws: WebSocket;
 let currentAssistantEl: HTMLElement | null = null;
 let assistantText = "";
 let hadToolCalls = false;
+let settingsPayload: SettingsPayload | null = null;
+let activeSettingsScope: SettingsScope = "workspace";
 
 const TOOL_RESULT_MAX = 500;
 
@@ -311,6 +363,276 @@ function scrollToBottom(): void {
   messagesEl.scrollTop = messagesEl.scrollHeight;
 }
 
+function closeHeaderMenus(): void {
+  modelDropdown.classList.add("hidden");
+  sessionDropdown.classList.add("hidden");
+}
+
+function isSettingsModalOpen(): boolean {
+  return !settingsModal.classList.contains("hidden");
+}
+
+function getScopeValue(entry: SettingsEntry, scope: SettingsScope): SettingsValue {
+  return scope === "workspace" ? entry.workspaceValue : entry.globalValue;
+}
+
+function getScopePath(settings: SettingsPayload, scope: SettingsScope): string {
+  return scope === "workspace" ? settings.workspaceConfigPath : settings.globalConfigPath;
+}
+
+function formatSettingsValue(value: SettingsValue): string {
+  return value === null ? "(unset)" : String(value);
+}
+
+function setSettingsBanner(message: string, tone: "info" | "success" | "error"): void {
+  settingsBanner.textContent = message;
+  settingsBanner.className = `settings-banner ${tone}`;
+}
+
+function clearSettingsBanner(): void {
+  settingsBanner.textContent = "";
+  settingsBanner.className = "settings-banner hidden";
+}
+
+function createSettingsControl(entry: SettingsEntry, inputId: string): HTMLElement {
+  const value = getScopeValue(entry, activeSettingsScope);
+
+  if (entry.type === "boolean") {
+    const select = document.createElement("select");
+    select.id = inputId;
+    select.className = "settings-select";
+    select.dataset.settingKey = entry.key;
+    select.innerHTML = `
+      <option value="">Use default</option>
+      <option value="true">True</option>
+      <option value="false">False</option>
+    `;
+    select.value = value === null ? "" : String(value);
+    return select;
+  }
+
+  if (entry.type === "enum") {
+    const select = document.createElement("select");
+    select.id = inputId;
+    select.className = "settings-select";
+    select.dataset.settingKey = entry.key;
+
+    const unsetOption = document.createElement("option");
+    unsetOption.value = "";
+    unsetOption.textContent = "Use default";
+    select.appendChild(unsetOption);
+
+    for (const optionValue of entry.values ?? []) {
+      const option = document.createElement("option");
+      option.value = optionValue;
+      option.textContent = optionValue;
+      select.appendChild(option);
+    }
+
+    select.value = value === null ? "" : String(value);
+    return select;
+  }
+
+  const input = document.createElement("input");
+  input.id = inputId;
+  input.className = "settings-control";
+  input.dataset.settingKey = entry.key;
+  input.type = entry.type === "number" ? "number" : "text";
+  if (entry.type === "number") {
+    input.step = "any";
+    input.inputMode = "numeric";
+  }
+  input.placeholder = "Use default";
+  input.value = value === null ? "" : String(value);
+  return input;
+}
+
+function renderSettings(): void {
+  if (!settingsPayload) {
+    return;
+  }
+
+  settingsScopeSelect.value = activeSettingsScope;
+  settingsPath.textContent = getScopePath(settingsPayload, activeSettingsScope);
+  settingsList.innerHTML = "";
+
+  for (const entry of settingsPayload.entries) {
+    const item = document.createElement("section");
+    item.className = "settings-item";
+
+    const header = document.createElement("div");
+    header.className = "settings-item-header";
+
+    const heading = document.createElement("div");
+    const title = document.createElement("div");
+    title.className = "settings-item-title";
+    title.textContent = entry.key;
+    const description = document.createElement("div");
+    description.className = "settings-item-description";
+    description.textContent = entry.description;
+    heading.append(title, description);
+
+    const badges = document.createElement("div");
+    badges.className = "settings-item-badges";
+    const envBadge = document.createElement("span");
+    envBadge.className = "settings-badge env";
+    envBadge.textContent = `Env: ${entry.envVar}`;
+    badges.appendChild(envBadge);
+
+    if (entry.overriddenByEnv) {
+      const overrideBadge = document.createElement("span");
+      overrideBadge.className = "settings-badge override";
+      overrideBadge.textContent = "Env override active";
+      badges.appendChild(overrideBadge);
+    }
+
+    header.append(heading, badges);
+
+    const meta = document.createElement("div");
+    meta.className = "settings-item-meta";
+    meta.innerHTML = `
+      <div class="settings-meta-block">
+        <span class="settings-meta-label">Effective</span>
+        <div class="settings-meta-value">${escapeHtml(formatSettingsValue(entry.effectiveValue))}</div>
+      </div>
+      <div class="settings-meta-block">
+        <span class="settings-meta-label">Workspace</span>
+        <div class="settings-meta-value">${escapeHtml(formatSettingsValue(entry.workspaceValue))}</div>
+      </div>
+      <div class="settings-meta-block">
+        <span class="settings-meta-label">Global</span>
+        <div class="settings-meta-value">${escapeHtml(formatSettingsValue(entry.globalValue))}</div>
+      </div>
+    `;
+
+    const controls = document.createElement("div");
+    controls.className = "settings-item-controls";
+    const inputId = `setting-${entry.key}`;
+    const label = document.createElement("label");
+    label.className = "settings-help";
+    label.htmlFor = inputId;
+    label.textContent = activeSettingsScope === "workspace"
+      ? "Saved in this workspace"
+      : "Saved in your global minicode config";
+    const control = createSettingsControl(entry, inputId);
+    controls.append(label, control);
+
+    if (entry.overriddenByEnv) {
+      const overrideHelp = document.createElement("div");
+      overrideHelp.className = "settings-help";
+      overrideHelp.textContent = `${entry.envVar} currently overrides this setting with ${formatSettingsValue(entry.envValue)}. Saving here updates the persisted default underneath that env value.`;
+      controls.appendChild(overrideHelp);
+    }
+
+    item.append(header, meta, controls);
+    settingsList.appendChild(item);
+  }
+
+  updateSettingsActions();
+}
+
+async function loadSettings(): Promise<void> {
+  settingsList.innerHTML = '<div class="dropdown-empty">Loading settings...</div>';
+  settingsSaveBtn.disabled = true;
+  settingsResetBtn.disabled = true;
+  settingsSaveBtn.textContent = "Save settings";
+  clearSettingsBanner();
+
+  try {
+    const res = await fetch("/api/config");
+    if (!res.ok) {
+      throw new Error(`Failed to load settings (${res.status})`);
+    }
+    const data = await res.json() as ConfigResponse;
+    settingsPayload = data.settings;
+    renderSettings();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to load settings";
+    settingsList.innerHTML = '<div class="dropdown-empty">Failed to load settings</div>';
+    setSettingsBanner(message, "error");
+  }
+}
+
+function readSettingsControlValue(entry: SettingsEntry): SettingsValue {
+  const control = settingsList.querySelector<HTMLElement>(`[data-setting-key="${entry.key}"]`);
+  if (!control) {
+    throw new Error(`Missing control for ${entry.key}`);
+  }
+
+  if (entry.type === "boolean" || entry.type === "enum") {
+    const value = (control as HTMLSelectElement).value.trim();
+    return value === "" ? null : entry.type === "boolean" ? value === "true" : value;
+  }
+
+  const rawValue = (control as HTMLInputElement).value.trim();
+  if (rawValue === "") {
+    return null;
+  }
+
+  if (entry.type === "number") {
+    const parsed = Number(rawValue);
+    if (!Number.isFinite(parsed)) {
+      throw new Error(`Expected a number for "${entry.key}".`);
+    }
+    return parsed;
+  }
+
+  return rawValue;
+}
+
+function collectSettingsUpdates(): Record<string, SettingsValue> {
+  if (!settingsPayload) {
+    return {};
+  }
+
+  const updates: Record<string, SettingsValue> = {};
+  for (const entry of settingsPayload.entries) {
+    const nextValue = readSettingsControlValue(entry);
+    const baseline = getScopeValue(entry, activeSettingsScope);
+    if (nextValue !== baseline) {
+      updates[entry.key] = nextValue;
+    }
+  }
+  return updates;
+}
+
+function updateSettingsActions(): void {
+  if (!settingsPayload) {
+    settingsSaveBtn.disabled = true;
+    settingsResetBtn.disabled = true;
+    settingsSaveBtn.textContent = "Save settings";
+    return;
+  }
+
+  try {
+    const changeCount = Object.keys(collectSettingsUpdates()).length;
+    settingsSaveBtn.disabled = changeCount === 0;
+    settingsResetBtn.disabled = changeCount === 0;
+    settingsSaveBtn.textContent = changeCount === 0
+      ? "Save settings"
+      : `Save ${changeCount} change${changeCount === 1 ? "" : "s"}`;
+  } catch {
+    settingsSaveBtn.disabled = true;
+    settingsResetBtn.disabled = false;
+    settingsSaveBtn.textContent = "Save settings";
+  }
+}
+
+function openSettings(): void {
+  closeHeaderMenus();
+  settingsModal.classList.remove("hidden");
+  settingsModal.setAttribute("aria-hidden", "false");
+  document.body.classList.add("modal-open");
+  void loadSettings();
+}
+
+function closeSettings(): void {
+  settingsModal.classList.add("hidden");
+  settingsModal.setAttribute("aria-hidden", "true");
+  document.body.classList.remove("modal-open");
+  clearSettingsBanner();
+}
+
 // Form handling
 chatForm.addEventListener("submit", (e: Event) => {
   e.preventDefault();
@@ -347,7 +669,6 @@ modelBtn.addEventListener("click", (e: Event) => {
   e.stopPropagation();
   const isOpen = !modelDropdown.classList.contains("hidden");
   modelDropdown.classList.toggle("hidden");
-  // Close session dropdown if open
   sessionDropdown.classList.add("hidden");
   if (!isOpen) {
     refreshModelList();
@@ -399,6 +720,7 @@ sessionBtn.addEventListener("click", (e: Event) => {
   e.stopPropagation();
   const isOpen = !sessionDropdown.classList.contains("hidden");
   sessionDropdown.classList.toggle("hidden");
+  modelDropdown.classList.add("hidden");
   if (!isOpen) {
     refreshSessionList();
   }
@@ -478,6 +800,93 @@ async function loadSession(label: string): Promise<void> {
     // ignore
   }
 }
+
+// -- Settings modal --
+
+settingsBtn.addEventListener("click", () => {
+  openSettings();
+});
+
+settingsCloseBtn.addEventListener("click", () => {
+  closeSettings();
+});
+
+settingsBackdrop.addEventListener("click", () => {
+  closeSettings();
+});
+
+settingsScopeSelect.addEventListener("change", () => {
+  activeSettingsScope = settingsScopeSelect.value === "global" ? "global" : "workspace";
+  clearSettingsBanner();
+  renderSettings();
+});
+
+settingsResetBtn.addEventListener("click", () => {
+  clearSettingsBanner();
+  renderSettings();
+});
+
+settingsSaveBtn.addEventListener("click", async () => {
+  if (!settingsPayload) {
+    return;
+  }
+
+  let updates: Record<string, SettingsValue>;
+  try {
+    updates = collectSettingsUpdates();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to read settings";
+    setSettingsBanner(message, "error");
+    return;
+  }
+
+  if (Object.keys(updates).length === 0) {
+    setSettingsBanner("No changes to save for this scope.", "info");
+    return;
+  }
+
+  settingsSaveBtn.disabled = true;
+  settingsSaveBtn.textContent = "Saving...";
+
+  try {
+    const res = await fetch("/api/config", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scope: activeSettingsScope,
+        updates,
+      }),
+    });
+    const body = await res.json() as ConfigSaveResponse | { error: string };
+    if (!res.ok) {
+      throw new Error("error" in body ? body.error : `Failed to save settings (${res.status})`);
+    }
+
+    settingsPayload = body.settings;
+    renderSettings();
+    setSettingsBanner(body.message, "success");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to save settings";
+    setSettingsBanner(message, "error");
+    updateSettingsActions();
+  }
+});
+
+settingsList.addEventListener("input", () => {
+  clearSettingsBanner();
+  updateSettingsActions();
+});
+
+settingsList.addEventListener("change", () => {
+  clearSettingsBanner();
+  updateSettingsActions();
+});
+
+document.addEventListener("keydown", (event: KeyboardEvent) => {
+  if (event.key === "Escape" && isSettingsModalOpen()) {
+    closeSettings();
+  }
+});
 
 // -- Resizable pane divider --
 

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -32,6 +32,7 @@
             </div>
           </div>
         </div>
+        <button id="settings-btn" class="header-btn" title="Edit persisted settings">Settings</button>
         <button id="graph-toggle" class="header-btn" title="Toggle graph pane">Graph</button>
         <div class="session-menu">
           <button id="session-btn" class="header-btn" title="Sessions">Sessions</button>
@@ -74,6 +75,48 @@
         <div id="symbol-detail" class="hidden"></div>
       </div>
     </div>
+  </div>
+
+  <div id="settings-modal" class="modal hidden" aria-hidden="true">
+    <div id="settings-backdrop" class="modal-backdrop"></div>
+    <section class="modal-panel" role="dialog" aria-modal="true" aria-labelledby="settings-title">
+      <div class="modal-header">
+        <div>
+          <h2 id="settings-title">Settings</h2>
+          <p id="settings-subtitle" class="modal-subtitle">Persist non-secret defaults for future sessions.</p>
+        </div>
+        <button id="settings-close" class="header-btn" type="button">Close</button>
+      </div>
+
+      <div class="settings-toolbar">
+        <label class="settings-scope-picker" for="settings-scope">
+          <span>Scope</span>
+          <select id="settings-scope">
+            <option value="workspace">Workspace</option>
+            <option value="global">Global</option>
+          </select>
+        </label>
+        <div class="settings-path-group">
+          <span class="settings-path-label">Config file</span>
+          <code id="settings-path" class="settings-path"></code>
+        </div>
+      </div>
+
+      <div id="settings-banner" class="settings-banner hidden" role="status" aria-live="polite"></div>
+      <div id="settings-list" class="settings-list">
+        <div class="dropdown-empty">Loading settings...</div>
+      </div>
+
+      <div class="modal-footer">
+        <p class="settings-footnote">
+          Secrets such as API keys stay env-only for now. Saved changes update persisted defaults and apply to new runs after restart.
+        </p>
+        <div class="settings-actions">
+          <button id="settings-reset" class="header-btn" type="button">Reset changes</button>
+          <button id="settings-save" class="dropdown-action" type="button">Save settings</button>
+        </div>
+      </div>
+    </section>
   </div>
 
   <script type="module" src="app.js"></script>

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -29,6 +29,10 @@ html, body {
   line-height: 1.6;
 }
 
+body.modal-open {
+  overflow: hidden;
+}
+
 #app {
   display: flex;
   flex-direction: column;
@@ -633,6 +637,303 @@ footer {
   display: none !important;
 }
 
+/* Settings modal */
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 500;
+}
+
+.modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(10, 10, 18, 0.72);
+  backdrop-filter: blur(4px);
+}
+
+.modal-panel {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: min(960px, calc(100vw - 32px));
+  max-height: calc(100vh - 48px);
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+}
+
+.modal-header,
+.modal-footer,
+.settings-toolbar {
+  padding: 18px 20px;
+}
+
+.modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.modal-header h2 {
+  font-size: 16px;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+
+.modal-subtitle {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.settings-toolbar {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 1px solid var(--border);
+  background: rgba(26, 27, 38, 0.55);
+}
+
+.settings-scope-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.settings-scope-picker select,
+.settings-control,
+.settings-select {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.settings-scope-picker select,
+.settings-select {
+  padding: 8px 10px;
+}
+
+.settings-control {
+  width: 100%;
+  padding: 9px 11px;
+}
+
+.settings-scope-picker select:focus,
+.settings-control:focus,
+.settings-select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.settings-path-group {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  min-width: 0;
+}
+
+.settings-path-label {
+  font-size: 11px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.settings-path {
+  max-width: min(100%, 500px);
+  overflow-x: auto;
+  white-space: nowrap;
+  color: var(--accent);
+  background: rgba(122, 162, 247, 0.08);
+  border: 1px solid rgba(122, 162, 247, 0.18);
+  border-radius: 999px;
+  padding: 4px 10px;
+}
+
+.settings-banner {
+  margin: 14px 20px 0;
+  padding: 10px 12px;
+  border-radius: 8px;
+  font-size: 12px;
+  border: 1px solid transparent;
+}
+
+.settings-banner.info {
+  background: rgba(122, 162, 247, 0.12);
+  border-color: rgba(122, 162, 247, 0.24);
+  color: var(--text);
+}
+
+.settings-banner.success {
+  background: rgba(158, 206, 106, 0.12);
+  border-color: rgba(158, 206, 106, 0.26);
+  color: var(--green);
+}
+
+.settings-banner.error {
+  background: rgba(247, 118, 142, 0.12);
+  border-color: rgba(247, 118, 142, 0.26);
+  color: var(--red);
+}
+
+.settings-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 18px 20px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.settings-item {
+  background: rgba(26, 27, 38, 0.72);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+}
+
+.settings-item-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 8px;
+}
+
+.settings-item-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+
+.settings-item-description {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.settings-item-badges {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.settings-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.settings-badge.env {
+  color: var(--accent);
+  background: rgba(122, 162, 247, 0.12);
+  border-color: rgba(122, 162, 247, 0.24);
+}
+
+.settings-badge.override {
+  color: var(--yellow);
+  background: rgba(224, 175, 104, 0.14);
+  border-color: rgba(224, 175, 104, 0.24);
+}
+
+.settings-item-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.settings-meta-block {
+  background: var(--bg);
+  border: 1px solid rgba(51, 53, 74, 0.8);
+  border-radius: 8px;
+  padding: 10px;
+  min-width: 0;
+}
+
+.settings-meta-label {
+  display: block;
+  font-size: 10px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 4px;
+}
+
+.settings-meta-value {
+  font-size: 12px;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.settings-item-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.settings-help {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.settings-footnote {
+  font-size: 12px;
+  color: var(--text-dim);
+  max-width: 560px;
+}
+
+.settings-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.settings-list::-webkit-scrollbar,
+.settings-path::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.settings-list::-webkit-scrollbar-track,
+.settings-path::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.settings-list::-webkit-scrollbar-thumb,
+.settings-path::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 999px;
+}
+
 /* Scrollbar */
 main::-webkit-scrollbar {
   width: 6px;
@@ -1034,4 +1335,35 @@ main::-webkit-scrollbar-thumb {
 
 @keyframes spin {
   to { transform: rotate(360deg); }
+}
+
+@media (max-width: 900px) {
+  .modal-panel {
+    width: calc(100vw - 20px);
+    max-height: calc(100vh - 20px);
+  }
+
+  .settings-toolbar,
+  .modal-footer,
+  .settings-item-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .settings-path-group {
+    align-items: flex-start;
+  }
+
+  .settings-item-badges {
+    justify-content: flex-start;
+  }
+
+  .settings-item-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
 }

--- a/tests/config-api.test.ts
+++ b/tests/config-api.test.ts
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import type { Server } from "node:http";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, test } from "node:test";
+
+import type { ModelInfo } from "@minicode/agent-sdk";
+import { createRequestHandler } from "../src/serve/server.js";
+import { AgentBridge } from "../src/serve/agent-bridge.js";
+import { createTestAgentConfig } from "./test-utils.js";
+
+class ConfigApiBridge extends AgentBridge {
+  private readonly workspaceRoot: string;
+
+  constructor(workspaceRoot: string) {
+    super(() => {}, false);
+    this.workspaceRoot = workspaceRoot;
+  }
+
+  override isBusy(): boolean {
+    return false;
+  }
+
+  override getConfig() {
+    return createTestAgentConfig(this.workspaceRoot);
+  }
+
+  override async listModels(): Promise<ModelInfo[]> {
+    return [];
+  }
+
+  override async runTurn(message: string) {
+    return { text: `Echo: ${message}`, usage: { inputTokens: 1, outputTokens: 1 } };
+  }
+
+  override async listSess() { return []; }
+  override hasIndex() { return false; }
+}
+
+const activeServers = new Set<Server>();
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    [...activeServers].map((server) => new Promise<void>((resolve) => server.close(() => resolve()))),
+  );
+  activeServers.clear();
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function startServer(bridge: AgentBridge): Promise<string> {
+  const server = createServer(createRequestHandler(bridge));
+  activeServers.add(server);
+
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (typeof address === "object" && address) {
+        resolve(`http://127.0.0.1:${address.port}`);
+      }
+    });
+  });
+}
+
+async function withUnsetEnvVars(
+  names: string[],
+  callback: () => Promise<void>,
+): Promise<void> {
+  const previous = new Map<string, string | undefined>();
+  for (const name of names) {
+    previous.set(name, process.env[name]);
+    delete process.env[name];
+  }
+
+  try {
+    await callback();
+  } finally {
+    for (const [name, value] of previous) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  }
+}
+
+test("GET /api/config returns structured editable settings payload", async () => {
+  await withUnsetEnvVars(["MAX_STEPS"], async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "minicode-config-api-"));
+    tempDirs.push(workspaceRoot);
+    const base = await startServer(new ConfigApiBridge(workspaceRoot));
+
+    const res = await fetch(`${base}/api/config`);
+    assert.equal(res.status, 200);
+
+    const body = await res.json() as {
+      config: string;
+      settings: {
+        workspaceConfigPath: string;
+        globalConfigPath: string;
+        entries: Array<{
+          key: string;
+          type: string;
+          description: string;
+          envVar: string;
+          effectiveValue: unknown;
+          workspaceValue: unknown;
+          globalValue: unknown;
+          envValue: unknown;
+          overriddenByEnv: boolean;
+        }>;
+      };
+      restartRequired: boolean;
+      secretsUiSupported: boolean;
+    };
+
+    assert.match(body.config, /workspaceRoot/);
+    assert.equal(body.restartRequired, true);
+    assert.equal(body.secretsUiSupported, false);
+    assert.equal(body.settings.workspaceConfigPath, path.join(workspaceRoot, "agent.config.json"));
+    assert.ok(body.settings.globalConfigPath.endsWith(path.join(".minicode", "agent.config.json")));
+    const maxSteps = body.settings.entries.find((entry) => entry.key === "maxSteps");
+    assert.equal(maxSteps?.type, "number");
+    assert.equal(maxSteps?.envVar, "MAX_STEPS");
+    assert.equal(maxSteps?.effectiveValue, 10);
+    assert.equal(maxSteps?.workspaceValue, null);
+    assert.equal(maxSteps?.globalValue, null);
+    assert.equal(maxSteps?.envValue, null);
+    assert.equal(maxSteps?.overriddenByEnv, false);
+    assert.match(maxSteps?.description ?? "", /Maximum agent loop steps per turn/);
+  });
+});
+
+test("POST /api/config persists workspace settings and returns updated metadata", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "minicode-config-api-"));
+  tempDirs.push(workspaceRoot);
+  const base = await startServer(new ConfigApiBridge(workspaceRoot));
+
+  const res = await fetch(`${base}/api/config`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      scope: "workspace",
+      updates: {
+        maxSteps: 42,
+        enableDynamicPrompt: false,
+      },
+    }),
+  });
+  assert.equal(res.status, 200);
+
+  const body = await res.json() as {
+    ok: boolean;
+    scope: string;
+    path: string;
+    saved: Array<{ key: string; value: unknown }>;
+    restartRequired: boolean;
+    message: string;
+    settings: {
+      entries: Array<{ key: string; workspaceValue: unknown }>;
+    };
+  };
+
+  assert.equal(body.ok, true);
+  assert.equal(body.scope, "workspace");
+  assert.equal(body.path, path.join(workspaceRoot, "agent.config.json"));
+  assert.equal(body.restartRequired, true);
+  assert.match(body.message, /Persisted config updated/);
+  assert.deepEqual(body.saved, [
+    { key: "maxSteps", value: 42 },
+    { key: "enableDynamicPrompt", value: false },
+  ]);
+
+  const persisted = JSON.parse(
+    await readFile(path.join(workspaceRoot, "agent.config.json"), "utf8"),
+  ) as { maxSteps: number; enableDynamicPrompt: boolean };
+  assert.equal(persisted.maxSteps, 42);
+  assert.equal(persisted.enableDynamicPrompt, false);
+
+  const maxSteps = body.settings.entries.find((entry) => entry.key === "maxSteps");
+  assert.equal(maxSteps?.workspaceValue, 42);
+});
+
+test("POST /api/config rejects invalid scopes", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "minicode-config-api-"));
+  tempDirs.push(workspaceRoot);
+  const base = await startServer(new ConfigApiBridge(workspaceRoot));
+
+  const res = await fetch(`${base}/api/config`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      scope: "project",
+      updates: {
+        maxSteps: 7,
+      },
+    }),
+  });
+
+  assert.equal(res.status, 400);
+  const body = await res.json() as { error: string };
+  assert.match(body.error, /Invalid scope/);
+});
+
+test("POST /api/config rejects invalid keys", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "minicode-config-api-"));
+  tempDirs.push(workspaceRoot);
+  const base = await startServer(new ConfigApiBridge(workspaceRoot));
+
+  const res = await fetch(`${base}/api/config`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      updates: {
+        openAiApiKey: "secret",
+      },
+    }),
+  });
+
+  assert.equal(res.status, 400);
+  const body = await res.json() as { error: string };
+  assert.match(body.error, /Unknown editable config key/);
+});

--- a/tests/editable-config.test.ts
+++ b/tests/editable-config.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, test } from "node:test";
+
+import {
+  applyPersistedConfigUpdates,
+  buildStructuredConfigPayload,
+  getConfigPathForScope,
+} from "../src/agent/editable-config.js";
+import { createTestAgentConfig } from "./test-utils.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempPaths(): Promise<{ workspace: string; home: string }> {
+  const base = await mkdtemp(path.join(os.tmpdir(), "minicode-editable-config-"));
+  const workspace = path.join(base, "workspace");
+  const home = path.join(base, "home");
+  tempDirs.push(base);
+  return { workspace, home };
+}
+
+async function withUnsetEnvVars(
+  names: string[],
+  callback: () => Promise<void>,
+): Promise<void> {
+  const previous = new Map<string, string | undefined>();
+  for (const name of names) {
+    previous.set(name, process.env[name]);
+    delete process.env[name];
+  }
+
+  try {
+    await callback();
+  } finally {
+    for (const [name, value] of previous) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  }
+}
+
+test("buildStructuredConfigPayload reports effective values, scope layers, and env overrides", async () => {
+  await withUnsetEnvVars(["MAX_STEPS", "MODEL", "ENABLE_DYNAMIC_PROMPT"], async () => {
+    const { workspace, home } = await createTempPaths();
+
+    await applyPersistedConfigUpdates({
+      cwd: workspace,
+      minicodeHome: home,
+      scope: "global",
+      updates: {
+        maxSteps: 77,
+        model: "global-model",
+      },
+    });
+    await applyPersistedConfigUpdates({
+      cwd: workspace,
+      minicodeHome: home,
+      scope: "workspace",
+      updates: {
+        model: "workspace-model",
+        enableDynamicPrompt: false,
+      },
+    });
+
+    process.env.MAX_STEPS = "120";
+
+    const payload = await buildStructuredConfigPayload(
+      {
+        ...createTestAgentConfig(workspace),
+        maxSteps: 120,
+        model: "workspace-model",
+        enableDynamicPrompt: false,
+      },
+      workspace,
+      home,
+    );
+
+    assert.equal(payload.workspaceConfigPath, path.join(workspace, "agent.config.json"));
+    assert.equal(payload.globalConfigPath, path.join(home, "agent.config.json"));
+
+    const maxSteps = payload.entries.find((entry) => entry.key === "maxSteps");
+    assert.equal(maxSteps?.effectiveValue, 120);
+    assert.equal(maxSteps?.workspaceValue, null);
+    assert.equal(maxSteps?.globalValue, 77);
+    assert.equal(maxSteps?.envValue, "120");
+    assert.equal(maxSteps?.overriddenByEnv, true);
+
+    const model = payload.entries.find((entry) => entry.key === "model");
+    assert.equal(model?.effectiveValue, "workspace-model");
+    assert.equal(model?.workspaceValue, "workspace-model");
+    assert.equal(model?.globalValue, "global-model");
+    assert.equal(model?.overriddenByEnv, false);
+  });
+});
+
+test("applyPersistedConfigUpdates writes global scope and removes files when everything is unset", async () => {
+  const { workspace, home } = await createTempPaths();
+
+  const result = await applyPersistedConfigUpdates({
+    cwd: workspace,
+    minicodeHome: home,
+    scope: "global",
+    updates: {
+      keepRecentMessages: 18,
+      enableFileReadDedup: false,
+    },
+  });
+
+  assert.equal(result.path, getConfigPathForScope(workspace, "global", home));
+  assert.deepEqual(result.saved, [
+    { key: "keepRecentMessages", value: 18 },
+    { key: "enableFileReadDedup", value: false },
+  ]);
+
+  const configPath = path.join(home, "agent.config.json");
+  const persisted = JSON.parse(await readFile(configPath, "utf8")) as {
+    keepRecentMessages: number;
+    enableFileReadDedup: boolean;
+  };
+  assert.equal(persisted.keepRecentMessages, 18);
+  assert.equal(persisted.enableFileReadDedup, false);
+
+  await applyPersistedConfigUpdates({
+    cwd: workspace,
+    minicodeHome: home,
+    scope: "global",
+    updates: {
+      keepRecentMessages: null,
+      enableFileReadDedup: null,
+    },
+  });
+
+  await assert.rejects(access(configPath));
+});

--- a/tests/serve.integration.test.ts
+++ b/tests/serve.integration.test.ts
@@ -256,16 +256,28 @@ test("GET /api/status returns busy when agent is busy", async () => {
   assert.equal(body.status, "busy");
 });
 
-test("GET /api/config returns formatted config", async () => {
+test("GET /api/config returns formatted config plus structured settings", async () => {
   const bridge = new MockBridge();
   const base = await startTestServer(bridge);
 
   const res = await fetch(`${base}/api/config`);
   assert.equal(res.status, 200);
 
-  const body = (await res.json()) as { config: string };
+  const body = (await res.json()) as {
+    config: string;
+    restartRequired: boolean;
+    secretsUiSupported: boolean;
+    settings: {
+      workspaceConfigPath: string;
+      entries: Array<{ key: string }>;
+    };
+  };
   assert.ok(body.config.includes("workspaceRoot"));
   assert.ok(body.config.includes("test-model"));
+  assert.equal(body.restartRequired, true);
+  assert.equal(body.secretsUiSupported, false);
+  assert.equal(body.settings.workspaceConfigPath, "/tmp/test-workspace/agent.config.json");
+  assert.ok(body.settings.entries.some((entry) => entry.key === "maxSteps"));
 });
 
 test("GET /api/sessions returns session list", async () => {

--- a/tests/settings-ui.test.ts
+++ b/tests/settings-ui.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const distWeb = join(import.meta.dirname, "..", "dist", "src", "web");
+
+test("built HTML contains settings entry point and modal shell", () => {
+  const html = readFileSync(join(distWeb, "index.html"), "utf8");
+  assert.ok(html.includes('id="settings-btn"'), "HTML should contain the settings button");
+  assert.ok(html.includes('id="settings-modal"'), "HTML should contain the settings modal");
+  assert.ok(html.includes('id="settings-scope"'), "HTML should contain the settings scope selector");
+  assert.ok(html.includes('id="settings-save"'), "HTML should contain the settings save action");
+});
+
+test("built CSS contains modal and settings layout styles", () => {
+  const css = readFileSync(join(distWeb, "style.css"), "utf8");
+  assert.ok(css.includes(".modal-panel"), "CSS should contain modal panel styles");
+  assert.ok(css.includes(".settings-list"), "CSS should contain settings list styles");
+  assert.ok(css.includes(".settings-item-meta"), "CSS should contain settings metadata grid styles");
+  assert.ok(css.includes("body.modal-open"), "CSS should lock scroll while the settings modal is open");
+});
+
+test("built JS contains config loading and saving logic for settings", () => {
+  const js = readFileSync(join(distWeb, "app.js"), "utf8");
+  assert.ok(js.includes("/api/config"), "JS should fetch the config API");
+  assert.ok(js.includes("Save settings"), "JS should contain the settings save action text");
+  assert.ok(js.includes("settingsPayload"), "JS should track settings payload state");
+  assert.ok(js.includes("activeSettingsScope"), "JS should wire scope-specific settings behavior");
+});


### PR DESCRIPTION
## Summary
- add a structured `/api/config` surface plus persisted config updates for workspace/global scopes
- add a web settings entry point and modal for editing non-secret persisted config
- add API, editable-config, serve integration, and built-web asset coverage for the new settings flow

## Verification
- `PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm test`
- `PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm run build`
- `PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm run lint`

Closes #68
Closes #69
