### PR TITLE
Add AI explanations for structural findings

### DIFF
--- a/src/serve/agent-bridge.ts
+++ b/src/serve/agent-bridge.ts
@@ -429,4 +429,63 @@ Be concise but thorough.`;
     const result = await explainAgent.runTurn(prompt, opts);
     return result.text;
   }
+
+  async explainStructuralFinding(
+    findingId: string,
+    onEvent: (event: UiUpdate) => void,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    const report = this.getStructuralAnalysis();
+    if (!report) throw new Error("No project index");
+
+    const finding = report.findings.find((item) => item.id === findingId);
+    if (!finding) throw new Error(`Structural finding "${findingId}" not found`);
+
+    const explainAgent = this.buildAgent(undefined, onEvent);
+    const affectedSymbols = finding.symbols.length > 0
+      ? finding.symbols.slice(0, 8).join(", ")
+      : "(none)";
+    const affectedFiles = finding.files.length > 0
+      ? finding.files.slice(0, 6).join(", ")
+      : "(none)";
+    const rationale = finding.rationale.map((item) => `- ${item}`).join("\n");
+    const metrics = Object.entries(finding.metrics)
+      .map(([key, value]) => `- ${key}: ${String(value)}`)
+      .join("\n");
+
+    const prompt = `Interpret this deterministic structural analysis finding for the current codebase.
+
+Finding type: ${finding.type}
+Severity: ${finding.severity}
+Title: ${finding.title}
+Summary: ${finding.summary}
+
+Affected symbols:
+${affectedSymbols}
+
+Affected files:
+${affectedFiles}
+
+Deterministic rationale:
+${rationale || "- No extra rationale provided."}
+
+Metrics:
+${metrics || "- No metrics provided."}
+
+Important constraints:
+- This finding came from deterministic graph analysis, not from the model.
+- Your job is to interpret the finding, not to replace it.
+- Keep the explanation advisory and note where the signal may be noisy or incomplete.
+- If useful, inspect a few affected symbols with read_symbol, get_dependencies, and find_references before explaining.
+
+Respond with short sections for:
+1. What this likely means
+2. Why it may matter
+3. Caveats / false-positive risk
+4. Potential next steps`;
+
+    const opts = signal ? { signal } : undefined;
+    const result = await explainAgent.runTurn(prompt, opts);
+    return result.text;
+  }
 }

--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -280,6 +280,46 @@ export function createRequestHandler(bridge: AgentBridge): (req: IncomingMessage
         return;
       }
 
+      if (pathname === "/api/analysis/explain" && method === "POST") {
+        const body = JSON.parse(await readBody(req)) as { findingId?: string };
+        if (!body.findingId || typeof body.findingId !== "string") {
+          sendJson(res, 400, { error: "findingId is required" });
+          return;
+        }
+
+        res.writeHead(200, {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        });
+
+        const abortController = new AbortController();
+        req.on("close", () => abortController.abort());
+
+        try {
+          await bridge.explainStructuralFinding(
+            body.findingId,
+            (event) => {
+              if (!res.writableEnded) {
+                res.write(`data: ${JSON.stringify(event)}\n\n`);
+              }
+            },
+            abortController.signal,
+          );
+        } catch (error) {
+          if (!res.writableEnded) {
+            const msg = error instanceof Error ? error.message : "Unknown error";
+            res.write(`data: ${JSON.stringify({ type: "error", message: msg })}\n\n`);
+          }
+        }
+
+        if (!res.writableEnded) {
+          res.write("data: [DONE]\n\n");
+          res.end();
+        }
+        return;
+      }
+
       if (pathname === "/api/focus" && method === "GET") {
         sendJson(res, 200, { pinned: bridge.getPinnedSymbols() });
         return;

--- a/src/web/graph.ts
+++ b/src/web/graph.ts
@@ -91,6 +91,7 @@ let allSymbolNames: string[] = [];
 let initialized = false;
 let analysisReport: StructuralAnalysisReport | null = null;
 let activeAnalysisFindingId: string | null = null;
+const analysisExplanationCache = new Map<string, string>();
 
 const LAYOUT_OPTIONS: Record<string, unknown> = {
   name: 'cose',
@@ -450,6 +451,15 @@ function renderAnalysisFindings(report: StructuralAnalysisReport): void {
         <div class="analysis-chip-row">${metricChips}</div>
         ${fileBadges ? `<div class="analysis-file-row">${fileBadges}</div>` : ''}
         ${rationale ? `<ul class="analysis-rationale">${rationale}</ul>` : ''}
+        <div class="analysis-finding-actions">
+          <button class="header-btn analysis-select-btn" type="button">Inspect in graph</button>
+          <button class="header-btn analysis-explain-btn" type="button">Explain this finding</button>
+        </div>
+        <div class="analysis-explanation hidden">
+          <div class="analysis-explanation-label">AI interpretation</div>
+          <div class="analysis-explanation-note">Advisory explanation grounded in the deterministic finding and affected symbols.</div>
+          <div class="detail-explain-content analysis-explanation-content"></div>
+        </div>
       </article>
     `;
   }).join('');
@@ -458,6 +468,25 @@ function renderAnalysisFindings(report: StructuralAnalysisReport): void {
     el.addEventListener('click', () => {
       const id = (el as HTMLElement).dataset.findingId || '';
       void selectAnalysisFinding(id);
+    });
+  });
+
+  findings.querySelectorAll('.analysis-select-btn').forEach((button) => {
+    button.addEventListener('click', (event) => {
+      event.stopPropagation();
+      const parent = (button as HTMLElement).closest('.analysis-finding') as HTMLElement | null;
+      const id = parent?.dataset.findingId || '';
+      void selectAnalysisFinding(id);
+    });
+  });
+
+  findings.querySelectorAll('.analysis-explain-btn').forEach((button) => {
+    button.addEventListener('click', (event) => {
+      event.stopPropagation();
+      const parent = (button as HTMLElement).closest('.analysis-finding') as HTMLElement | null;
+      if (!parent) return;
+      const id = parent.dataset.findingId || '';
+      void explainAnalysisFinding(id, parent);
     });
   });
 }
@@ -484,6 +513,7 @@ async function runStructuralAnalysis(): Promise<void> {
     const report = await res.json() as StructuralAnalysisReport;
     analysisReport = report;
     activeAnalysisFindingId = null;
+    analysisExplanationCache.clear();
     clearAnalysisStatus();
     setAnalysisStatus(
       `Analyzed ${report.summary.symbolCount} symbols across ${report.summary.fileCount} files. These are graph-derived structural signals.`,
@@ -494,11 +524,97 @@ async function runStructuralAnalysis(): Promise<void> {
   } catch (error) {
     analysisReport = null;
     activeAnalysisFindingId = null;
+    analysisExplanationCache.clear();
     clearAnalysisGraphClasses();
     getAnalysisPanelEls().summary.innerHTML = '';
     const message = error instanceof Error ? error.message : 'Failed to run structural analysis.';
     findings.innerHTML = `<div class="analysis-empty">${escapeHtml(message)}</div>`;
     setAnalysisStatus(message, 'error');
+  }
+}
+
+async function streamExplanationInto(
+  request: () => Promise<Response>,
+  content: HTMLElement,
+  loadingLabel: string,
+  unavailableText: string,
+  failureText: string,
+  onComplete?: (markdown: string) => void,
+): Promise<void> {
+  content.innerHTML = `<span class="explain-status"><span class="explain-spinner"></span> ${escapeHtml(loadingLabel)}</span>`;
+
+  let streaming = false;
+  let rawText = '';
+
+  function showToolStatus(toolName: string, input: Record<string, unknown>): void {
+    if (streaming) return;
+    const arg = input.name || input.path || input.symbol || input.query || '';
+    content.innerHTML = `<span class="explain-status"><span class="explain-spinner"></span> ${escapeHtml(toolName)}(${escapeHtml(String(arg))})</span>`;
+  }
+
+  function startStreaming(): void {
+    if (streaming) return;
+    streaming = true;
+    rawText = '';
+    content.textContent = '';
+  }
+
+  function finalize(): void {
+    if (!rawText) return;
+    onComplete?.(rawText);
+    renderMarkdownInto(content, rawText);
+  }
+
+  try {
+    const res = await request();
+    if (!res.ok || !res.body) {
+      content.textContent = unavailableText;
+      return;
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue;
+        const payload = line.slice(6);
+        if (payload === '[DONE]') {
+          finalize();
+          return;
+        }
+        try {
+          const event = JSON.parse(payload);
+          if (event.type === 'tool_call_start') {
+            showToolStatus(event.name, event.input || {});
+          } else if (event.type === 'streaming_chunk' && event.content) {
+            startStreaming();
+            rawText += event.content;
+            content.textContent = rawText;
+            content.scrollTop = content.scrollHeight;
+          } else if (event.type === 'error') {
+            startStreaming();
+            rawText += `\n[Error: ${event.message}]`;
+            content.textContent = rawText;
+          }
+        } catch {
+          // skip unparseable lines
+        }
+      }
+    }
+    finalize();
+  } catch {
+    if (!streaming) {
+      content.textContent = failureText;
+    } else {
+      finalize();
+    }
   }
 }
 
@@ -534,6 +650,48 @@ async function selectAnalysisFinding(findingId: string): Promise<void> {
     }
     primaryNode.flashClass('highlighted', 1200);
     await showDetail(primaryNode, document.getElementById('symbol-detail')!);
+  }
+}
+
+async function explainAnalysisFinding(findingId: string, findingEl: HTMLElement): Promise<void> {
+  await selectAnalysisFinding(findingId);
+
+  const explanationEl = findingEl.querySelector('.analysis-explanation') as HTMLElement | null;
+  const contentEl = findingEl.querySelector('.analysis-explanation-content') as HTMLElement | null;
+  if (!explanationEl || !contentEl) return;
+
+  explanationEl.classList.remove('hidden');
+
+  const cached = analysisExplanationCache.get(findingId);
+  if (cached) {
+    renderMarkdownInto(contentEl, cached);
+    return;
+  }
+
+  if (findingEl.dataset.explaining === 'true') {
+    return;
+  }
+  findingEl.dataset.explaining = 'true';
+
+  try {
+    await streamExplanationInto(
+      () => fetch('/api/analysis/explain', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ findingId }),
+      }),
+      contentEl,
+      'Interpreting deterministic finding...',
+      '(analysis explanation unavailable)',
+      '(analysis explanation failed)',
+      (markdown) => {
+        if (!markdown.includes('[Error:')) {
+          analysisExplanationCache.set(findingId, markdown);
+        }
+      },
+    );
+  } finally {
+    delete findingEl.dataset.explaining;
   }
 }
 
@@ -843,77 +1001,13 @@ async function explainSymbol(name: string, detailEl: HTMLElement): Promise<void>
   const section = detailEl.querySelector('#detail-explain') as HTMLElement;
   const content = section.querySelector('.detail-explain-content') as HTMLElement;
   section.classList.remove('hidden');
-  content.innerHTML = '<span class="explain-status"><span class="explain-spinner"></span> Researching...</span>';
-
-  let streaming = false;
-  let rawText = '';
-
-  function showToolStatus(toolName: string, input: Record<string, unknown>): void {
-    if (streaming) return;
-    const arg = input.name || input.path || input.symbol || input.query || '';
-    content.innerHTML = `<span class="explain-status"><span class="explain-spinner"></span> ${escapeHtml(toolName)}(${escapeHtml(String(arg))})</span>`;
-  }
-
-  function startStreaming(): void {
-    if (streaming) return;
-    streaming = true;
-    rawText = '';
-    content.textContent = '';
-  }
-
-  function finalize(): void {
-    if (rawText) {
-      renderMarkdownInto(content, rawText);
-    }
-  }
-
-  try {
-    const res = await fetch(`/api/symbols/${encodeURIComponent(name)}/explain`);
-    if (!res.ok || !res.body) {
-      content.textContent = '(explain unavailable)';
-      return;
-    }
-    const reader = res.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = '';
-
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split('\n');
-      buffer = lines.pop() || '';
-      for (const line of lines) {
-        if (!line.startsWith('data: ')) continue;
-        const payload = line.slice(6);
-        if (payload === '[DONE]') { finalize(); return; }
-        try {
-          const event = JSON.parse(payload);
-          if (event.type === 'tool_call_start') {
-            showToolStatus(event.name, event.input || {});
-          } else if (event.type === 'streaming_chunk' && event.content) {
-            startStreaming();
-            rawText += event.content;
-            content.textContent = rawText;
-            content.scrollTop = content.scrollHeight;
-          } else if (event.type === 'error') {
-            startStreaming();
-            rawText += `\n[Error: ${event.message}]`;
-            content.textContent = rawText;
-          }
-        } catch {
-          // skip unparseable lines
-        }
-      }
-    }
-    finalize();
-  } catch {
-    if (!streaming) {
-      content.textContent = '(explain failed)';
-    } else {
-      finalize();
-    }
-  }
+  await streamExplanationInto(
+    () => fetch(`/api/symbols/${encodeURIComponent(name)}/explain`),
+    content,
+    'Researching...',
+    '(explain unavailable)',
+    '(explain failed)',
+  );
 }
 
 async function togglePin(name: string, node: CyCollection, btnEl: HTMLButtonElement): Promise<void> {

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -1296,6 +1296,42 @@ main::-webkit-scrollbar-thumb {
   margin-top: 4px;
 }
 
+.analysis-finding-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.analysis-finding-actions .header-btn {
+  flex: 1;
+  text-align: center;
+}
+
+.analysis-explanation {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(122, 162, 247, 0.12);
+}
+
+.analysis-explanation-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #7dcfff;
+  margin-bottom: 4px;
+}
+
+.analysis-explanation-note {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-dim);
+  margin-bottom: 10px;
+}
+
+.analysis-explanation-content {
+  max-height: 280px;
+}
+
 .graph-empty {
   display: flex;
   align-items: center;

--- a/tests/analysis-ui.test.ts
+++ b/tests/analysis-ui.test.ts
@@ -20,11 +20,14 @@ test("built CSS contains analysis drawer and finding card styles", () => {
   assert.ok(css.includes("#analysis-panel"), "CSS should contain analysis panel styles");
   assert.ok(css.includes(".analysis-finding"), "CSS should contain finding card styles");
   assert.ok(css.includes(".analysis-summary-card"), "CSS should contain summary card styles");
+  assert.ok(css.includes(".analysis-explanation"), "CSS should contain AI explanation styles");
 });
 
 test("built JS contains structural analysis loading and highlighting logic", () => {
   const js = readFileSync(join(distWeb, "app.js"), "utf8");
   assert.ok(js.includes("/api/analysis"), "JS should fetch the analysis API");
+  assert.ok(js.includes("/api/analysis/explain"), "JS should call the analysis explanation API");
   assert.ok(js.includes("analysis-selected"), "JS should apply selected analysis highlight classes");
   assert.ok(js.includes("graph-derived structural signals"), "JS should surface deterministic analysis messaging");
+  assert.ok(js.includes("AI interpretation"), "JS should label advisory AI interpretation distinctly");
 });

--- a/tests/serve.integration.test.ts
+++ b/tests/serve.integration.test.ts
@@ -261,6 +261,17 @@ class MockBridge extends AgentBridge {
     onEvent({ type: "streaming_chunk", content: `Explaining ${name}...` } as UiUpdate);
     return `Explaining ${name}...`;
   }
+
+  override async explainStructuralFinding(
+    findingId: string,
+    onEvent: (event: UiUpdate) => void,
+  ): Promise<string> {
+    if (findingId !== "hotspot:foo") {
+      throw new Error(`Structural finding "${findingId}" not found`);
+    }
+    onEvent({ type: "streaming_chunk", content: `Interpreting ${findingId}...` } as UiUpdate);
+    return `Interpreting ${findingId}...`;
+  }
 }
 
 // ── Test harness ──
@@ -746,6 +757,54 @@ test("GET /api/analysis returns deterministic structural findings", async () => 
   assert.equal(body.summary.findingCount, 1);
   assert.equal(body.findings[0]?.type, "hotspot");
   assert.deepEqual(body.findings[0]?.symbols, ["foo"]);
+});
+
+test("POST /api/analysis/explain returns SSE stream", async () => {
+  const bridge = new MockBridge();
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/analysis/explain`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ findingId: "hotspot:foo" }),
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("content-type"), "text/event-stream");
+
+  const text = await res.text();
+  assert.ok(text.includes("Interpreting hotspot:foo"));
+  assert.ok(text.includes("[DONE]"));
+});
+
+test("POST /api/analysis/explain rejects missing finding id", async () => {
+  const bridge = new MockBridge();
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/analysis/explain`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  assert.equal(res.status, 400);
+  assert.deepEqual(await res.json(), { error: "findingId is required" });
+});
+
+test("POST /api/analysis/explain streams error event for unknown finding", async () => {
+  const bridge = new MockBridge();
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/analysis/explain`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ findingId: "missing" }),
+  });
+  assert.equal(res.status, 200);
+  const text = await res.text();
+  const errorLine = text.split("\n").find((line) => line.startsWith("data: {") && line.includes('"type":"error"'));
+  assert.ok(errorLine);
+  const payload = JSON.parse(errorLine!.slice(6)) as { type: string; message: string };
+  assert.equal(payload.type, "error");
+  assert.equal(payload.message, 'Structural finding "missing" not found');
 });
 
 test("GET /api/focus returns pinned symbols", async () => {


### PR DESCRIPTION
## Summary
- add an opt-in AI explanation flow for deterministic structural findings in the graph UI
- stream advisory explanations through a dedicated structural-analysis SSE endpoint
- label the interpretation distinctly in the UI and cover the new route with integration tests

## Verification
- TMPDIR=/tmp PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm test
- TMPDIR=/tmp PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm run build
- TMPDIR=/tmp PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm run lint

Closes #66