### PR TITLE
Auto-open symbol details from graph activity

### DIFF
--- a/src/web/graph.ts
+++ b/src/web/graph.ts
@@ -188,22 +188,13 @@ export async function initGraph(): Promise<void> {
 
 export function highlightAgentActivity(symbolName: string): void {
   if (!cy) return;
-  // If node is already in graph, pulse it
-  const node = findNode(symbolName);
-  if (node) {
-    node.addClass('agent-pulse');
-    setTimeout(() => node.removeClass('agent-pulse'), 2000);
-    return;
-  }
-  // Otherwise, reveal only the specific symbol being read.
-  // Agent activity should stay legible while a turn is in progress;
-  // user-driven graph exploration still expands neighbors explicitly.
-  renderNodeNeighborhoodAndLayout(symbolName, 0);
-  const added = findNode(symbolName);
-  if (added) {
-    added.addClass('agent-pulse');
-    setTimeout(() => added.removeClass('agent-pulse'), 2000);
-  }
+  void focusSymbolInGraph(symbolName, {
+    maxDegrees: 0,
+    pulse: true,
+    pulseDuration: 2000,
+    animate: false,
+    openDetail: true,
+  });
 }
 
 /** Resize the Cytoscape canvas (call after pane resize). */
@@ -277,6 +268,52 @@ function renderNodeNeighborhoodAndLayout(symbolId: string, maxDegrees = 1): void
   refreshAnalysisGraphState();
   if (cy.nodes().length > beforeNodeCount) {
     runLayout();
+  }
+}
+
+interface FocusSymbolOptions {
+  maxDegrees?: number;
+  pulse?: boolean;
+  pulseDuration?: number;
+  animate?: boolean;
+  zoom?: number;
+  flashDuration?: number;
+  openDetail?: boolean;
+}
+
+async function focusSymbolInGraph(symbolId: string, options: FocusSymbolOptions = {}): Promise<void> {
+  if (!cy) return;
+
+  const {
+    maxDegrees = 0,
+    pulse = false,
+    pulseDuration = 1500,
+    animate = false,
+    zoom = 1.2,
+    flashDuration = 1200,
+    openDetail = false,
+  } = options;
+
+  renderNodeNeighborhoodAndLayout(symbolId, maxDegrees);
+  const node = findNode(symbolId);
+  if (!node) return;
+
+  if (animate) {
+    cy.animate({ center: { eles: node }, zoom }, { duration: 300 });
+  }
+
+  if (pulse) {
+    node.addClass('agent-pulse');
+    setTimeout(() => node.removeClass('agent-pulse'), pulseDuration);
+  } else {
+    node.flashClass('highlighted', flashDuration);
+  }
+
+  if (openDetail) {
+    const detailEl = document.getElementById('symbol-detail');
+    if (detailEl) {
+      await showDetail(node, detailEl);
+    }
   }
 }
 
@@ -1116,18 +1153,15 @@ function setupToolbar(): void {
     dropdown.querySelectorAll('.search-result').forEach((el) => {
       el.addEventListener('click', () => {
         const id = (el as HTMLElement).dataset.id || '';
-        expandNodeAndLayout(id);
         searchInput.value = '';
         dropdown.classList.add('hidden');
-
-        if (!cy) return;
-        const targetNode = cy.getElementById(id);
-        if (targetNode.length) {
-          setTimeout(() => {
-            cy!.animate({ center: { eles: targetNode }, zoom: 1.2 }, { duration: 300 });
-            targetNode.flashClass('highlighted', 1500);
-          }, 350);
-        }
+        void focusSymbolInGraph(id, {
+          maxDegrees: 1,
+          animate: true,
+          zoom: 1.2,
+          flashDuration: 1500,
+          openDetail: true,
+        });
       });
     });
   }

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -1382,7 +1382,7 @@ main::-webkit-scrollbar-thumb {
   position: absolute;
   top: 0;
   right: 0;
-  width: 320px;
+  width: 380px;
   min-width: 200px;
   max-width: 80%;
   height: 100%;

--- a/tests/graph-onboarding.test.ts
+++ b/tests/graph-onboarding.test.ts
@@ -12,6 +12,7 @@ test('built CSS contains graph-onboarding styles', () => {
   assert.ok(css.includes('.graph-onboarding-title'), 'CSS should contain .graph-onboarding-title class');
   assert.ok(css.includes('.graph-onboarding-subtitle'), 'CSS should contain .graph-onboarding-subtitle class');
   assert.ok(css.includes('pointer-events: none'), 'onboarding overlay should not block interactions');
+  assert.ok(css.includes('width: 380px;'), 'symbol detail panel should have a wider default width');
 });
 
 test('built JS contains onboarding hint logic', () => {
@@ -67,11 +68,27 @@ test('built JS keeps agent activity reveals narrower than manual expansion', () 
     'JS should define a configurable graph-rendering helper',
   );
   assert.ok(
-    js.includes('renderNodeNeighborhoodAndLayout(symbolName, 0)'),
+    js.includes('maxDegrees: 0'),
     'agent activity should reveal only the active symbol instead of expanding neighbors',
   );
   assert.ok(
-    js.includes('renderNodeNeighborhoodAndLayout(symbolId, 1)'),
+    js.includes('maxDegrees: 1'),
     'intentional graph exploration should still render first-degree neighbors',
+  );
+});
+
+test('built JS auto-opens symbol details for agent activity and graph search selection', () => {
+  const js = readFileSync(join(distWeb, 'app.js'), 'utf-8');
+  assert.ok(
+    js.includes('focusSymbolInGraph'),
+    'JS should define a shared focus helper for graph-driven symbol selection',
+  );
+  assert.ok(
+    js.includes('openDetail: true'),
+    'JS should request the detail panel when focusing symbols from agent activity or search',
+  );
+  assert.ok(
+    js.includes('await showDetail(node, detailEl)'),
+    'JS should populate the symbol detail panel when focus requests it',
   );
 });


### PR DESCRIPTION
## Summary
- auto-open the symbol detail panel when live agent graph activity focuses a symbol
- use the same shared focus path for graph search selection so search results populate the graph and open details immediately
- widen the default symbol detail panel and add built-web regression coverage for the new graph UX

## Testing
- TMPDIR=/tmp PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm test
- TMPDIR=/tmp PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm run build

Closes #82