### PR TITLE
Tune structural analysis signal quality

### DIFF
--- a/src/analysis/structural-analysis.ts
+++ b/src/analysis/structural-analysis.ts
@@ -26,6 +26,7 @@ export interface StructuralSymbolMetric {
   name: string;
   kind: string;
   filePath: string;
+  spanLines: number;
   fanIn: number;
   fanOut: number;
   totalDegree: number;
@@ -87,8 +88,9 @@ function quantile(values: number[], percentile: number): number {
   return sorted[position] ?? 0;
 }
 
-function thresholdFor(values: number[], minimum: number): number {
-  return Math.max(minimum, Math.ceil(quantile(values, 0.9)));
+function thresholdFor(values: number[], minimum: number, percentile = 0.9): number {
+  const activeValues = values.filter((value) => value > 0);
+  return Math.max(minimum, Math.ceil(quantile(activeValues, percentile)));
 }
 
 function uniqueSorted(values: Iterable<string>): string[] {
@@ -183,6 +185,49 @@ function compareFindings(a: StructuralFinding, b: StructuralFinding): number {
   return a.title.localeCompare(b.title);
 }
 
+function shouldSuppressSymbolFinding(metric: StructuralSymbolMetric): boolean {
+  return metric.kind === "interface" || metric.kind === "type";
+}
+
+function isSmallCompositionRootSymbol(metric: StructuralSymbolMetric): boolean {
+  return (
+    (metric.kind === "function" || metric.kind === "method") &&
+    metric.spanLines <= 40 &&
+    metric.fanIn <= 3 &&
+    metric.fanOut >= 8
+  );
+}
+
+function isContractModule(
+  fileSymbols: IndexedSymbol[],
+  fileMetric: StructuralFileMetric,
+): boolean {
+  return (
+    fileSymbols.length > 0 &&
+    fileMetric.efferentCoupling === 0 &&
+    fileSymbols.every((symbol) => symbol.kind === "interface" || symbol.kind === "type")
+  );
+}
+
+function isCompositionRootFile(
+  fileSymbols: IndexedSymbol[],
+  fileMetric: StructuralFileMetric,
+): boolean {
+  const hasConcreteRuntimeSymbol = fileSymbols.some((symbol) =>
+    symbol.kind === "function" ||
+    symbol.kind === "class" ||
+    symbol.kind === "method" ||
+    symbol.kind === "variable"
+  );
+
+  return (
+    hasConcreteRuntimeSymbol &&
+    fileMetric.symbolCount <= 6 &&
+    fileMetric.afferentCoupling <= 3 &&
+    fileMetric.instability >= 0.8
+  );
+}
+
 export function analyzeProjectStructure(projectIndex: ProjectIndex): StructuralAnalysisReport {
   const symbols = [...projectIndex.symbols.values()].sort((a, b) =>
     a.qualifiedName.localeCompare(b.qualifiedName),
@@ -218,6 +263,7 @@ export function analyzeProjectStructure(projectIndex: ProjectIndex): StructuralA
       name: symbol.name,
       kind: symbol.kind,
       filePath: symbol.filePath,
+      spanLines: Math.max(1, symbol.endLine - symbol.startLine + 1),
       fanIn: incoming.length,
       fanOut: outgoing.length,
       totalDegree: incoming.length + outgoing.length,
@@ -288,11 +334,20 @@ export function analyzeProjectStructure(projectIndex: ProjectIndex): StructuralA
     .sort((a, b) => a.filePath.localeCompare(b.filePath));
 
   const thresholds: StructuralAnalysisThresholds = {
-    fanIn: thresholdFor(symbolMetrics.map((metric) => metric.fanIn), 3),
-    fanOut: thresholdFor(symbolMetrics.map((metric) => metric.fanOut), 3),
-    hotspot: thresholdFor(symbolMetrics.map((metric) => metric.totalDegree), 4),
-    fileCoupling: thresholdFor(fileMetrics.map((metric) => metric.totalCoupling), 3),
+    fanIn: thresholdFor(symbolMetrics.map((metric) => metric.fanIn), 3, 0.98),
+    fanOut: thresholdFor(symbolMetrics.map((metric) => metric.fanOut), 3, 0.98),
+    hotspot: thresholdFor(symbolMetrics.map((metric) => metric.totalDegree), 4, 0.99),
+    fileCoupling: thresholdFor(fileMetrics.map((metric) => metric.totalCoupling), 3, 0.95),
   };
+  const fileSymbolsByPath = new Map<string, IndexedSymbol[]>();
+  for (const symbol of symbols) {
+    const list = fileSymbolsByPath.get(symbol.filePath);
+    if (list) {
+      list.push(symbol);
+    } else {
+      fileSymbolsByPath.set(symbol.filePath, [symbol]);
+    }
+  }
 
   const findings: StructuralFinding[] = [];
   const components = findStronglyConnectedComponents(symbolMap, edges);
@@ -301,8 +356,7 @@ export function analyzeProjectStructure(projectIndex: ProjectIndex): StructuralA
     const cycleEdges = edges.filter(
       (edge) => componentSet.has(edge.from) && componentSet.has(edge.to),
     );
-    const hasSelfLoop = component.length === 1 && cycleEdges.some((edge) => edge.from === edge.to);
-    if (component.length < 2 && !hasSelfLoop) {
+    if (component.length < 2) {
       continue;
     }
 
@@ -315,31 +369,30 @@ export function analyzeProjectStructure(projectIndex: ProjectIndex): StructuralA
       id: `cycle:${component.join("->")}`,
       type: "cycle",
       severity: component.length >= 3 ? "high" : "warning",
-      title: hasSelfLoop
-        ? `Self-referential dependency on ${component[0]}`
-        : `Cycle across ${component.length} symbols`,
-      summary: hasSelfLoop
-        ? `${component[0]} depends on itself in the current graph.`
-        : `${component.length} symbols participate in a strongly connected component.`,
+      title: `Cycle across ${component.length} symbols`,
+      summary: `${component.length} symbols participate in a strongly connected component.`,
       symbols: component,
       files,
       metrics: {
         cycleSize: component.length,
         edgeCount: cycleEdges.length,
         fileCount: files.length,
-        hasSelfLoop,
       },
-      rationale: hasSelfLoop
-        ? ["Self-loop detected in the dependency graph for this symbol."]
-        : [
-            "Strongly connected component detected using deterministic cycle analysis.",
-            `Cycle includes ${cycleEdges.length} internal dependency edges across ${files.length} file(s).`,
-          ],
+      rationale: [
+        "Strongly connected component detected using deterministic cycle analysis.",
+        `Cycle includes ${cycleEdges.length} internal dependency edges across ${files.length} file(s).`,
+      ],
     });
   }
 
   for (const metric of symbolMetrics) {
-    if (metric.fanIn >= thresholds.fanIn && metric.fanIn > 0) {
+    if (shouldSuppressSymbolFinding(metric) || isSmallCompositionRootSymbol(metric)) {
+      continue;
+    }
+
+    const isHotspot = metric.totalDegree >= thresholds.hotspot && metric.totalDegree > 0;
+
+    if (!isHotspot && metric.fanIn >= thresholds.fanIn && metric.fanIn > 0) {
       findings.push({
         id: `fanin:${metric.qualifiedName}`,
         type: "fanInOutlier",
@@ -359,7 +412,7 @@ export function analyzeProjectStructure(projectIndex: ProjectIndex): StructuralA
       });
     }
 
-    if (metric.fanOut >= thresholds.fanOut && metric.fanOut > 0) {
+    if (!isHotspot && metric.fanOut >= thresholds.fanOut && metric.fanOut > 0) {
       findings.push({
         id: `fanout:${metric.qualifiedName}`,
         type: "fanOutOutlier",
@@ -379,7 +432,7 @@ export function analyzeProjectStructure(projectIndex: ProjectIndex): StructuralA
       });
     }
 
-    if (metric.totalDegree >= thresholds.hotspot && metric.totalDegree > 0) {
+    if (isHotspot) {
       findings.push({
         id: `hotspot:${metric.qualifiedName}`,
         type: "hotspot",
@@ -408,9 +461,15 @@ export function analyzeProjectStructure(projectIndex: ProjectIndex): StructuralA
       continue;
     }
 
-    const fileSymbols = symbols
-      .filter((symbol) => symbol.filePath === metric.filePath)
-      .map((symbol) => symbol.qualifiedName);
+    const fileSymbolEntries = fileSymbolsByPath.get(metric.filePath) ?? [];
+    if (
+      isContractModule(fileSymbolEntries, metric) ||
+      isCompositionRootFile(fileSymbolEntries, metric)
+    ) {
+      continue;
+    }
+
+    const fileSymbols = fileSymbolEntries.map((symbol) => symbol.qualifiedName);
     findings.push({
       id: `file-coupling:${metric.filePath}`,
       type: "fileCoupling",

--- a/src/indexer/plugins/typescript.ts
+++ b/src/indexer/plugins/typescript.ts
@@ -340,7 +340,10 @@ function createPlugin(): LanguagePlugin {
         targetKinds?: IndexedSymbol["kind"][],
       ): void {
         const fromMatches = resolveCandidates(rawFrom, filePath);
-        const toMatches = resolveCandidates(rawTo, undefined, targetKinds);
+        const sameFileTargets = resolveCandidates(rawTo, filePath, targetKinds);
+        const toMatches = sameFileTargets.length > 0
+          ? sameFileTargets
+          : resolveCandidates(rawTo, undefined, targetKinds);
         for (const fromSymbol of fromMatches) {
           for (const toSymbol of toMatches) {
             addEdge(fromSymbol.qualifiedName, toSymbol.qualifiedName, kind);

--- a/src/indexer/symbol-names.ts
+++ b/src/indexer/symbol-names.ts
@@ -8,34 +8,34 @@ function buildDisplayName(
   baseName: string,
   symbol: IndexedSymbol,
   kindCount: number,
-  fileCount: number,
+  distinctFileCount: number,
 ): string {
+  if (distinctFileCount > 1) {
+    return `${baseName} (${symbol.kind} in ${symbol.filePath}:${symbol.startLine})`;
+  }
+
   if (kindCount === 1) {
     return `${baseName} (${symbol.kind})`;
   }
 
-  if (fileCount === 1) {
-    return `${baseName} (${symbol.kind}:${symbol.startLine})`;
-  }
-
-  return `${baseName} (${symbol.kind} in ${symbol.filePath}:${symbol.startLine})`;
+  return `${baseName} (${symbol.kind}:${symbol.startLine})`;
 }
 
 function buildQualifiedName(
   baseName: string,
   symbol: IndexedSymbol,
   kindCount: number,
-  fileCount: number,
+  distinctFileCount: number,
 ): string {
+  if (distinctFileCount > 1) {
+    return `${baseName}#${symbol.kind}@${symbol.filePath}:${symbol.startLine}`;
+  }
+
   if (kindCount === 1) {
     return `${baseName}#${symbol.kind}`;
   }
 
-  if (fileCount === 1) {
-    return `${baseName}#${symbol.kind}:${symbol.startLine}`;
-  }
-
-  return `${baseName}#${symbol.kind}@${symbol.filePath}:${symbol.startLine}`;
+  return `${baseName}#${symbol.kind}:${symbol.startLine}`;
 }
 
 function countByKind(symbols: IndexedSymbol[]): Map<SymbolKind, number> {
@@ -101,13 +101,12 @@ export function normalizeIndexedSymbols(
       a.kind.localeCompare(b.kind),
     );
     const kindCounts = countByKind(sorted);
-    const fileCounts = countByFile(sorted);
+    const distinctFileCount = countByFile(sorted).size;
 
     for (const symbol of sorted) {
       const kindCount = kindCounts.get(symbol.kind) ?? 1;
-      const fileCount = fileCounts.get(symbol.filePath) ?? 1;
-      const displayName = buildDisplayName(baseName, symbol, kindCount, fileCount);
-      const qualifiedName = buildQualifiedName(baseName, symbol, kindCount, fileCount);
+      const displayName = buildDisplayName(baseName, symbol, kindCount, distinctFileCount);
+      const qualifiedName = buildQualifiedName(baseName, symbol, kindCount, distinctFileCount);
 
       symbol.displayName = displayName;
       symbol.aliases = dedupe([

--- a/src/web/analysis-helpers.ts
+++ b/src/web/analysis-helpers.ts
@@ -6,6 +6,7 @@ export type StructuralFindingType =
   | "fileCoupling";
 
 export type StructuralFindingSeverity = "info" | "warning" | "high";
+export type AnalysisFindingFilter = "all" | "cycle" | "hotspot" | "fileCoupling";
 
 export interface StructuralFinding {
   id: string;
@@ -148,4 +149,14 @@ export function countFindingsByType(findings: StructuralFinding[]): Record<Struc
       fileCoupling: 0,
     },
   );
+}
+
+export function filterFindings(
+  findings: StructuralFinding[],
+  filter: AnalysisFindingFilter,
+): StructuralFinding[] {
+  if (filter === "all") {
+    return findings;
+  }
+  return findings.filter((finding) => finding.type === filter);
 }

--- a/src/web/graph.ts
+++ b/src/web/graph.ts
@@ -7,8 +7,10 @@ import {
   buildFindingGraphContext,
   buildFindingMetricChips,
   countFindingsByType,
+  filterFindings,
   findingSeverityLabel,
   findingTypeLabel,
+  type AnalysisFindingFilter,
   type StructuralAnalysisReport,
 } from './analysis-helpers.ts';
 import { KIND_COLORS, buildStylesheet } from '../shared/graph-styles.ts';
@@ -91,6 +93,7 @@ let allSymbolNames: string[] = [];
 let initialized = false;
 let analysisReport: StructuralAnalysisReport | null = null;
 let activeAnalysisFindingId: string | null = null;
+let activeAnalysisFilter: AnalysisFindingFilter = 'all';
 const analysisExplanationCache = new Map<string, string>();
 
 const LAYOUT_OPTIONS: Record<string, unknown> = {
@@ -434,7 +437,7 @@ function refreshAnalysisGraphState(): void {
 
   const candidateNodeIds = new Set<string>();
   const candidateEdgeIds = new Set<string>();
-  for (const finding of analysisReport.findings) {
+  for (const finding of getVisibleAnalysisFindings()) {
     const context = buildFindingGraphContext(finding, graphEdges);
     for (const nodeId of context.nodes) candidateNodeIds.add(nodeId);
     for (const edgeId of context.edgeIds) candidateEdgeIds.add(edgeId);
@@ -448,7 +451,7 @@ function refreshAnalysisGraphState(): void {
   }
 
   if (!activeAnalysisFindingId) return;
-  const activeFinding = analysisReport.findings.find((finding) => finding.id === activeAnalysisFindingId);
+  const activeFinding = getVisibleAnalysisFindings().find((finding) => finding.id === activeAnalysisFindingId);
   if (!activeFinding) return;
 
   const activeContext = buildFindingGraphContext(activeFinding, graphEdges);
@@ -460,36 +463,52 @@ function refreshAnalysisGraphState(): void {
   }
 }
 
+function getVisibleAnalysisFindings(): ReturnType<typeof filterFindings> {
+  return analysisReport ? filterFindings(analysisReport.findings, activeAnalysisFilter) : [];
+}
+
 function renderAnalysisSummary(report: StructuralAnalysisReport): void {
   const { summary } = getAnalysisPanelEls();
   const counts = countFindingsByType(report.findings);
   const cards = [
-    { label: 'Findings', value: report.summary.findingCount },
-    { label: 'Cycles', value: counts.cycle },
-    { label: 'Hotspots', value: counts.hotspot },
-    { label: 'Coupling', value: counts.fileCoupling },
+    { label: 'Findings', value: report.summary.findingCount, filter: 'all' as const },
+    { label: 'Cycles', value: counts.cycle, filter: 'cycle' as const },
+    { label: 'Hotspots', value: counts.hotspot, filter: 'hotspot' as const },
+    { label: 'Coupling', value: counts.fileCoupling, filter: 'fileCoupling' as const },
   ];
   summary.innerHTML = cards.map((card) => `
-    <div class="analysis-summary-card">
+    <button
+      class="analysis-summary-card ${card.filter === activeAnalysisFilter ? 'active' : ''}"
+      data-filter="${card.filter}"
+      type="button"
+    >
       <span class="analysis-summary-value">${card.value}</span>
       <span class="analysis-summary-label">${escapeHtml(card.label)}</span>
-    </div>
+    </button>
   `).join('');
+
+  summary.querySelectorAll('.analysis-summary-card').forEach((el) => {
+    el.addEventListener('click', () => {
+      const filter = ((el as HTMLElement).dataset.filter || 'all') as AnalysisFindingFilter;
+      setAnalysisFilter(filter);
+    });
+  });
 }
 
 function renderAnalysisFindings(report: StructuralAnalysisReport): void {
   const { findings } = getAnalysisPanelEls();
+  const visibleFindings = filterFindings(report.findings, activeAnalysisFilter);
 
-  if (report.findings.length === 0) {
+  if (visibleFindings.length === 0) {
     findings.innerHTML = `
       <div class="analysis-empty">
-        No structural outliers cleared the current thresholds for this graph snapshot.
+        No ${escapeHtml(activeAnalysisFilter === 'all' ? 'structural outliers' : findingTypeLabel(activeAnalysisFilter).toLowerCase())} cleared the current thresholds for this graph snapshot.
       </div>
     `;
     return;
   }
 
-  findings.innerHTML = report.findings.map((finding) => {
+  findings.innerHTML = visibleFindings.map((finding) => {
     const metricChips = buildFindingMetricChips(finding)
       .map((chip) => `<span class="analysis-metric-chip">${escapeHtml(chip)}</span>`)
       .join('');
@@ -562,6 +581,25 @@ function setActiveFindingCard(findingId: string | null): void {
   });
 }
 
+function setAnalysisFilter(filter: AnalysisFindingFilter): void {
+  const nextFilter = activeAnalysisFilter === filter ? 'all' : filter;
+  activeAnalysisFilter = nextFilter;
+
+  if (!analysisReport) {
+    return;
+  }
+
+  const visibleFindings = filterFindings(analysisReport.findings, activeAnalysisFilter);
+  if (activeAnalysisFindingId && !visibleFindings.some((finding) => finding.id === activeAnalysisFindingId)) {
+    activeAnalysisFindingId = null;
+  }
+
+  renderAnalysisSummary(analysisReport);
+  renderAnalysisFindings(analysisReport);
+  refreshAnalysisGraphState();
+  setActiveFindingCard(activeAnalysisFindingId);
+}
+
 async function runStructuralAnalysis(): Promise<void> {
   const { panel, findings } = getAnalysisPanelEls();
   panel.classList.remove('hidden');
@@ -577,6 +615,7 @@ async function runStructuralAnalysis(): Promise<void> {
     const report = await res.json() as StructuralAnalysisReport;
     analysisReport = report;
     activeAnalysisFindingId = null;
+    activeAnalysisFilter = 'all';
     analysisExplanationCache.clear();
     clearAnalysisStatus();
     setAnalysisStatus(
@@ -588,6 +627,7 @@ async function runStructuralAnalysis(): Promise<void> {
   } catch (error) {
     analysisReport = null;
     activeAnalysisFindingId = null;
+    activeAnalysisFilter = 'all';
     analysisExplanationCache.clear();
     clearAnalysisGraphClasses();
     getAnalysisPanelEls().summary.innerHTML = '';

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -1124,10 +1124,27 @@ main::-webkit-scrollbar-thumb {
 }
 
 .analysis-summary-card {
+  appearance: none;
+  width: 100%;
+  text-align: left;
   border: 1px solid rgba(122, 162, 247, 0.14);
   border-radius: 12px;
   background: rgba(31, 35, 53, 0.72);
   padding: 12px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, transform 0.15s ease, background 0.15s ease;
+}
+
+.analysis-summary-card:hover {
+  border-color: rgba(122, 162, 247, 0.3);
+  background: rgba(36, 40, 60, 0.82);
+  transform: translateY(-1px);
+}
+
+.analysis-summary-card.active {
+  border-color: rgba(122, 162, 247, 0.38);
+  background: rgba(34, 41, 67, 0.92);
+  box-shadow: 0 0 0 1px rgba(122, 162, 247, 0.16);
 }
 
 .analysis-summary-value {

--- a/tests/analysis-helpers.test.ts
+++ b/tests/analysis-helpers.test.ts
@@ -5,6 +5,7 @@ import {
   buildFindingGraphContext,
   buildFindingMetricChips,
   countFindingsByType,
+  filterFindings,
   findingTypeLabel,
   type StructuralFinding,
 } from "../src/web/analysis-helpers.js";
@@ -99,4 +100,6 @@ test("analysis helpers summarize types and metrics for rendering", () => {
   assert.deepEqual(buildFindingMetricChips(findings[0]!), ["fan-in 5", "threshold 3"]);
   assert.deepEqual(buildFindingMetricChips(findings[1]!), ["coupling 4", "instability 0.75"]);
   assert.equal(findingTypeLabel("fileCoupling"), "File coupling");
+  assert.deepEqual(filterFindings(findings, "all").map((finding) => finding.id), ["fanin:util", "file:service"]);
+  assert.deepEqual(filterFindings(findings, "fileCoupling").map((finding) => finding.id), ["file:service"]);
 });

--- a/tests/analysis-ui.test.ts
+++ b/tests/analysis-ui.test.ts
@@ -20,6 +20,7 @@ test("built CSS contains analysis drawer and finding card styles", () => {
   assert.ok(css.includes("#analysis-panel"), "CSS should contain analysis panel styles");
   assert.ok(css.includes(".analysis-finding"), "CSS should contain finding card styles");
   assert.ok(css.includes(".analysis-summary-card"), "CSS should contain summary card styles");
+  assert.ok(css.includes(".analysis-summary-card.active"), "CSS should style the active analysis filter");
   assert.ok(css.includes(".analysis-explanation"), "CSS should contain AI explanation styles");
 });
 
@@ -30,4 +31,6 @@ test("built JS contains structural analysis loading and highlighting logic", () 
   assert.ok(js.includes("analysis-selected"), "JS should apply selected analysis highlight classes");
   assert.ok(js.includes("graph-derived structural signals"), "JS should surface deterministic analysis messaging");
   assert.ok(js.includes("AI interpretation"), "JS should label advisory AI interpretation distinctly");
+  assert.ok(js.includes("activeAnalysisFilter"), "JS should track the active analysis filter");
+  assert.ok(js.includes("data-filter"), "JS should wire summary cards into finding filters");
 });

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -8,6 +8,7 @@ import { generateCodeMap } from "../src/indexer/code-map.js";
 import { getPluginForFile, loadPlugins } from "../src/indexer/plugin-loader.js";
 import { buildProjectIndex } from "../src/indexer/project-index.js";
 import { typescriptPlugin } from "../src/indexer/plugins/typescript.js";
+import { normalizeIndexedSymbols } from "../src/indexer/symbol-names.js";
 
 const SAMPLE_TS = `
 export interface Foo {
@@ -456,4 +457,66 @@ function beta() {}
     (e) => e.from === "alpha" && e.to === "beta" && e.kind === "calls",
   );
   assert.ok(callEdge, "should resolve dependencies even without cached AST");
+});
+
+test("resolveDependencies prefers same-file symbols over same-named helpers in other files", () => {
+  const projectIndexCode = `
+async function collectSourceFiles(dir: string): Promise<void> {
+  await collectSourceFiles(dir + "/nested");
+}
+
+export async function buildProjectIndex(): Promise<void> {
+  await collectSourceFiles("src");
+}
+`;
+
+  const cacheCode = `
+async function collectSourceFiles(dir: string): Promise<void> {
+  await collectSourceFiles(dir + "/cached");
+}
+
+export async function computeFileHashes(): Promise<void> {
+  await collectSourceFiles("src");
+}
+`;
+
+  const byFile = new Map([
+    ["src/indexer/project-index.ts", typescriptPlugin.indexFile("src/indexer/project-index.ts", projectIndexCode)],
+    ["src/indexer/cache.ts", typescriptPlugin.indexFile("src/indexer/cache.ts", cacheCode)],
+  ]);
+  const symbols = [...normalizeIndexedSymbols(byFile).values()];
+  const projectFiles = new Map([
+    ["src/indexer/project-index.ts", projectIndexCode],
+    ["src/indexer/cache.ts", cacheCode],
+  ]);
+  const edges = typescriptPlugin.resolveDependencies!(symbols, projectFiles);
+  const projectHelper = symbols.find(
+    (symbol) => symbol.name === "collectSourceFiles" && symbol.filePath === "src/indexer/project-index.ts",
+  );
+  const cacheHelper = symbols.find(
+    (symbol) => symbol.name === "collectSourceFiles" && symbol.filePath === "src/indexer/cache.ts",
+  );
+
+  assert.ok(projectHelper, "project-index helper should be uniquely preserved after normalization");
+  assert.ok(cacheHelper, "cache helper should be uniquely preserved after normalization");
+
+  const projectSelfEdge = edges.find(
+    (edge) => edge.from === projectHelper?.qualifiedName
+      && edge.to === projectHelper?.qualifiedName
+      && edge.kind === "calls",
+  );
+  const cacheSelfEdge = edges.find(
+    (edge) => edge.from === cacheHelper?.qualifiedName
+      && edge.to === cacheHelper?.qualifiedName
+      && edge.kind === "calls",
+  );
+  const crossFileEdge = edges.find(
+    (edge) => edge.from === projectHelper?.qualifiedName
+      && edge.to === cacheHelper?.qualifiedName
+      && edge.kind === "calls",
+  );
+
+  assert.ok(projectSelfEdge, "project-index helper should resolve recursive calls to itself");
+  assert.ok(cacheSelfEdge, "cache helper should resolve recursive calls to itself");
+  assert.ok(!crossFileEdge, "same-named helpers in other files should not be linked by default");
 });

--- a/tests/serve.integration.test.ts
+++ b/tests/serve.integration.test.ts
@@ -160,6 +160,7 @@ class MockBridge extends AgentBridge {
           name: "foo",
           kind: "function",
           filePath: "src/foo.ts",
+          spanLines: 12,
           fanIn: 1,
           fanOut: 3,
           totalDegree: 4,

--- a/tests/structural-analysis.test.ts
+++ b/tests/structural-analysis.test.ts
@@ -5,7 +5,13 @@ import type { DependencyEdge, IndexedSymbol } from "@minicode/agent-sdk";
 import { analyzeProjectStructure } from "../src/analysis/structural-analysis.js";
 import { createProjectIndex } from "../src/indexer/project-index.js";
 
-function makeSymbol(qualifiedName: string, filePath: string, kind: IndexedSymbol["kind"] = "function"): IndexedSymbol {
+function makeSymbol(
+  qualifiedName: string,
+  filePath: string,
+  kind: IndexedSymbol["kind"] = "function",
+  startLine = 1,
+  endLine = 5,
+): IndexedSymbol {
   const shortName = qualifiedName.includes(".")
     ? qualifiedName.slice(qualifiedName.lastIndexOf(".") + 1)
     : qualifiedName;
@@ -15,8 +21,8 @@ function makeSymbol(qualifiedName: string, filePath: string, kind: IndexedSymbol
     qualifiedName,
     kind,
     filePath,
-    startLine: 1,
-    endLine: 5,
+    startLine,
+    endLine,
     signature: `${kind} ${qualifiedName}`,
     exported: true,
     dependencies: [],
@@ -85,17 +91,17 @@ test("analyzeProjectStructure reports cycles, symbol outliers, and file coupling
   assert.ok(fanInFinding);
   assert.equal(fanInFinding?.metrics.fanIn, 3);
 
-  const fanOutFinding = report.findings.find(
-    (finding) => finding.type === "fanOutOutlier" && finding.symbols.includes("service"),
-  );
-  assert.ok(fanOutFinding);
-  assert.equal(fanOutFinding?.metrics.fanOut, 3);
-
   const hotspotFinding = report.findings.find(
     (finding) => finding.type === "hotspot" && finding.symbols.includes("service"),
   );
   assert.ok(hotspotFinding);
   assert.equal(hotspotFinding?.metrics.totalDegree, 4);
+  assert.ok(
+    !report.findings.some(
+      (finding) => finding.type === "fanOutOutlier" && finding.symbols.includes("service"),
+    ),
+    "hotspot findings should absorb overlapping fan-out outliers for the same symbol",
+  );
 
   const fileFinding = report.findings.find(
     (finding) => finding.type === "fileCoupling" && finding.files.includes("src/service.ts"),
@@ -124,4 +130,172 @@ test("analyzeProjectStructure stays empty for disconnected graphs", () => {
   assert.equal(report.summary.cycleCount, 0);
   assert.equal(report.fileMetrics.length, 2);
   assert.equal(report.symbolMetrics[0]?.totalDegree, 0);
+});
+
+test("analyzeProjectStructure avoids flagging routine fan-out in skewed graphs", () => {
+  const symbols: IndexedSymbol[] = [makeSymbol("sharedUtil", "src/shared.ts")];
+  const edges: DependencyEdge[] = [];
+
+  for (let i = 0; i < 40; i += 1) {
+    const worker = `worker${i}`;
+    symbols.push(makeSymbol(worker, `src/workers/${worker}.ts`));
+    edges.push({ from: worker, to: "sharedUtil", kind: "calls" });
+  }
+
+  for (let i = 0; i < 5; i += 1) {
+    const orchestrator = `orchestrator${i}`;
+    symbols.push(makeSymbol(orchestrator, `src/orchestrators/${orchestrator}.ts`, "function", 1, 80));
+    for (let j = 0; j < 10; j += 1) {
+      const leaf = `${orchestrator}.leaf${j}`;
+      symbols.push(makeSymbol(leaf, `src/orchestrators/${orchestrator}.ts`));
+      edges.push({ from: orchestrator, to: leaf, kind: "calls" });
+    }
+  }
+
+  const report = analyzeProjectStructure(buildTestIndex(symbols, edges));
+
+  assert.equal(report.summary.thresholds.fanOut, 10);
+
+  const fanOutFindings = report.findings.filter((finding) => finding.type === "fanOutOutlier");
+  assert.equal(fanOutFindings.length, 5);
+  assert.ok(fanOutFindings.every((finding) => finding.symbols[0]?.startsWith("orchestrator")));
+  assert.ok(report.findings.every((finding) => !finding.symbols.includes("worker0")));
+});
+
+test("analyzeProjectStructure keeps fan-out findings for non-hotspot orchestrators", () => {
+  const symbols: IndexedSymbol[] = [
+    makeSymbol("orchestrator", "src/orchestrator.ts", "function", 1, 80),
+  ];
+  const edges: DependencyEdge[] = [];
+
+  for (let i = 0; i < 3; i += 1) {
+    const shared = `shared${i}`;
+    symbols.push(makeSymbol(shared, `src/shared/${shared}.ts`));
+    edges.push({ from: "orchestrator", to: shared, kind: "calls" });
+  }
+
+  const report = analyzeProjectStructure(buildTestIndex(symbols, edges));
+  const fanOutFinding = report.findings.find(
+    (finding) => finding.type === "fanOutOutlier" && finding.symbols.includes("orchestrator"),
+  );
+
+  assert.ok(fanOutFinding, "high fan-out should still surface when the symbol is not also a hotspot");
+  assert.ok(
+    !report.findings.some(
+      (finding) => finding.type === "hotspot" && finding.symbols.includes("orchestrator"),
+    ),
+    "fan-out only orchestrators should not be forced into hotspot findings",
+  );
+});
+
+test("analyzeProjectStructure ignores self-recursive loops and suppresses shared type hubs", () => {
+  const symbols = [
+    makeSymbol("SharedConfig", "src/types.ts", "interface"),
+    makeSymbol("loadConfig", "src/load.ts"),
+    makeSymbol("saveConfig", "src/save.ts"),
+    makeSymbol("runConfigFlow", "src/flow.ts"),
+    makeSymbol("walk", "src/walk.ts"),
+  ];
+  const edges: DependencyEdge[] = [
+    { from: "loadConfig", to: "SharedConfig", kind: "references" },
+    { from: "saveConfig", to: "SharedConfig", kind: "references" },
+    { from: "runConfigFlow", to: "SharedConfig", kind: "references" },
+    { from: "walk", to: "walk", kind: "calls" },
+  ];
+
+  const report = analyzeProjectStructure(buildTestIndex(symbols, edges));
+
+  assert.ok(!report.findings.some((finding) => finding.type === "cycle"), "self-recursion should not surface as a cycle finding");
+  assert.ok(
+    !report.findings.some(
+      (finding) => finding.type !== "fileCoupling" && finding.symbols.includes("SharedConfig"),
+    ),
+    "shared type/interface hubs should not produce symbol-level findings by default",
+  );
+});
+
+test("analyzeProjectStructure suppresses contract modules and composition roots at the file level", () => {
+  const symbols = [
+    makeSymbol("SharedConfig", "src/types.ts", "interface"),
+    makeSymbol("SharedEvent", "src/types.ts", "type"),
+    makeSymbol("loadConfig", "src/load.ts"),
+    makeSymbol("saveConfig", "src/save.ts"),
+    makeSymbol("runWorkflow", "src/run.ts"),
+    makeSymbol("auditWorkflow", "src/audit.ts"),
+    makeSymbol("bridgeRuntime", "src/bridge.ts"),
+    makeSymbol("buildShell", "src/bootstrap.ts"),
+    makeSymbol("helperA", "src/helpers/a.ts"),
+    makeSymbol("helperB", "src/helpers/b.ts"),
+    makeSymbol("helperC", "src/helpers/c.ts"),
+    makeSymbol("helperD", "src/helpers/d.ts"),
+  ];
+  const edges: DependencyEdge[] = [
+    { from: "loadConfig", to: "SharedConfig", kind: "references" },
+    { from: "saveConfig", to: "SharedConfig", kind: "references" },
+    { from: "runWorkflow", to: "SharedConfig", kind: "references" },
+    { from: "auditWorkflow", to: "SharedEvent", kind: "references" },
+    { from: "loadConfig", to: "bridgeRuntime", kind: "calls" },
+    { from: "saveConfig", to: "bridgeRuntime", kind: "calls" },
+    { from: "bridgeRuntime", to: "helperA", kind: "calls" },
+    { from: "bridgeRuntime", to: "helperB", kind: "calls" },
+    { from: "buildShell", to: "helperA", kind: "calls" },
+    { from: "buildShell", to: "helperB", kind: "calls" },
+    { from: "buildShell", to: "helperC", kind: "calls" },
+    { from: "buildShell", to: "helperD", kind: "calls" },
+  ];
+
+  const report = analyzeProjectStructure(buildTestIndex(symbols, edges));
+  const fileCouplingFiles = report.findings
+    .filter((finding) => finding.type === "fileCoupling")
+    .flatMap((finding) => finding.files);
+
+  assert.ok(
+    !fileCouplingFiles.includes("src/types.ts"),
+    "pure contract modules should not surface as file-coupling smells",
+  );
+  assert.ok(
+    !fileCouplingFiles.includes("src/bootstrap.ts"),
+    "obvious composition roots should not surface as file-coupling smells",
+  );
+  assert.ok(
+    fileCouplingFiles.includes("src/bridge.ts"),
+    "runtime bridge files with meaningful inbound and outbound coupling should still surface",
+  );
+});
+
+test("analyzeProjectStructure suppresses small composition-root hotspot symbols but keeps long orchestrators", () => {
+  const symbols = [
+    makeSymbol("composeTools", "src/registry.ts", "function", 1, 28),
+    makeSymbol("runRuntime", "src/runtime.ts", "function", 1, 120),
+  ];
+  const edges: DependencyEdge[] = [];
+
+  for (let i = 0; i < 3; i += 1) {
+    const caller = `caller${i}`;
+    symbols.push(makeSymbol(caller, `src/callers/${caller}.ts`));
+    edges.push({ from: caller, to: "composeTools", kind: "calls" });
+  }
+
+  for (let i = 0; i < 12; i += 1) {
+    const dep = `dep${i}`;
+    symbols.push(makeSymbol(dep, `src/deps/${dep}.ts`));
+    edges.push({ from: "composeTools", to: dep, kind: "calls" });
+  }
+
+  for (let i = 0; i < 16; i += 1) {
+    const dep = `runtimeDep${i}`;
+    symbols.push(makeSymbol(dep, `src/runtime/deps/${dep}.ts`));
+    edges.push({ from: "runRuntime", to: dep, kind: "calls" });
+  }
+
+  const report = analyzeProjectStructure(buildTestIndex(symbols, edges));
+
+  assert.ok(
+    !report.findings.some((finding) => finding.symbols.includes("composeTools")),
+    "small composition-root helpers should not surface as structural outliers by default",
+  );
+  assert.ok(
+    report.findings.some((finding) => finding.symbols.includes("runRuntime")),
+    "long orchestrators should still surface when they fan out broadly",
+  );
 });


### PR DESCRIPTION
## Summary
- reduce noisy structural-analysis findings by suppressing contract modules and small composition-root helpers
- keep the analysis drawer filterable by finding type and preserve graph highlighting for the visible set
- tighten regression coverage for analyzer tuning, same-name symbol resolution, and analysis UI behavior

## Verification
- TMPDIR=/tmp PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm test
- TMPDIR=/tmp PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm run build