### PR TITLE
Improve turn limit guidance when maxSteps is reached

### DIFF
--- a/packages/agent-sdk/src/agent/agent.ts
+++ b/packages/agent-sdk/src/agent/agent.ts
@@ -1,6 +1,6 @@
 import { buildSystemPrompt } from "../prompt/system-prompt.js";
 import type { CodeMapResult } from "../indexer/types.js";
-import { ensureStepWithinLimit } from "../safety/guardrails.js";
+import { ensureStepWithinLimit, formatStepLimitMessage } from "../safety/guardrails.js";
 import { Session } from "../session/session.js";
 import type { CompactionResult } from "../session/session.js";
 import { ToolRegistry } from "../tools/registry.js";
@@ -577,8 +577,7 @@ export class CodingAgent {
       }
     }
 
-    const stepLimitMessage =
-      "Reached the maximum number of steps for this turn. I stopped to avoid an infinite loop.";
+    const stepLimitMessage = formatStepLimitMessage(this.config.maxSteps);
     this.session.addMessage({
       role: "assistant",
       content: stepLimitMessage,

--- a/packages/agent-sdk/src/safety/guardrails.ts
+++ b/packages/agent-sdk/src/safety/guardrails.ts
@@ -67,11 +67,17 @@ export function isDestructiveCommand(command: string): boolean {
   return DESTRUCTIVE_COMMAND_PATTERNS.some((pattern) => pattern.test(command));
 }
 
+export function formatStepLimitMessage(maxSteps: number): string {
+  return [
+    `Reached the turn call limit (${maxSteps}) for this turn, so I paused here.`,
+    'Type "continue" to let me keep working from the current session.',
+    'If you want longer turns by default, increase the turn call limit (maxSteps) in Settings or with /config set maxSteps <n>.',
+  ].join(" ");
+}
+
 export function ensureStepWithinLimit(step: number, maxSteps: number): void {
   if (step >= maxSteps) {
-    throw new Error(
-      `Reached maximum step limit (${maxSteps}). Stopping tool loop.`,
-    );
+    throw new Error(formatStepLimitMessage(maxSteps));
   }
 }
 

--- a/packages/agent-sdk/tests/agent.test.ts
+++ b/packages/agent-sdk/tests/agent.test.ts
@@ -215,7 +215,9 @@ test("agent respects maxSteps limit", async () => {
   });
 
   const { text } = await agent.runTurn("Go forever");
-  assert.match(text, /maximum number of steps/);
+  assert.match(text, /turn call limit/);
+  assert.match(text, /Type "continue"/);
+  assert.match(text, /maxSteps/);
   assert.equal(callCount, 2);
 });
 

--- a/packages/agent-sdk/tests/guardrails.test.ts
+++ b/packages/agent-sdk/tests/guardrails.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   ensureStepWithinLimit,
+  formatStepLimitMessage,
   isDestructiveCommand,
   resolveWorkspacePath,
   validateCommand,
@@ -62,12 +63,19 @@ test("isDestructiveCommand returns false for safe commands", () => {
 test("ensureStepWithinLimit throws at limit", () => {
   assert.throws(
     () => ensureStepWithinLimit(10, 10),
-    /maximum step limit/,
+    /turn call limit/,
   );
 });
 
 test("ensureStepWithinLimit allows steps below limit", () => {
   assert.doesNotThrow(() => ensureStepWithinLimit(5, 10));
+});
+
+test("formatStepLimitMessage explains how to continue and adjust the limit", () => {
+  const message = formatStepLimitMessage(10);
+  assert.match(message, /Type "continue"/);
+  assert.match(message, /Settings/);
+  assert.match(message, /maxSteps/);
 });
 
 test("validateFileReadSize throws for oversized files", () => {

--- a/src/agent/editable-config.ts
+++ b/src/agent/editable-config.ts
@@ -88,7 +88,7 @@ export const EDITABLE_CONFIG_DEFINITIONS: readonly EditableConfigDefinition[] = 
     fileKey: "maxSteps",
     envVar: "MAX_STEPS",
     type: "number",
-    description: "Maximum agent loop steps per turn",
+    description: "Turn call limit before the agent pauses and waits for another prompt",
   },
   {
     key: "maxTokens",

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -57,6 +57,31 @@ class RepeatingModelClient implements ModelClient {
   }
 }
 
+class InfiniteToolModelClient implements ModelClient {
+  private callCount = 0;
+
+  getCalls(): number {
+    return this.callCount;
+  }
+
+  async chat(params: {
+    model: string;
+    system: string;
+    messages: SessionMessage[];
+    tools: ToolSchema[];
+    maxTokens: number;
+  }): Promise<ModelResponse> {
+    void params;
+    this.callCount += 1;
+    return {
+      text: `step ${this.callCount}`,
+      toolCalls: [{ id: `tool-${this.callCount}`, name: "echo_tool", input: { value: String(this.callCount) } }],
+      stopReason: "tool_use",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    };
+  }
+}
+
 function createEchoTool(): ToolDefinition {
   return {
     name: "echo_tool",
@@ -114,6 +139,24 @@ test("agent stops on repeated identical tool calls", async () => {
 
   const { text } = await agent.runTurn("Do something");
   assert.match(text, /repeated identical tool calls/);
+});
+
+test("agent tells the user how to continue when the turn call limit is reached", async () => {
+  const config = createTestAgentConfig("/tmp");
+  config.maxSteps = 2;
+  const modelClient = new InfiniteToolModelClient();
+
+  const agent = new CodingAgent({
+    config,
+    modelClient,
+    toolRegistry: new ToolRegistry([createEchoTool()]),
+  });
+
+  const { text } = await agent.runTurn("Keep working");
+  assert.match(text, /turn call limit/);
+  assert.match(text, /Type "continue"/);
+  assert.match(text, /Settings/);
+  assert.equal(modelClient.getCalls(), 2);
 });
 
 test("agent omits code map when projectIndex is not provided", async () => {

--- a/tests/config-api.test.ts
+++ b/tests/config-api.test.ts
@@ -130,7 +130,7 @@ test("GET /api/config returns structured editable settings payload", async () =>
     assert.equal(maxSteps?.globalValue, null);
     assert.equal(maxSteps?.envValue, null);
     assert.equal(maxSteps?.overriddenByEnv, false);
-    assert.match(maxSteps?.description ?? "", /Maximum agent loop steps per turn/);
+    assert.match(maxSteps?.description ?? "", /Turn call limit/);
   });
 });
 


### PR DESCRIPTION
## Summary
- improve the shared maxSteps fallback message so it tells users to type `continue` and points them to the turn call limit setting
- update the editable settings description to use the same turn call limit wording
- add regression coverage in both the SDK and app-layer tests

## Verification
- TMPDIR=/tmp PATH=/tmp/node-v22.14.0-linux-x64/bin:/mnt/c/Users/seanh/.codex/tmp/arg0/codex-arg0jIHcgz:/mnt/c/Users/seanh/.codex/bin/wsl:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib:/mnt/c/Program Files/Oculus/Support/oculus-runtime:/mnt/c/WINDOWS/system32:/mnt/c/WINDOWS:/mnt/c/WINDOWS/System32/Wbem:/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/:/mnt/c/WINDOWS/System32/OpenSSH/:/mnt/c/Program Files/Go/bin:/mnt/c/ProgramData/chocolatey/bin:/mnt/c/Program Files/Git/cmd:/mnt/c/ProgramData/chocolatey/lib/pulumi/tools/Pulumi/bin:/mnt/c/Users/seanh/AppData/Local/Programs/cursor/resources/app/bin:/mnt/c/WINDOWS/system32:/mnt/c/WINDOWS:/mnt/c/WINDOWS/System32/Wbem:/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/:/mnt/c/WINDOWS/System32/OpenSSH/:/mnt/c/Program Files/Docker/Docker/resources/bin:/mnt/c/Program Files/nodejs/:/mnt/c/Program Files/Vagrant/bin:/mnt/c/Users/seanh/AppData/Local/Programs/Python/Launcher/:/mnt/c/Users/seanh/AppData/Local/Microsoft/WindowsApps:/mnt/c/Users/seanh/AppData/Local/Programs/Microsoft VS Code/bin:/mnt/c/Users/seanh/go/bin:/mnt/c/Users/seanh/AppData/Local/Programs/cursor/resources/app/bin:/mnt/c/Users/seanh/AppData/Local/Programs/Ollama:/mnt/c/Users/seanh/.lmstudio/bin:/mnt/c/Users/seanh/AppData/Roaming/npm:/snap/bin npm test
- TMPDIR=/tmp PATH=/tmp/node-v22.14.0-linux-x64/bin:/mnt/c/Users/seanh/.codex/tmp/arg0/codex-arg0jIHcgz:/mnt/c/Users/seanh/.codex/bin/wsl:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib:/mnt/c/Program Files/Oculus/Support/oculus-runtime:/mnt/c/WINDOWS/system32:/mnt/c/WINDOWS:/mnt/c/WINDOWS/System32/Wbem:/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/:/mnt/c/WINDOWS/System32/OpenSSH/:/mnt/c/Program Files/Go/bin:/mnt/c/ProgramData/chocolatey/bin:/mnt/c/Program Files/Git/cmd:/mnt/c/ProgramData/chocolatey/lib/pulumi/tools/Pulumi/bin:/mnt/c/Users/seanh/AppData/Local/Programs/cursor/resources/app/bin:/mnt/c/WINDOWS/system32:/mnt/c/WINDOWS:/mnt/c/WINDOWS/System32/Wbem:/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/:/mnt/c/WINDOWS/System32/OpenSSH/:/mnt/c/Program Files/Docker/Docker/resources/bin:/mnt/c/Program Files/nodejs/:/mnt/c/Program Files/Vagrant/bin:/mnt/c/Users/seanh/AppData/Local/Programs/Python/Launcher/:/mnt/c/Users/seanh/AppData/Local/Microsoft/WindowsApps:/mnt/c/Users/seanh/AppData/Local/Programs/Microsoft VS Code/bin:/mnt/c/Users/seanh/go/bin:/mnt/c/Users/seanh/AppData/Local/Programs/cursor/resources/app/bin:/mnt/c/Users/seanh/AppData/Local/Programs/Ollama:/mnt/c/Users/seanh/.lmstudio/bin:/mnt/c/Users/seanh/AppData/Roaming/npm:/snap/bin npm run build
- TMPDIR=/tmp PATH=/tmp/node-v22.14.0-linux-x64/bin:/mnt/c/Users/seanh/.codex/tmp/arg0/codex-arg0jIHcgz:/mnt/c/Users/seanh/.codex/bin/wsl:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib:/mnt/c/Program Files/Oculus/Support/oculus-runtime:/mnt/c/WINDOWS/system32:/mnt/c/WINDOWS:/mnt/c/WINDOWS/System32/Wbem:/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/:/mnt/c/WINDOWS/System32/OpenSSH/:/mnt/c/Program Files/Go/bin:/mnt/c/ProgramData/chocolatey/bin:/mnt/c/Program Files/Git/cmd:/mnt/c/ProgramData/chocolatey/lib/pulumi/tools/Pulumi/bin:/mnt/c/Users/seanh/AppData/Local/Programs/cursor/resources/app/bin:/mnt/c/WINDOWS/system32:/mnt/c/WINDOWS:/mnt/c/WINDOWS/System32/Wbem:/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/:/mnt/c/WINDOWS/System32/OpenSSH/:/mnt/c/Program Files/Docker/Docker/resources/bin:/mnt/c/Program Files/nodejs/:/mnt/c/Program Files/Vagrant/bin:/mnt/c/Users/seanh/AppData/Local/Programs/Python/Launcher/:/mnt/c/Users/seanh/AppData/Local/Microsoft/WindowsApps:/mnt/c/Users/seanh/AppData/Local/Programs/Microsoft VS Code/bin:/mnt/c/Users/seanh/go/bin:/mnt/c/Users/seanh/AppData/Local/Programs/cursor/resources/app/bin:/mnt/c/Users/seanh/AppData/Local/Programs/Ollama:/mnt/c/Users/seanh/.lmstudio/bin:/mnt/c/Users/seanh/AppData/Roaming/npm:/snap/bin npm run lint