### PR TITLE
Add structural analysis workflow to graph UI

### DIFF
--- a/src/shared/graph-styles.ts
+++ b/src/shared/graph-styles.ts
@@ -94,6 +94,41 @@ export function buildStylesheet(): unknown[] {
   styles.push({ selector: 'edge.faded', style: { 'opacity': 0.05 } });
   styles.push({ selector: 'node.highlighted', style: { 'border-width': 2.5, 'z-index': 10 } });
   styles.push({ selector: 'edge.highlighted', style: { 'opacity': 0.9, 'width': 2, 'z-index': 10 } });
+  styles.push({
+    selector: 'node.analysis-flagged',
+    style: {
+      'border-style': 'double',
+      'border-width': 3,
+      'overlay-color': '#7dcfff',
+      'overlay-opacity': 0.05,
+    },
+  });
+  styles.push({
+    selector: 'node.analysis-selected',
+    style: {
+      'border-color': '#f7768e',
+      'border-width': 4,
+      'background-color': 'rgba(247,118,142,0.18)',
+      'z-index': 30,
+    },
+  });
+  styles.push({
+    selector: 'edge.analysis-flagged',
+    style: {
+      'opacity': 0.55,
+      'width': 1.75,
+    },
+  });
+  styles.push({
+    selector: 'edge.analysis-selected',
+    style: {
+      'line-color': '#f7768e',
+      'target-arrow-color': '#f7768e',
+      'opacity': 0.95,
+      'width': 3,
+      'z-index': 30,
+    },
+  });
   styles.push({ selector: 'node.agent-pulse', style: { 'border-color': '#ff9e64', 'border-width': 4, 'background-color': 'rgba(255,158,100,0.25)' } });
   styles.push({ selector: 'node.search-match', style: { 'border-color': '#e0af68', 'border-width': 2.5 } });
   styles.push({ selector: 'node.expanded', style: { 'border-width': 2.5 } });

--- a/src/web/analysis-helpers.ts
+++ b/src/web/analysis-helpers.ts
@@ -1,0 +1,151 @@
+export type StructuralFindingType =
+  | "cycle"
+  | "fanInOutlier"
+  | "fanOutOutlier"
+  | "hotspot"
+  | "fileCoupling";
+
+export type StructuralFindingSeverity = "info" | "warning" | "high";
+
+export interface StructuralFinding {
+  id: string;
+  type: StructuralFindingType;
+  severity: StructuralFindingSeverity;
+  title: string;
+  summary: string;
+  symbols: string[];
+  files: string[];
+  metrics: Record<string, number | string | boolean>;
+  rationale: string[];
+}
+
+export interface StructuralAnalysisSummary {
+  symbolCount: number;
+  edgeCount: number;
+  fileCount: number;
+  findingCount: number;
+  cycleCount: number;
+  hotspotCount: number;
+  thresholds: {
+    fanIn: number;
+    fanOut: number;
+    hotspot: number;
+    fileCoupling: number;
+  };
+}
+
+export interface StructuralAnalysisReport {
+  version: 1;
+  findings: StructuralFinding[];
+  summary: StructuralAnalysisSummary;
+}
+
+export interface GraphEdgeRef {
+  source: string;
+  target: string;
+  kind: string;
+}
+
+export interface FindingGraphContext {
+  nodes: string[];
+  edgeIds: string[];
+}
+
+export function findingTypeLabel(type: StructuralFindingType): string {
+  switch (type) {
+    case "cycle":
+      return "Cycle";
+    case "fanInOutlier":
+      return "High fan-in";
+    case "fanOutOutlier":
+      return "High fan-out";
+    case "hotspot":
+      return "Hotspot";
+    case "fileCoupling":
+      return "File coupling";
+  }
+}
+
+export function findingSeverityLabel(severity: StructuralFindingSeverity): string {
+  switch (severity) {
+    case "high":
+      return "High";
+    case "warning":
+      return "Warning";
+    case "info":
+      return "Info";
+  }
+}
+
+export function buildFindingMetricChips(finding: StructuralFinding): string[] {
+  switch (finding.type) {
+    case "cycle":
+      return [
+        `${Number(finding.metrics.cycleSize ?? finding.symbols.length)} symbols`,
+        `${Number(finding.metrics.edgeCount ?? 0)} edges`,
+        `${Number(finding.metrics.fileCount ?? finding.files.length)} files`,
+      ];
+    case "fanInOutlier":
+      return [
+        `fan-in ${Number(finding.metrics.fanIn ?? 0)}`,
+        `threshold ${Number(finding.metrics.threshold ?? 0)}`,
+      ];
+    case "fanOutOutlier":
+      return [
+        `fan-out ${Number(finding.metrics.fanOut ?? 0)}`,
+        `threshold ${Number(finding.metrics.threshold ?? 0)}`,
+      ];
+    case "hotspot":
+      return [
+        `degree ${Number(finding.metrics.totalDegree ?? 0)}`,
+        `${Number(finding.metrics.fanIn ?? 0)} in`,
+        `${Number(finding.metrics.fanOut ?? 0)} out`,
+      ];
+    case "fileCoupling":
+      return [
+        `coupling ${Number(finding.metrics.totalCoupling ?? 0)}`,
+        `instability ${Number(finding.metrics.instability ?? 0)}`,
+      ];
+  }
+}
+
+export function buildFindingGraphContext(
+  finding: StructuralFinding,
+  edges: GraphEdgeRef[],
+): FindingGraphContext {
+  const selectedSymbols = new Set(finding.symbols);
+  const edgeIds = new Set<string>();
+
+  for (const edge of edges) {
+    const touchesSelected = selectedSymbols.has(edge.source) || selectedSymbols.has(edge.target);
+    const internalToSelection = selectedSymbols.has(edge.source) && selectedSymbols.has(edge.target);
+
+    if (
+      (finding.type === "cycle" && internalToSelection) ||
+      (finding.type !== "cycle" && touchesSelected)
+    ) {
+      edgeIds.add(`${edge.source}->${edge.target}:${edge.kind}`);
+    }
+  }
+
+  return {
+    nodes: [...selectedSymbols].sort((a, b) => a.localeCompare(b)),
+    edgeIds: [...edgeIds].sort((a, b) => a.localeCompare(b)),
+  };
+}
+
+export function countFindingsByType(findings: StructuralFinding[]): Record<StructuralFindingType, number> {
+  return findings.reduce<Record<StructuralFindingType, number>>(
+    (counts, finding) => {
+      counts[finding.type] += 1;
+      return counts;
+    },
+    {
+      cycle: 0,
+      fanInOutlier: 0,
+      fanOutOutlier: 0,
+      hotspot: 0,
+      fileCoupling: 0,
+    },
+  );
+}

--- a/src/web/graph.ts
+++ b/src/web/graph.ts
@@ -3,6 +3,14 @@
 // Clicking a node expands its 1-hop neighbors. Walk the graph in real time.
 
 import { escapeHtml, renderMarkdownInto } from './utils.ts';
+import {
+  buildFindingGraphContext,
+  buildFindingMetricChips,
+  countFindingsByType,
+  findingSeverityLabel,
+  findingTypeLabel,
+  type StructuralAnalysisReport,
+} from './analysis-helpers.ts';
 import { KIND_COLORS, buildStylesheet } from '../shared/graph-styles.ts';
 
 declare const cytoscape: (opts: unknown) => CyInstance;
@@ -81,6 +89,8 @@ const edgeIndex = new Map<string, GraphEdge[]>();
 const pinnedNames = new Set<string>();
 let allSymbolNames: string[] = [];
 let initialized = false;
+let analysisReport: StructuralAnalysisReport | null = null;
+let activeAnalysisFindingId: string | null = null;
 
 const LAYOUT_OPTIONS: Record<string, unknown> = {
   name: 'cose',
@@ -243,6 +253,7 @@ function addNodeAndNeighbors(symbolId: string): void {
 function expandNodeAndLayout(symbolId: string): void {
   addNodeAndNeighbors(symbolId);
   connectExistingNodes();
+  refreshAnalysisGraphState();
   runLayout();
 }
 
@@ -307,6 +318,223 @@ function findNode(name: string): CyCollection | null {
     return nName === name || qName.endsWith('.' + name);
   });
   return match.length > 0 ? match : null;
+}
+
+interface AnalysisPanelEls {
+  panel: HTMLElement;
+  status: HTMLElement;
+  summary: HTMLElement;
+  findings: HTMLElement;
+}
+
+function getAnalysisPanelEls(): AnalysisPanelEls {
+  return {
+    panel: document.getElementById('analysis-panel')!,
+    status: document.getElementById('analysis-status')!,
+    summary: document.getElementById('analysis-summary')!,
+    findings: document.getElementById('analysis-findings')!,
+  };
+}
+
+function setAnalysisStatus(message: string, tone: 'info' | 'error' = 'info'): void {
+  const { status } = getAnalysisPanelEls();
+  status.textContent = message;
+  status.classList.remove('hidden', 'error');
+  if (tone === 'error') {
+    status.classList.add('error');
+  }
+}
+
+function clearAnalysisStatus(): void {
+  const { status } = getAnalysisPanelEls();
+  status.textContent = '';
+  status.classList.add('hidden');
+  status.classList.remove('error');
+}
+
+function clearAnalysisGraphClasses(): void {
+  if (!cy) return;
+  cy.elements().removeClass('analysis-flagged');
+  cy.elements().removeClass('analysis-selected');
+}
+
+function refreshAnalysisGraphState(): void {
+  const { panel } = getAnalysisPanelEls();
+  if (!cy || !analysisReport || panel.classList.contains('hidden')) {
+    clearAnalysisGraphClasses();
+    return;
+  }
+
+  clearAnalysisGraphClasses();
+
+  const candidateNodeIds = new Set<string>();
+  const candidateEdgeIds = new Set<string>();
+  for (const finding of analysisReport.findings) {
+    const context = buildFindingGraphContext(finding, graphEdges);
+    for (const nodeId of context.nodes) candidateNodeIds.add(nodeId);
+    for (const edgeId of context.edgeIds) candidateEdgeIds.add(edgeId);
+  }
+
+  for (const nodeId of candidateNodeIds) {
+    cy.getElementById(nodeId).addClass('analysis-flagged');
+  }
+  for (const edgeId of candidateEdgeIds) {
+    cy.getElementById(edgeId).addClass('analysis-flagged');
+  }
+
+  if (!activeAnalysisFindingId) return;
+  const activeFinding = analysisReport.findings.find((finding) => finding.id === activeAnalysisFindingId);
+  if (!activeFinding) return;
+
+  const activeContext = buildFindingGraphContext(activeFinding, graphEdges);
+  for (const nodeId of activeContext.nodes) {
+    cy.getElementById(nodeId).addClass('analysis-selected');
+  }
+  for (const edgeId of activeContext.edgeIds) {
+    cy.getElementById(edgeId).addClass('analysis-selected');
+  }
+}
+
+function renderAnalysisSummary(report: StructuralAnalysisReport): void {
+  const { summary } = getAnalysisPanelEls();
+  const counts = countFindingsByType(report.findings);
+  const cards = [
+    { label: 'Findings', value: report.summary.findingCount },
+    { label: 'Cycles', value: counts.cycle },
+    { label: 'Hotspots', value: counts.hotspot },
+    { label: 'Coupling', value: counts.fileCoupling },
+  ];
+  summary.innerHTML = cards.map((card) => `
+    <div class="analysis-summary-card">
+      <span class="analysis-summary-value">${card.value}</span>
+      <span class="analysis-summary-label">${escapeHtml(card.label)}</span>
+    </div>
+  `).join('');
+}
+
+function renderAnalysisFindings(report: StructuralAnalysisReport): void {
+  const { findings } = getAnalysisPanelEls();
+
+  if (report.findings.length === 0) {
+    findings.innerHTML = `
+      <div class="analysis-empty">
+        No structural outliers cleared the current thresholds for this graph snapshot.
+      </div>
+    `;
+    return;
+  }
+
+  findings.innerHTML = report.findings.map((finding) => {
+    const metricChips = buildFindingMetricChips(finding)
+      .map((chip) => `<span class="analysis-metric-chip">${escapeHtml(chip)}</span>`)
+      .join('');
+    const fileBadges = finding.files.slice(0, 3)
+      .map((file) => `<span class="analysis-file-badge">${escapeHtml(file)}</span>`)
+      .join('');
+    const rationale = finding.rationale.slice(0, 2)
+      .map((item) => `<li>${escapeHtml(item)}</li>`)
+      .join('');
+
+    return `
+      <article class="analysis-finding" data-finding-id="${escapeHtml(finding.id)}">
+        <div class="analysis-finding-header">
+          <div>
+            <h3 class="analysis-finding-title">${escapeHtml(finding.title)}</h3>
+          </div>
+          <div class="analysis-finding-meta">
+            <span class="analysis-type-badge">${escapeHtml(findingTypeLabel(finding.type))}</span>
+            <span class="analysis-severity-badge ${escapeHtml(finding.severity)}">${escapeHtml(findingSeverityLabel(finding.severity))}</span>
+          </div>
+        </div>
+        <p class="analysis-finding-summary">${escapeHtml(finding.summary)}</p>
+        <div class="analysis-chip-row">${metricChips}</div>
+        ${fileBadges ? `<div class="analysis-file-row">${fileBadges}</div>` : ''}
+        ${rationale ? `<ul class="analysis-rationale">${rationale}</ul>` : ''}
+      </article>
+    `;
+  }).join('');
+
+  findings.querySelectorAll('.analysis-finding').forEach((el) => {
+    el.addEventListener('click', () => {
+      const id = (el as HTMLElement).dataset.findingId || '';
+      void selectAnalysisFinding(id);
+    });
+  });
+}
+
+function setActiveFindingCard(findingId: string | null): void {
+  const { findings } = getAnalysisPanelEls();
+  findings.querySelectorAll('.analysis-finding').forEach((el) => {
+    el.classList.toggle('active', (el as HTMLElement).dataset.findingId === findingId);
+  });
+}
+
+async function runStructuralAnalysis(): Promise<void> {
+  const { panel, findings } = getAnalysisPanelEls();
+  panel.classList.remove('hidden');
+  findings.innerHTML = '<div class="analysis-empty">Running structural analysis on the current dependency graph...</div>';
+  setAnalysisStatus('Analyzing the current graph snapshot...');
+
+  try {
+    const res = await fetch('/api/analysis');
+    if (!res.ok) {
+      throw new Error(res.status === 404 ? 'No project index available for analysis yet.' : `Analysis request failed (${res.status})`);
+    }
+
+    const report = await res.json() as StructuralAnalysisReport;
+    analysisReport = report;
+    activeAnalysisFindingId = null;
+    clearAnalysisStatus();
+    setAnalysisStatus(
+      `Analyzed ${report.summary.symbolCount} symbols across ${report.summary.fileCount} files. These are graph-derived structural signals.`,
+    );
+    renderAnalysisSummary(report);
+    renderAnalysisFindings(report);
+    refreshAnalysisGraphState();
+  } catch (error) {
+    analysisReport = null;
+    activeAnalysisFindingId = null;
+    clearAnalysisGraphClasses();
+    getAnalysisPanelEls().summary.innerHTML = '';
+    const message = error instanceof Error ? error.message : 'Failed to run structural analysis.';
+    findings.innerHTML = `<div class="analysis-empty">${escapeHtml(message)}</div>`;
+    setAnalysisStatus(message, 'error');
+  }
+}
+
+async function selectAnalysisFinding(findingId: string): Promise<void> {
+  if (!analysisReport || !cy) return;
+  const finding = analysisReport.findings.find((item) => item.id === findingId);
+  if (!finding) return;
+
+  const beforeNodeCount = cy.nodes().length;
+  for (const symbol of finding.symbols) {
+    addNodeAndNeighbors(symbol);
+  }
+  connectExistingNodes();
+
+  activeAnalysisFindingId = findingId;
+  refreshAnalysisGraphState();
+  setActiveFindingCard(findingId);
+
+  const afterNodeCount = cy.nodes().length;
+  if (afterNodeCount > beforeNodeCount) {
+    runLayout();
+  }
+
+  const primarySymbol = finding.symbols[0];
+  if (!primarySymbol) return;
+
+  const primaryNode = cy.getElementById(primarySymbol);
+  if (primaryNode.length > 0) {
+    if (finding.symbols.length > 1) {
+      cy.fit(80);
+    } else {
+      cy.animate({ center: { eles: primaryNode }, zoom: 1.35 }, { duration: 300 });
+    }
+    primaryNode.flashClass('highlighted', 1200);
+    await showDetail(primaryNode, document.getElementById('symbol-detail')!);
+  }
 }
 
 // -- Interactions --
@@ -719,9 +947,13 @@ async function togglePin(name: string, node: CyCollection, btnEl: HTMLButtonElem
 
 function setupToolbar(): void {
   const searchInput = document.getElementById('graph-search') as HTMLInputElement;
+  const analyzeBtn = document.getElementById('graph-analyze') as HTMLButtonElement;
   const fitBtn = document.getElementById('graph-fit') as HTMLButtonElement;
   const relayoutBtn = document.getElementById('graph-relayout') as HTMLButtonElement;
   const clearBtn = document.getElementById('graph-clear') as HTMLButtonElement;
+  const analysisCloseBtn = document.getElementById('analysis-close') as HTMLButtonElement;
+  const analysisRerunBtn = document.getElementById('analysis-rerun') as HTMLButtonElement;
+  const analysisPanel = document.getElementById('analysis-panel')!;
 
   let searchTimeout: ReturnType<typeof setTimeout>;
   const dropdown = document.createElement('div');
@@ -821,6 +1053,22 @@ function setupToolbar(): void {
     }
   });
 
+  analyzeBtn.addEventListener('click', () => {
+    void runStructuralAnalysis();
+  });
+
+  analysisRerunBtn.addEventListener('click', () => {
+    void runStructuralAnalysis();
+  });
+
+  analysisCloseBtn.addEventListener('click', () => {
+    analysisPanel.classList.add('hidden');
+    activeAnalysisFindingId = null;
+    clearAnalysisStatus();
+    clearAnalysisGraphClasses();
+    setActiveFindingCard(null);
+  });
+
   relayoutBtn.addEventListener('click', () => {
     runLayout();
   });
@@ -831,5 +1079,6 @@ function setupToolbar(): void {
     document.getElementById('symbol-detail')!.classList.add('hidden');
     const cyEl = document.getElementById('cy');
     if (cyEl) showOnboardingHint(cyEl);
+    refreshAnalysisGraphState();
   });
 }

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -67,12 +67,38 @@
       <div id="graph-pane">
         <div id="graph-toolbar">
           <input id="graph-search" type="text" placeholder="Search symbols..." autocomplete="off" />
+          <button id="graph-analyze" class="header-btn">Analyze</button>
           <button id="graph-fit" class="header-btn">Fit</button>
           <button id="graph-relayout" class="header-btn">Re-layout</button>
           <button id="graph-clear" class="header-btn">Clear</button>
         </div>
-        <div id="cy"></div>
-        <div id="symbol-detail" class="hidden"></div>
+        <div id="graph-stage">
+          <div id="cy"></div>
+          <aside id="analysis-panel" class="hidden" aria-live="polite">
+            <div class="analysis-panel-header">
+              <div>
+                <div class="analysis-kicker">Deterministic analysis</div>
+                <div class="analysis-title-row">
+                  <h2 id="analysis-title">Structural findings</h2>
+                  <span class="analysis-pill">Graph-driven</span>
+                </div>
+                <p class="analysis-subtitle">
+                  These signals come from the dependency graph itself, not from agent judgment.
+                </p>
+              </div>
+              <div class="analysis-panel-actions">
+                <button id="analysis-rerun" class="header-btn" type="button">Re-run</button>
+                <button id="analysis-close" class="header-btn" type="button">Close</button>
+              </div>
+            </div>
+            <div id="analysis-status" class="analysis-status hidden"></div>
+            <div id="analysis-summary" class="analysis-summary"></div>
+            <div id="analysis-findings" class="analysis-findings">
+              <div class="analysis-empty">Run analysis to inspect cycles, hotspots, and coupling outliers.</div>
+            </div>
+          </aside>
+          <div id="symbol-detail" class="hidden"></div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -960,6 +960,13 @@ main::-webkit-scrollbar-thumb {
   flex-wrap: wrap;
 }
 
+#graph-stage {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  background: var(--bg);
+}
+
 #graph-search {
   background: var(--bg-surface);
   border: 1px solid var(--border);
@@ -1017,10 +1024,276 @@ main::-webkit-scrollbar-thumb {
 }
 
 #cy {
-  flex: 1;
-  min-height: 0;
+  width: 100%;
+  height: 100%;
   background: var(--bg);
   position: relative;
+}
+
+#analysis-panel {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  bottom: 16px;
+  width: min(380px, calc(100% - 32px));
+  background: rgba(17, 19, 29, 0.96);
+  border: 1px solid rgba(122, 162, 247, 0.22);
+  border-radius: 16px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(16px);
+  z-index: 40;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.analysis-panel-header {
+  padding: 18px 18px 14px;
+  border-bottom: 1px solid rgba(122, 162, 247, 0.14);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.analysis-kicker {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+
+.analysis-title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.analysis-title-row h2 {
+  margin: 0;
+  font-size: 17px;
+  color: var(--text);
+}
+
+.analysis-pill {
+  border: 1px solid rgba(122, 162, 247, 0.3);
+  border-radius: 999px;
+  padding: 3px 8px;
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.analysis-subtitle {
+  margin: 10px 0 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-dim);
+  max-width: 48ch;
+}
+
+.analysis-panel-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.analysis-status {
+  margin: 12px 18px 0;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(122, 162, 247, 0.18);
+  background: rgba(122, 162, 247, 0.08);
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.analysis-status.error {
+  border-color: rgba(247, 118, 142, 0.28);
+  background: rgba(247, 118, 142, 0.1);
+  color: #f4b1ba;
+}
+
+.analysis-summary {
+  padding: 14px 18px 10px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.analysis-summary-card {
+  border: 1px solid rgba(122, 162, 247, 0.14);
+  border-radius: 12px;
+  background: rgba(31, 35, 53, 0.72);
+  padding: 12px;
+}
+
+.analysis-summary-value {
+  display: block;
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.analysis-summary-label {
+  display: block;
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.analysis-findings {
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px 18px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.analysis-findings::-webkit-scrollbar {
+  width: 6px;
+}
+
+.analysis-findings::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.analysis-findings::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 999px;
+}
+
+.analysis-empty {
+  border: 1px dashed rgba(122, 162, 247, 0.2);
+  border-radius: 12px;
+  padding: 16px;
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.analysis-finding {
+  border: 1px solid rgba(122, 162, 247, 0.14);
+  border-radius: 14px;
+  background: rgba(31, 35, 53, 0.78);
+  padding: 14px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, transform 0.15s ease, background 0.15s ease;
+}
+
+.analysis-finding:hover {
+  border-color: rgba(122, 162, 247, 0.32);
+  background: rgba(36, 40, 60, 0.86);
+  transform: translateY(-1px);
+}
+
+.analysis-finding.active {
+  border-color: rgba(247, 118, 142, 0.4);
+  box-shadow: 0 0 0 1px rgba(247, 118, 142, 0.2);
+}
+
+.analysis-finding-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.analysis-finding-title {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.4;
+  color: var(--text);
+}
+
+.analysis-finding-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.analysis-type-badge,
+.analysis-severity-badge,
+.analysis-metric-chip,
+.analysis-file-badge {
+  border-radius: 999px;
+  font-size: 11px;
+  padding: 3px 8px;
+}
+
+.analysis-type-badge {
+  color: var(--accent);
+  background: rgba(122, 162, 247, 0.12);
+  border: 1px solid rgba(122, 162, 247, 0.2);
+}
+
+.analysis-severity-badge {
+  border: 1px solid transparent;
+}
+
+.analysis-severity-badge.info {
+  color: #7dcfff;
+  background: rgba(125, 207, 255, 0.12);
+  border-color: rgba(125, 207, 255, 0.18);
+}
+
+.analysis-severity-badge.warning {
+  color: #e0af68;
+  background: rgba(224, 175, 104, 0.12);
+  border-color: rgba(224, 175, 104, 0.2);
+}
+
+.analysis-severity-badge.high {
+  color: #f7768e;
+  background: rgba(247, 118, 142, 0.12);
+  border-color: rgba(247, 118, 142, 0.24);
+}
+
+.analysis-finding-summary {
+  margin: 0 0 10px;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--text-dim);
+}
+
+.analysis-chip-row,
+.analysis-file-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.analysis-metric-chip {
+  color: var(--text);
+  background: rgba(17, 19, 29, 0.75);
+  border: 1px solid rgba(122, 162, 247, 0.12);
+}
+
+.analysis-file-badge {
+  color: var(--text-dim);
+  background: rgba(17, 19, 29, 0.75);
+  border: 1px solid rgba(86, 95, 137, 0.32);
+}
+
+.analysis-rationale {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--text-dim);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.analysis-rationale li + li {
+  margin-top: 4px;
 }
 
 .graph-empty {
@@ -1365,5 +1638,27 @@ main::-webkit-scrollbar-thumb {
   .settings-actions {
     width: 100%;
     justify-content: flex-end;
+  }
+
+  #analysis-panel {
+    top: auto;
+    left: 12px;
+    right: 12px;
+    bottom: 12px;
+    width: auto;
+    max-height: min(70vh, 560px);
+  }
+
+  .analysis-panel-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .analysis-panel-actions {
+    justify-content: flex-end;
+  }
+
+  .analysis-summary {
+    grid-template-columns: 1fr 1fr;
   }
 }

--- a/tests/analysis-helpers.test.ts
+++ b/tests/analysis-helpers.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildFindingGraphContext,
+  buildFindingMetricChips,
+  countFindingsByType,
+  findingTypeLabel,
+  type StructuralFinding,
+} from "../src/web/analysis-helpers.js";
+
+test("buildFindingGraphContext limits cycle highlights to internal cycle edges", () => {
+  const finding: StructuralFinding = {
+    id: "cycle:alpha->beta",
+    type: "cycle",
+    severity: "warning",
+    title: "Cycle across 2 symbols",
+    summary: "alpha and beta are mutually dependent.",
+    symbols: ["alpha", "beta"],
+    files: ["src/a.ts", "src/b.ts"],
+    metrics: { cycleSize: 2, edgeCount: 2, fileCount: 2 },
+    rationale: ["Strongly connected component detected."],
+  };
+
+  const context = buildFindingGraphContext(finding, [
+    { source: "alpha", target: "beta", kind: "calls" },
+    { source: "beta", target: "alpha", kind: "calls" },
+    { source: "alpha", target: "gamma", kind: "calls" },
+  ]);
+
+  assert.deepEqual(context.nodes, ["alpha", "beta"]);
+  assert.deepEqual(context.edgeIds, [
+    "alpha->beta:calls",
+    "beta->alpha:calls",
+  ]);
+});
+
+test("buildFindingGraphContext includes incident edges for hotspot-style findings", () => {
+  const finding: StructuralFinding = {
+    id: "hotspot:service",
+    type: "hotspot",
+    severity: "info",
+    title: "service is a structural hotspot",
+    summary: "service has total degree 4.",
+    symbols: ["service"],
+    files: ["src/service.ts"],
+    metrics: { totalDegree: 4, fanIn: 1, fanOut: 3, threshold: 4 },
+    rationale: ["Total degree exceeds hotspot threshold."],
+  };
+
+  const context = buildFindingGraphContext(finding, [
+    { source: "entry", target: "service", kind: "calls" },
+    { source: "service", target: "repo", kind: "calls" },
+    { source: "service", target: "util", kind: "calls" },
+    { source: "other", target: "elsewhere", kind: "calls" },
+  ]);
+
+  assert.deepEqual(context.nodes, ["service"]);
+  assert.deepEqual(context.edgeIds, [
+    "entry->service:calls",
+    "service->repo:calls",
+    "service->util:calls",
+  ]);
+});
+
+test("analysis helpers summarize types and metrics for rendering", () => {
+  const findings: StructuralFinding[] = [
+    {
+      id: "fanin:util",
+      type: "fanInOutlier",
+      severity: "info",
+      title: "util has high fan-in",
+      summary: "util is widely referenced.",
+      symbols: ["util"],
+      files: ["src/util.ts"],
+      metrics: { fanIn: 5, threshold: 3 },
+      rationale: [],
+    },
+    {
+      id: "file:service",
+      type: "fileCoupling",
+      severity: "warning",
+      title: "service.ts is highly coupled",
+      summary: "service.ts has high afferent/efferent coupling.",
+      symbols: ["service"],
+      files: ["src/service.ts"],
+      metrics: { totalCoupling: 4, instability: 0.75 },
+      rationale: [],
+    },
+  ];
+
+  assert.deepEqual(countFindingsByType(findings), {
+    cycle: 0,
+    fanInOutlier: 1,
+    fanOutOutlier: 0,
+    hotspot: 0,
+    fileCoupling: 1,
+  });
+  assert.deepEqual(buildFindingMetricChips(findings[0]!), ["fan-in 5", "threshold 3"]);
+  assert.deepEqual(buildFindingMetricChips(findings[1]!), ["coupling 4", "instability 0.75"]);
+  assert.equal(findingTypeLabel("fileCoupling"), "File coupling");
+});

--- a/tests/analysis-ui.test.ts
+++ b/tests/analysis-ui.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const distWeb = join(import.meta.dirname, "..", "dist", "src", "web");
+
+test("built HTML contains analysis entry point and drawer shell", () => {
+  const html = readFileSync(join(distWeb, "index.html"), "utf8");
+  assert.ok(html.includes('id="graph-analyze"'), "HTML should contain the Analyze toolbar button");
+  assert.ok(html.includes('id="analysis-panel"'), "HTML should contain the analysis panel");
+  assert.ok(
+    html.includes("These signals come from the dependency graph itself, not from agent judgment."),
+    "HTML should explain the deterministic scope of the analysis",
+  );
+});
+
+test("built CSS contains analysis drawer and finding card styles", () => {
+  const css = readFileSync(join(distWeb, "style.css"), "utf8");
+  assert.ok(css.includes("#analysis-panel"), "CSS should contain analysis panel styles");
+  assert.ok(css.includes(".analysis-finding"), "CSS should contain finding card styles");
+  assert.ok(css.includes(".analysis-summary-card"), "CSS should contain summary card styles");
+});
+
+test("built JS contains structural analysis loading and highlighting logic", () => {
+  const js = readFileSync(join(distWeb, "app.js"), "utf8");
+  assert.ok(js.includes("/api/analysis"), "JS should fetch the analysis API");
+  assert.ok(js.includes("analysis-selected"), "JS should apply selected analysis highlight classes");
+  assert.ok(js.includes("graph-derived structural signals"), "JS should surface deterministic analysis messaging");
+});

--- a/tests/graph-styles.test.ts
+++ b/tests/graph-styles.test.ts
@@ -66,6 +66,26 @@ describe('buildStylesheet', () => {
     );
   });
 
+  it('includes structural analysis styles for flagged graph elements', () => {
+    const flaggedNode = styles.find((s) => s.selector === 'node.analysis-flagged');
+    assert.ok(flaggedNode, 'analysis-flagged node style should exist');
+    assert.equal(flaggedNode.style['border-style'], 'double');
+
+    const selectedNode = styles.find((s) => s.selector === 'node.analysis-selected');
+    assert.ok(selectedNode, 'analysis-selected node style should exist');
+    assert.ok(
+      (selectedNode.style['border-width'] as number) >= 4,
+      'analysis-selected node should emphasize border width',
+    );
+
+    const selectedEdge = styles.find((s) => s.selector === 'edge.analysis-selected');
+    assert.ok(selectedEdge, 'analysis-selected edge style should exist');
+    assert.ok(
+      (selectedEdge.style['width'] as number) >= 3,
+      'analysis-selected edge should increase edge width',
+    );
+  });
+
   it('includes faded style for non-neighborhood elements', () => {
     const fadedNode = styles.find((s) => s.selector === 'node.faded');
     assert.ok(fadedNode, 'faded node style should exist');


### PR DESCRIPTION
## Summary
- add an Analyze workflow and dedicated structural findings drawer to the web graph UI
- highlight flagged nodes and edges and let users click findings to navigate graph context
- add helper, graph-style, and built-asset coverage for the new analysis experience

## Verification
- TMPDIR=/tmp PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm test
- TMPDIR=/tmp PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm run build
- TMPDIR=/tmp PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm run lint

Closes #65