### PR TITLE
Preserve colliding symbols in the project index

### DIFF
--- a/packages/agent-sdk/src/indexer/types.ts
+++ b/packages/agent-sdk/src/indexer/types.ts
@@ -15,6 +15,9 @@ export type SymbolKind =
 export interface IndexedSymbol {
   name: string;
   qualifiedName: string;
+  originalQualifiedName?: string;
+  displayName?: string;
+  aliases?: string[];
   kind: SymbolKind;
   filePath: string;
   startLine: number;

--- a/src/indexer/code-map.ts
+++ b/src/indexer/code-map.ts
@@ -1,3 +1,4 @@
+import { getSymbolDisplayName } from "./symbol-names.js";
 import type { CodeMapResult, DependencyEdge, IndexedSymbol } from "./types.js";
 
 const DEFAULT_TOKEN_BUDGET = 1500;
@@ -15,7 +16,7 @@ function formatSymbol(
   if (isMethod) {
     return `${indent}  ${symbol.signature}`;
   }
-  return `${indent}${symbol.kind} ${symbol.qualifiedName}\n${indent}  ${symbol.signature}`;
+  return `${indent}${symbol.kind} ${getSymbolDisplayName(symbol)}\n${indent}  ${symbol.signature}`;
 }
 
 function isEntryPointFile(filePath: string): boolean {

--- a/src/indexer/plugins/typescript.ts
+++ b/src/indexer/plugins/typescript.ts
@@ -280,47 +280,102 @@ function createPlugin(): LanguagePlugin {
       projectFiles: Map<string, string>,
     ): DependencyEdge[] {
       const symbolSet = new Set(symbols.map((s) => s.qualifiedName));
+      const symbolsByLookup = new Map<string, IndexedSymbol[]>();
       const edges: DependencyEdge[] = [];
+      const edgeKeys = new Set<string>();
       const rootDir = "/project";
+
+      function addLookup(key: string, symbol: IndexedSymbol): void {
+        if (key.length === 0) return;
+        const existing = symbolsByLookup.get(key);
+        if (existing) {
+          existing.push(symbol);
+        } else {
+          symbolsByLookup.set(key, [symbol]);
+        }
+      }
+
+      for (const symbol of symbols) {
+        const lookupKeys = new Set([
+          symbol.qualifiedName,
+          symbol.name,
+          symbol.originalQualifiedName ?? "",
+          symbol.displayName ?? "",
+          ...(symbol.aliases ?? []),
+        ]);
+        for (const key of lookupKeys) {
+          addLookup(key, symbol);
+        }
+      }
 
       function addEdge(
         from: string,
         to: string,
         kind: DependencyEdgeKind,
       ): void {
-        if (symbolSet.has(to)) {
+        const edgeKey = `${from}->${to}:${kind}`;
+        if (symbolSet.has(from) && symbolSet.has(to) && !edgeKeys.has(edgeKey)) {
+          edgeKeys.add(edgeKey);
           edges.push({ from, to, kind });
         }
       }
 
-      function collectTypeRefs(node: ts.Node, from: string): void {
+      function resolveCandidates(
+        rawName: string,
+        filePath?: string,
+        kinds?: IndexedSymbol["kind"][],
+      ): IndexedSymbol[] {
+        const matches = symbolsByLookup.get(rawName) ?? [];
+        return matches.filter((symbol) =>
+          (filePath === undefined || symbol.filePath === filePath) &&
+          (kinds === undefined || kinds.includes(symbol.kind)),
+        );
+      }
+
+      function addResolvedEdges(
+        rawFrom: string,
+        rawTo: string,
+        kind: DependencyEdgeKind,
+        filePath: string,
+        targetKinds?: IndexedSymbol["kind"][],
+      ): void {
+        const fromMatches = resolveCandidates(rawFrom, filePath);
+        const toMatches = resolveCandidates(rawTo, undefined, targetKinds);
+        for (const fromSymbol of fromMatches) {
+          for (const toSymbol of toMatches) {
+            addEdge(fromSymbol.qualifiedName, toSymbol.qualifiedName, kind);
+          }
+        }
+      }
+
+      function collectTypeRefs(node: ts.Node, from: string, filePath: string): void {
         if (ts.isTypeReferenceNode(node)) {
           const name = node.typeName.getText();
-          addEdge(from, name, "references");
+          addResolvedEdges(from, name, "references", filePath, ["type", "interface", "class"]);
           if (ts.isQualifiedName(node.typeName)) {
             const left = node.typeName.left;
             if (ts.isIdentifier(left)) {
-              addEdge(from, left.getText(), "references");
+              addResolvedEdges(from, left.getText(), "references", filePath, ["type", "interface", "class"]);
             }
           }
         }
-        ts.forEachChild(node, (n) => collectTypeRefs(n, from));
+        ts.forEachChild(node, (n) => collectTypeRefs(n, from, filePath));
       }
 
-      function collectCalls(node: ts.Node, from: string): void {
+      function collectCalls(node: ts.Node, from: string, filePath: string): void {
         if (ts.isCallExpression(node)) {
           const expr = node.expression;
           if (ts.isIdentifier(expr)) {
-            addEdge(from, expr.getText(), "calls");
+            addResolvedEdges(from, expr.getText(), "calls", filePath, ["function", "class", "variable"]);
           }
         }
         if (ts.isNewExpression(node)) {
           const expr = node.expression;
           if (ts.isIdentifier(expr)) {
-            addEdge(from, expr.getText(), "calls");
+            addResolvedEdges(from, expr.getText(), "calls", filePath, ["class", "function"]);
           }
         }
-        ts.forEachChild(node, (n) => collectCalls(n, from));
+        ts.forEachChild(node, (n) => collectCalls(n, from, filePath));
       }
 
       for (const [filePath, content] of projectFiles) {
@@ -355,7 +410,7 @@ function createPlugin(): LanguagePlugin {
                   clause.token === ts.SyntaxKind.ExtendsKeyword
                     ? "extends"
                     : "implements";
-                addEdge(name, target, kind);
+                addResolvedEdges(name, target, kind, filePath, ["class", "interface"]);
               }
             }
           }
@@ -376,9 +431,9 @@ function createPlugin(): LanguagePlugin {
 
           if (ts.isConstructorDeclaration(node)) {
             const from = currentClass ? `${currentClass}.constructor` : "constructor";
-            if (symbolSet.has(from)) {
-              collectTypeRefs(node, from);
-              collectCalls(node, from);
+            if (resolveCandidates(from, filePath).length > 0) {
+              collectTypeRefs(node, from, filePath);
+              collectCalls(node, from, filePath);
             }
             return;
           }
@@ -389,9 +444,9 @@ function createPlugin(): LanguagePlugin {
                 ? "[computed]"
                 : node.name.getText(sourceFile);
             const from = currentClass ? `${currentClass}.${name}` : name;
-            if (symbolSet.has(from)) {
-              collectTypeRefs(node, from);
-              collectCalls(node, from);
+            if (resolveCandidates(from, filePath).length > 0) {
+              collectTypeRefs(node, from, filePath);
+              collectCalls(node, from, filePath);
             }
             return;
           }
@@ -399,9 +454,9 @@ function createPlugin(): LanguagePlugin {
           if (ts.isFunctionDeclaration(node) && node.name) {
             const name = node.name.getText(sourceFile);
             const from = currentClass ? `${currentClass}.${name}` : name;
-            if (symbolSet.has(from)) {
-              collectTypeRefs(node, from);
-              collectCalls(node, from);
+            if (resolveCandidates(from, filePath).length > 0) {
+              collectTypeRefs(node, from, filePath);
+              collectCalls(node, from, filePath);
             }
             return;
           }
@@ -413,9 +468,9 @@ function createPlugin(): LanguagePlugin {
 
               if (ts.isArrowFunction(init) || ts.isFunctionExpression(init)) {
                 const name = decl.name.getText(sourceFile);
-                if (symbolSet.has(name)) {
-                  collectTypeRefs(decl, name);
-                  collectCalls(decl, name);
+                if (resolveCandidates(name, filePath).length > 0) {
+                  collectTypeRefs(decl, name, filePath);
+                  collectCalls(decl, name, filePath);
                 }
               } else if (ts.isClassExpression(init)) {
                 const name = decl.name.getText(sourceFile);

--- a/src/indexer/project-index.ts
+++ b/src/indexer/project-index.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import { generateCodeMap } from "./code-map.js";
 import { getPluginForFile, loadPlugins } from "./plugin-loader.js";
+import { getSymbolLookupNames, normalizeIndexedSymbols } from "./symbol-names.js";
 import type {
   CodeMapResult,
   DependencyEdge,
@@ -72,10 +73,21 @@ function resolveSymbol(
 ): IndexedSymbol | undefined {
   const direct = symbols.get(name);
   if (direct) return direct;
-  for (const sym of symbols.values()) {
-    if (sym.name === name || sym.qualifiedName === name) return sym;
+
+  const matches = [...symbols.values()].filter((sym) =>
+    getSymbolLookupNames(sym).includes(name),
+  );
+  if (matches.length === 0) {
+    return undefined;
   }
-  return undefined;
+
+  matches.sort((a, b) =>
+    Number(b.exported) - Number(a.exported) ||
+    a.filePath.localeCompare(b.filePath) ||
+    a.startLine - b.startLine ||
+    a.qualifiedName.localeCompare(b.qualifiedName),
+  );
+  return matches[0];
 }
 
 export function createProjectIndex(
@@ -87,6 +99,14 @@ export function createProjectIndex(
   workspaceRoot: string,
 ): ProjectIndex {
   let adjacencyFrom = buildAdjacencyFrom(dependencyEdges);
+
+  function rebuildSymbolsMap(): void {
+    const normalizedSymbols = normalizeIndexedSymbols(files);
+    symbols.clear();
+    for (const [qualifiedName, symbol] of normalizedSymbols) {
+      symbols.set(qualifiedName, symbol);
+    }
+  }
 
   return {
     symbols,
@@ -258,21 +278,12 @@ export function createProjectIndex(
       const plugin = getPluginForFile(relPath, plugins);
       if (!plugin) return;
 
-      const oldSymbols = files.get(relPath) ?? [];
-      for (const sym of oldSymbols) {
-        symbols.delete(sym.qualifiedName);
-      }
       files.delete(relPath);
 
       projectFiles.set(relPath, content);
       const extracted = plugin.indexFile(relPath, content);
-
-      for (const sym of extracted) {
-        symbols.set(sym.qualifiedName, sym);
-        const existing = files.get(relPath) ?? [];
-        existing.push(sym);
-        files.set(relPath, existing);
-      }
+      files.set(relPath, extracted);
+      rebuildSymbolsMap();
 
       for (const p of plugins) {
         if (p.resolveDependencies) {
@@ -318,13 +329,13 @@ export async function buildProjectIndex(
 
     projectFiles.set(relPath, content);
     const extracted = plugin.indexFile(relPath, content);
+    files.set(relPath, extracted);
+  }
 
-    for (const sym of extracted) {
-      symbols.set(sym.qualifiedName, sym);
-      const existing = files.get(relPath) ?? [];
-      existing.push(sym);
-      files.set(relPath, existing);
-    }
+  const normalizedSymbols = normalizeIndexedSymbols(files);
+  symbols.clear();
+  for (const [qualifiedName, symbol] of normalizedSymbols) {
+    symbols.set(qualifiedName, symbol);
   }
 
   let dependencyEdges: DependencyEdge[] = [];

--- a/src/indexer/symbol-names.ts
+++ b/src/indexer/symbol-names.ts
@@ -1,0 +1,124 @@
+import type { IndexedSymbol, SymbolKind } from "./types.js";
+
+function dedupe(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.length > 0))];
+}
+
+function buildDisplayName(
+  baseName: string,
+  symbol: IndexedSymbol,
+  kindCount: number,
+  fileCount: number,
+): string {
+  if (kindCount === 1) {
+    return `${baseName} (${symbol.kind})`;
+  }
+
+  if (fileCount === 1) {
+    return `${baseName} (${symbol.kind}:${symbol.startLine})`;
+  }
+
+  return `${baseName} (${symbol.kind} in ${symbol.filePath}:${symbol.startLine})`;
+}
+
+function buildQualifiedName(
+  baseName: string,
+  symbol: IndexedSymbol,
+  kindCount: number,
+  fileCount: number,
+): string {
+  if (kindCount === 1) {
+    return `${baseName}#${symbol.kind}`;
+  }
+
+  if (fileCount === 1) {
+    return `${baseName}#${symbol.kind}:${symbol.startLine}`;
+  }
+
+  return `${baseName}#${symbol.kind}@${symbol.filePath}:${symbol.startLine}`;
+}
+
+function countByKind(symbols: IndexedSymbol[]): Map<SymbolKind, number> {
+  const counts = new Map<SymbolKind, number>();
+  for (const symbol of symbols) {
+    counts.set(symbol.kind, (counts.get(symbol.kind) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function countByFile(symbols: IndexedSymbol[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const symbol of symbols) {
+    counts.set(symbol.filePath, (counts.get(symbol.filePath) ?? 0) + 1);
+  }
+  return counts;
+}
+
+export function getSymbolDisplayName(symbol: IndexedSymbol): string {
+  return symbol.displayName ?? symbol.qualifiedName;
+}
+
+export function getSymbolLookupNames(symbol: IndexedSymbol): string[] {
+  return dedupe([
+    symbol.qualifiedName,
+    symbol.originalQualifiedName ?? "",
+    symbol.displayName ?? "",
+    symbol.name,
+    ...(symbol.aliases ?? []),
+  ]);
+}
+
+export function normalizeIndexedSymbols(
+  symbolsByFile: Map<string, IndexedSymbol[]>,
+): Map<string, IndexedSymbol> {
+  const allSymbols = [...symbolsByFile.values()].flat();
+  const groupedByBaseName = new Map<string, IndexedSymbol[]>();
+
+  for (const symbol of allSymbols) {
+    const baseName = symbol.originalQualifiedName ?? symbol.qualifiedName;
+    symbol.originalQualifiedName = baseName;
+    symbol.displayName = symbol.displayName ?? baseName;
+    symbol.aliases = dedupe([
+      symbol.name,
+      baseName,
+      symbol.displayName,
+      ...(symbol.aliases ?? []),
+    ]);
+    const existing = groupedByBaseName.get(baseName);
+    if (existing) {
+      existing.push(symbol);
+    } else {
+      groupedByBaseName.set(baseName, [symbol]);
+    }
+  }
+
+  for (const [baseName, group] of groupedByBaseName) {
+    if (group.length < 2) continue;
+
+    const sorted = [...group].sort((a, b) =>
+      a.filePath.localeCompare(b.filePath) ||
+      a.startLine - b.startLine ||
+      a.kind.localeCompare(b.kind),
+    );
+    const kindCounts = countByKind(sorted);
+    const fileCounts = countByFile(sorted);
+
+    for (const symbol of sorted) {
+      const kindCount = kindCounts.get(symbol.kind) ?? 1;
+      const fileCount = fileCounts.get(symbol.filePath) ?? 1;
+      const displayName = buildDisplayName(baseName, symbol, kindCount, fileCount);
+      const qualifiedName = buildQualifiedName(baseName, symbol, kindCount, fileCount);
+
+      symbol.displayName = displayName;
+      symbol.aliases = dedupe([
+        symbol.name,
+        baseName,
+        displayName,
+        ...(symbol.aliases ?? []),
+      ]);
+      symbol.qualifiedName = qualifiedName;
+    }
+  }
+
+  return new Map(allSymbols.map((symbol) => [symbol.qualifiedName, symbol]));
+}

--- a/src/serve/agent-bridge.ts
+++ b/src/serve/agent-bridge.ts
@@ -21,6 +21,7 @@ import {
   loadSessionByLabel,
   saveSession,
 } from "../session/session-store.js";
+import { getSymbolDisplayName } from "../indexer/symbol-names.js";
 import type { ServerMessage } from "./types.js";
 
 export type UiListener = (msg: ServerMessage) => void;
@@ -287,7 +288,7 @@ export class AgentBridge {
     }> = [];
     for (const sym of this.projectIndex.symbols.values()) {
       symbols.push({
-        name: sym.name,
+        name: getSymbolDisplayName(sym),
         qualifiedName: sym.qualifiedName,
         kind: sym.kind,
         filePath: sym.filePath,
@@ -310,7 +311,7 @@ export class AgentBridge {
     const cone = this.projectIndex.getDependencyCone(symbolName, depth);
     if (cone.length === 0) return undefined;
     return cone.map((sym) => ({
-      name: sym.name,
+      name: getSymbolDisplayName(sym),
       qualifiedName: sym.qualifiedName,
       kind: sym.kind,
       filePath: sym.filePath,
@@ -325,7 +326,14 @@ export class AgentBridge {
     // Find all edges pointing TO this symbol
     const refs = this.projectIndex.dependencyEdges
       .filter((e) => e.to === sym.qualifiedName || e.to === sym.name)
-      .map((e) => ({ from: e.from, kind: e.kind }));
+      .map((e) => {
+        const fromSymbol = this.projectIndex!.getSymbol(e.from);
+        return {
+          from: e.from,
+          kind: e.kind,
+          ...(fromSymbol ? { name: getSymbolDisplayName(fromSymbol) } : {}),
+        };
+      });
     return refs;
   }
 
@@ -347,7 +355,7 @@ export class AgentBridge {
     for (const sym of this.projectIndex.symbols.values()) {
       nodes.push({
         id: sym.qualifiedName,
-        name: sym.name,
+        name: getSymbolDisplayName(sym),
         kind: sym.kind,
         filePath: sym.filePath,
         exported: sym.exported,

--- a/src/serve/mcp-server.ts
+++ b/src/serve/mcp-server.ts
@@ -11,6 +11,7 @@ import { randomUUID } from "node:crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { z } from "zod";
+import { getSymbolDisplayName } from "../indexer/symbol-names.js";
 import type { AgentBridge } from "./agent-bridge.js";
 import type { ServerMessage } from "./types.js";
 
@@ -77,7 +78,7 @@ function createMcpServer(bridge: AgentBridge, emit: (msg: ServerMessage) => void
         const refs = bridge.getReferences(name);
 
         const lines: string[] = [
-          `## ${sym.kind}: ${sym.name}`,
+          `## ${sym.kind}: ${getSymbolDisplayName(sym)}`,
           `File: ${sym.filePath}:${sym.startLine}`,
           `Signature: ${sym.signature}`,
           "",
@@ -100,11 +101,11 @@ function createMcpServer(bridge: AgentBridge, emit: (msg: ServerMessage) => void
         }
 
         if (deps && deps.length > 0) {
-          lines.push("Dependencies:", ...deps.map((d) => `  - ${d.qualifiedName} (${d.kind})`), "");
+          lines.push("Dependencies:", ...deps.map((d) => `  - ${d.name} (${d.kind})`), "");
         }
 
         if (refs && refs.length > 0) {
-          lines.push("Referenced by:", ...refs.map((r) => `  - ${r.from} (${r.kind})`), "");
+          lines.push("Referenced by:", ...refs.map((r) => `  - ${r.name ?? r.from} (${r.kind})`), "");
         }
 
         // Append annotations if present
@@ -129,7 +130,7 @@ function createMcpServer(bridge: AgentBridge, emit: (msg: ServerMessage) => void
           return { content: [{ type: "text" as const, text: `No references found for "${name}".` }] };
         }
 
-        const lines = [`References to "${name}":`, ...refs.map((r) => `  - ${r.from} (${r.kind})`)];
+        const lines = [`References to "${name}":`, ...refs.map((r) => `  - ${r.name ?? r.from} (${r.kind})`)];
 
         const annotations = bridge.getAnnotationsForSymbol(name);
         if (annotations.length > 0) {
@@ -200,7 +201,7 @@ function createMcpServer(bridge: AgentBridge, emit: (msg: ServerMessage) => void
 
         const lines = [
           `Found ${matches.length} symbol(s) matching "${query}":`,
-          ...matches.map((s) => `  - ${s.qualifiedName} (${s.kind}) — ${s.filePath}:${s.startLine}${s.signature ? `\n    ${s.signature}` : ""}`),
+          ...matches.map((s) => `  - ${s.name} (${s.kind}) — ${s.filePath}:${s.startLine}${s.signature ? `\n    ${s.signature}` : ""}`),
         ];
 
         return { content: [{ type: "text" as const, text: lines.join("\n") }] };

--- a/src/tools/find-path.ts
+++ b/src/tools/find-path.ts
@@ -1,5 +1,6 @@
 import type { ToolDefinition } from "@minicode/agent-sdk";
 import { expectNonEmptyString, expectOptionalNumber } from "@minicode/agent-sdk";
+import { getSymbolDisplayName } from "../indexer/symbol-names.js";
 import type { ProjectIndex } from "../indexer/types.js";
 
 export function createFindPathTool(
@@ -55,11 +56,11 @@ export function createFindPathTool(
 
         const lines = path.map((s, i) => {
           const arrow = i < path.length - 1 ? " ->" : "";
-          return `${i + 1}. [${s.kind}] ${s.qualifiedName} (${s.filePath}:${s.startLine})${arrow}`;
+          return `${i + 1}. [${s.kind}] ${getSymbolDisplayName(s)} (${s.filePath}:${s.startLine})${arrow}`;
         });
 
         return [
-          `# Path from ${fromSymbol.qualifiedName} to ${toSymbol.qualifiedName} (${path.length} symbols)`,
+          `# Path from ${getSymbolDisplayName(fromSymbol)} to ${getSymbolDisplayName(toSymbol)} (${path.length} symbols)`,
           "",
           ...lines,
         ].join("\n");
@@ -74,13 +75,13 @@ export function createFindPathTool(
         const sections = paths.map((p, pi) => {
           const lines = p.map((s, i) => {
             const arrow = i < p.length - 1 ? " ->" : "";
-            return `  ${i + 1}. [${s.kind}] ${s.qualifiedName} (${s.filePath}:${s.startLine})${arrow}`;
+            return `  ${i + 1}. [${s.kind}] ${getSymbolDisplayName(s)} (${s.filePath}:${s.startLine})${arrow}`;
           });
           return [`## Path ${pi + 1}`, ...lines].join("\n");
         });
 
         return [
-          `# Entry point paths for ${fromSymbol.qualifiedName} (${paths.length} path${paths.length === 1 ? "" : "s"})`,
+          `# Entry point paths for ${getSymbolDisplayName(fromSymbol)} (${paths.length} path${paths.length === 1 ? "" : "s"})`,
           "",
           ...sections,
         ].join("\n\n");

--- a/src/tools/find-references.ts
+++ b/src/tools/find-references.ts
@@ -1,5 +1,6 @@
 import type { ToolDefinition } from "@minicode/agent-sdk";
 import { expectNonEmptyString, expectOptionalNumber } from "@minicode/agent-sdk";
+import { getSymbolDisplayName } from "../indexer/symbol-names.js";
 import type { ProjectIndex } from "../indexer/types.js";
 
 const DEFAULT_LIMIT = 50;
@@ -51,14 +52,18 @@ export function createFindReferencesTool(
       }
 
       const shown = refs.slice(skip, skip + limit);
-      const lines = shown.map((e) => `- ${e.from} (${e.kind})`);
+      const lines = shown.map((e) => {
+        const fromSymbol = projectIndex.getSymbol(e.from);
+        const label = fromSymbol ? getSymbolDisplayName(fromSymbol) : e.from;
+        return `- ${label} (${e.kind})`;
+      });
       const remaining = refs.length - skip - shown.length;
       const footer =
         remaining > 0
           ? `\n... and ${remaining} more (use skip: ${skip + limit}, limit: ${limit} for next page)`
           : "";
       return [
-        `# References to ${symbol.qualifiedName} (${refs.length} total)`,
+        `# References to ${getSymbolDisplayName(symbol)} (${refs.length} total)`,
         "",
         ...lines,
         footer,

--- a/src/tools/get-dependencies.ts
+++ b/src/tools/get-dependencies.ts
@@ -1,5 +1,6 @@
 import type { ToolDefinition } from "@minicode/agent-sdk";
 import { expectNonEmptyString, expectOptionalNumber } from "@minicode/agent-sdk";
+import { getSymbolDisplayName } from "../indexer/symbol-names.js";
 import type { ProjectIndex } from "../indexer/types.js";
 
 export function createGetDependenciesTool(
@@ -50,7 +51,7 @@ export function createGetDependenciesTool(
 
       const shown = cone.slice(skip, skip + limit);
       const lines = shown.map((s) => {
-        const header = `${s.kind} ${s.qualifiedName}`;
+        const header = `${s.kind} ${getSymbolDisplayName(s)}`;
         return `${header}\n  ${s.signature}`;
       });
       const remaining = cone.length - skip - shown.length;
@@ -60,7 +61,7 @@ export function createGetDependenciesTool(
           : "";
 
       return [
-        `# Dependencies of ${symbol.qualifiedName} (depth ${depth}, ${cone.length} total)`,
+        `# Dependencies of ${getSymbolDisplayName(symbol)} (depth ${depth}, ${cone.length} total)`,
         "",
         ...lines,
         footer,

--- a/src/tools/read-symbol.ts
+++ b/src/tools/read-symbol.ts
@@ -7,6 +7,7 @@ import {
   expectNonEmptyString,
   expectOptionalBoolean,
 } from "@minicode/agent-sdk";
+import { getSymbolDisplayName } from "../indexer/symbol-names.js";
 import type { ProjectIndex } from "../indexer/types.js";
 
 const LEADING_CONTEXT_LINES = 3;
@@ -72,7 +73,7 @@ export function createReadSymbolTool(
           .join("\n");
 
         const parts: string[] = [
-          `# ${symbol.qualifiedName} (${symbol.kind})`,
+          `# ${getSymbolDisplayName(symbol)} (${symbol.kind})`,
           `File: ${symbol.filePath}`,
           `Lines: ${symbol.startLine}-${symbol.endLine}`,
           "",
@@ -88,7 +89,10 @@ export function createReadSymbolTool(
               e.to === symbol.qualifiedName || e.to === symbol.name,
           )
           .slice(0, 5)
-          .map((e) => e.from);
+          .map((e) => {
+            const ref = projectIndex.getSymbol(e.from);
+            return ref ? getSymbolDisplayName(ref) : e.from;
+          });
         if (usedBy.length > 0) {
           parts.push("", "## Used by", "", usedBy.map((s) => `- ${s}`).join("\n"));
         }
@@ -99,7 +103,10 @@ export function createReadSymbolTool(
               e.from === symbol.qualifiedName || e.from === symbol.name,
           )
           .slice(0, 5)
-          .map((e) => e.to);
+          .map((e) => {
+            const dep = projectIndex.getSymbol(e.to);
+            return dep ? getSymbolDisplayName(dep) : e.to;
+          });
         if (calls.length > 0) {
           parts.push("", "## Calls", "", calls.map((s) => `- ${s}`).join("\n"));
         }
@@ -113,7 +120,7 @@ export function createReadSymbolTool(
         if (typeRefs.length > 0) {
           parts.push("", "## Referenced Types", "");
           for (const ref of typeRefs) {
-            parts.push(`### ${ref.qualifiedName}`, ref.signature, "");
+            parts.push(`### ${getSymbolDisplayName(ref)}`, ref.signature, "");
           }
         }
 
@@ -121,7 +128,7 @@ export function createReadSymbolTool(
       }
 
       const sigParts = [
-        `# ${symbol.qualifiedName} (${symbol.kind})`,
+        `# ${getSymbolDisplayName(symbol)} (${symbol.kind})`,
         `File: ${symbol.filePath}`,
         `Lines: ${symbol.startLine}-${symbol.endLine}`,
         "",

--- a/src/tools/search-code-map.ts
+++ b/src/tools/search-code-map.ts
@@ -1,5 +1,6 @@
 import type { ToolDefinition } from "@minicode/agent-sdk";
 import { expectNonEmptyString, expectOptionalNumber } from "@minicode/agent-sdk";
+import { getSymbolDisplayName, getSymbolLookupNames } from "../indexer/symbol-names.js";
 import type { ProjectIndex } from "../indexer/types.js";
 
 const DEFAULT_LIMIT = 30;
@@ -64,7 +65,8 @@ export function createSearchCodeMapTool(
 
       const symbols = [...projectIndex.symbols.values()];
       const matches = symbols.filter((sym) => {
-        if (!matchesPattern(sym.name, pattern) && !matchesPattern(sym.qualifiedName, pattern)) {
+        const lookupNames = getSymbolLookupNames(sym);
+        if (!lookupNames.some((candidate) => matchesPattern(candidate, pattern))) {
           return false;
         }
         if (kind && sym.kind !== kind) {
@@ -75,7 +77,7 @@ export function createSearchCodeMapTool(
 
       const shown = matches.slice(skip, skip + limit);
       const lines = shown.map(
-        (s) => `- ${s.qualifiedName} (${s.kind}) — ${s.filePath}`,
+        (s) => `- ${getSymbolDisplayName(s)} (${s.kind}) — ${s.filePath}`,
       );
       const remaining = matches.length - skip - shown.length;
       const footer =

--- a/src/web/graph.ts
+++ b/src/web/graph.ts
@@ -931,7 +931,7 @@ async function loadDepsAndRefs(name: string, detailEl: HTMLElement): Promise<voi
       refsEl.innerHTML = items.length
         ? items.map((r) => {
             const id = typeof r === 'string' ? r : r.from || r.qualifiedName || r.name || '';
-            const label = id.split('.').pop() || id;
+            const label = typeof r === 'string' ? id : r.name || id.split('.').pop() || id;
             const kind = typeof r === 'string' ? '' : r.kind || '';
             return `<a class="detail-link" data-target="${escapeHtml(id)}">${escapeHtml(label)} <span style="opacity:0.5">${escapeHtml(kind)}</span></a>`;
           }).join('')

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -260,6 +260,53 @@ test("reindexFile updates symbols and code map after file change", async () => {
   assert.ok(codeMap.text.includes("title?: string"), "code map should reflect new signature");
 });
 
+test("buildProjectIndex preserves colliding top-level symbols with distinct display names", async () => {
+  const workspaceRoot = await mkdtemp(path.join(tmpdir(), "minicode-colliding-symbols-"));
+  const samplePath = path.join(workspaceRoot, "sample.ts");
+  const content = `export interface Employee {
+  id: string;
+}
+
+export class Employee {
+  constructor(public id: string) {}
+}
+`;
+  await writeFile(samplePath, content, "utf8");
+
+  const index = await buildProjectIndex(workspaceRoot);
+  const fileSymbols = index.getSymbolsInFile("sample.ts");
+
+  assert.equal(fileSymbols.length, 3, "should preserve interface, class, and constructor");
+
+  const employeeSymbols = fileSymbols.filter((symbol) => symbol.name === "Employee");
+  assert.equal(employeeSymbols.length, 2, "should keep both colliding Employee symbols");
+  assert.notEqual(
+    employeeSymbols[0]!.qualifiedName,
+    employeeSymbols[1]!.qualifiedName,
+    "colliding symbols should have unique internal qualified names",
+  );
+  assert.ok(employeeSymbols.some((symbol) => symbol.displayName === "Employee (interface)"));
+  assert.ok(employeeSymbols.some((symbol) => symbol.displayName === "Employee (class)"));
+
+  const employeeClass = index.getSymbol("Employee (class)");
+  const employeeInterface = index.getSymbol("Employee (interface)");
+  assert.ok(employeeClass, "should resolve colliding class by display name");
+  assert.ok(employeeInterface, "should resolve colliding interface by display name");
+  assert.equal(employeeClass!.kind, "class");
+  assert.equal(employeeInterface!.kind, "interface");
+
+  const codeMap = index.getCodeMap();
+  assert.ok(codeMap.text.includes("interface Employee (interface)"));
+  assert.ok(codeMap.text.includes("class Employee (class)"));
+
+  const resolved = index.getSymbol("Employee");
+  assert.ok(resolved, "bare lookup should still resolve one of the colliding symbols");
+  assert.ok(
+    resolved!.displayName === "Employee (class)" || resolved!.displayName === "Employee (interface)",
+    "resolved symbol should use a disambiguated display name",
+  );
+});
+
 test("TypeScript plugin indexes class expressions assigned to variables", () => {
   const code = `const MyClass = class MyClass {
   constructor(name) {

--- a/tests/search-code-map.test.ts
+++ b/tests/search-code-map.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { tmpdir } from "node:os";
 import { test } from "node:test";
 
 import { buildProjectIndex } from "../src/indexer/project-index.js";
@@ -40,4 +42,28 @@ test("search_code_map appears in tool registry when projectIndex provided", asyn
   const searchCodeMap = schemas.find((s) => s.name === "search_code_map");
 
   assert.ok(searchCodeMap);
+});
+
+test("search_code_map shows colliding symbols with disambiguated display names", async () => {
+  const workspaceRoot = await mkdtemp(path.join(tmpdir(), "minicode-search-collisions-"));
+  await writeFile(
+    path.join(workspaceRoot, "sample.ts"),
+    `export interface Employee {
+  id: string;
+}
+
+export class Employee {
+  constructor(public id: string) {}
+}
+`,
+    "utf8",
+  );
+
+  const projectIndex = await buildProjectIndex(workspaceRoot);
+  const tool = createSearchCodeMapTool(projectIndex);
+
+  const result = await tool.execute({ pattern: "Employee" });
+
+  assert.ok(result.includes("Employee (interface)"));
+  assert.ok(result.includes("Employee (class)"));
 });


### PR DESCRIPTION
## Summary
- preserve colliding top-level symbols instead of overwriting them in the project index
- introduce disambiguated internal qualified names plus human-friendly display names and aliases
- update dependency resolution and user-facing symbol surfaces to use the new naming model, with regression tests for index and search behavior

## Testing
- TMPDIR=/tmp PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm test
- TMPDIR=/tmp PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm run build

Closes #78