### PR TITLE
Harden benchmark task execution

### DIFF
--- a/packages/agent-sdk/src/tools/registry.ts
+++ b/packages/agent-sdk/src/tools/registry.ts
@@ -59,6 +59,10 @@ export class ToolRegistry {
     return [...this.toolsByName.values()].map(toToolSchema);
   }
 
+  getDefinitions(): ToolDefinition[] {
+    return [...this.toolsByName.values()];
+  }
+
   async execute(name: string, input: unknown): Promise<string> {
     const tool = this.toolsByName.get(name);
     if (!tool) {

--- a/scripts/run-benchmarks.ts
+++ b/scripts/run-benchmarks.ts
@@ -21,19 +21,15 @@ import { writeFile } from "node:fs/promises";
 
 import {
   createModelClient,
-  createReadFileTool,
-  createWriteFileTool,
-  createEditFileTool,
-  createSearchTool,
-  createListFilesTool,
-  createRunCommandTool,
 } from "@minicode/agent-sdk";
-import type { AgentConfig, ToolDefinition } from "@minicode/agent-sdk";
+import type { AgentConfig } from "@minicode/agent-sdk";
 
 import { loadBenchmarkTasks, loadBenchmarkTask } from "../src/benchmark/task-loader.js";
 import { runBenchmarkSuite } from "../src/benchmark/runner.js";
 import { buildReport, formatReport } from "../src/benchmark/reporter.js";
 import type { BenchmarkTask } from "../src/benchmark/types.js";
+import { buildProjectIndex } from "../src/indexer/project-index.js";
+import { createToolRegistry } from "../src/tools/registry.js";
 
 /* ------------------------------------------------------------------ */
 /*  CLI argument parsing                                               */
@@ -145,20 +141,21 @@ async function main(): Promise<void> {
   console.log("");
 
   const modelClient = createModelClient(config);
-  const tools: ToolDefinition[] = [
-    createReadFileTool(config),
-    createWriteFileTool(config),
-    createEditFileTool(config),
-    createSearchTool(config),
-    createListFilesTool(config),
-    createRunCommandTool(config),
-  ];
 
   const traces = await runBenchmarkSuite(tasks, {
     modelClient,
     config,
-    tools,
     variant: args.variant,
+    repoRoot: process.cwd(),
+    isolateWorkspace: true,
+    createToolset: async (taskConfig) => {
+      const projectIndex = await buildProjectIndex(taskConfig.workspaceRoot);
+      const toolRegistry = createToolRegistry(taskConfig, projectIndex);
+      return {
+        tools: toolRegistry.getDefinitions(),
+        projectIndex,
+      };
+    },
     onTaskComplete: (taskId, trace) => {
       const dur = (trace.durationMs / 1000).toFixed(1);
       console.log(`  [done] ${taskId} (${dur}s, ${trace.toolCalls.length} tool calls)`);

--- a/src/benchmark/runner.ts
+++ b/src/benchmark/runner.ts
@@ -6,6 +6,9 @@
  */
 
 import { execSync } from "node:child_process";
+import { cp, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 import {
   CodingAgent,
@@ -23,18 +26,38 @@ import type {
   BenchmarkTrace,
   CapturedToolCall,
 } from "./types.js";
+import type { ProjectIndex } from "../indexer/types.js";
+
+const COPY_SKIP_NAMES = new Set([
+  ".git",
+  "node_modules",
+  "dist",
+  "build",
+  "coverage",
+]);
 
 export interface RunnerOptions {
   /** Model client to use. */
   modelClient: ModelClient;
   /** Base agent config (workspace root will be overridden per task). */
   config: AgentConfig;
-  /** Tool definitions to register. */
-  tools: ToolDefinition[];
+  /** Static tool definitions to register. */
+  tools?: ToolDefinition[];
+  /** Optional factory for building task-specific tools and index metadata. */
+  createToolset?: (config: AgentConfig, task: BenchmarkTask) => Promise<BenchmarkToolset>;
   /** Variant label for this run (e.g. "baseline"). */
   variant: string;
+  /** Repo root used for resolving task.workspaceRoot overrides. */
+  repoRoot?: string;
+  /** Whether each task should run in an isolated temp workspace copy. Defaults to true. */
+  isolateWorkspace?: boolean;
   /** Optional callback after each task completes. */
   onTaskComplete?: (taskId: string, trace: BenchmarkTrace) => void;
+}
+
+export interface BenchmarkToolset {
+  tools: ToolDefinition[];
+  projectIndex?: ProjectIndex | undefined;
 }
 
 function getGitCommitSha(): string {
@@ -50,7 +73,90 @@ const STRUCTURAL_TOOLS = new Set([
   "find_references",
   "get_dependencies",
   "search_code_map",
+  "find_path",
 ]);
+
+function sanitizeTaskId(taskId: string): string {
+  return taskId.replace(/[^a-z0-9-_]+/gi, "-");
+}
+
+function resolveSourceWorkspaceRoot(
+  task: BenchmarkTask,
+  options: RunnerOptions,
+): string {
+  if (!task.workspaceRoot) {
+    return path.resolve(options.config.workspaceRoot);
+  }
+
+  const repoRoot = path.resolve(options.repoRoot ?? process.cwd());
+  return path.resolve(repoRoot, task.workspaceRoot);
+}
+
+function shouldCopyPath(src: string): boolean {
+  const name = path.basename(src);
+  return !COPY_SKIP_NAMES.has(name);
+}
+
+async function prepareTaskWorkspace(
+  task: BenchmarkTask,
+  options: RunnerOptions,
+): Promise<{ sourceWorkspaceRoot: string; workspaceRoot: string; cleanup: () => Promise<void> }> {
+  const sourceWorkspaceRoot = resolveSourceWorkspaceRoot(task, options);
+  if (options.isolateWorkspace === false) {
+    return {
+      sourceWorkspaceRoot,
+      workspaceRoot: sourceWorkspaceRoot,
+      cleanup: async () => {},
+    };
+  }
+
+  const tempRoot = await mkdtemp(path.join(tmpdir(), "minicode-benchmark-"));
+  const isolatedWorkspaceRoot = path.join(tempRoot, sanitizeTaskId(task.id));
+  await cp(sourceWorkspaceRoot, isolatedWorkspaceRoot, {
+    recursive: true,
+    filter: shouldCopyPath,
+  });
+
+  return {
+    sourceWorkspaceRoot,
+    workspaceRoot: isolatedWorkspaceRoot,
+    cleanup: async () => {
+      await rm(tempRoot, { recursive: true, force: true });
+    },
+  };
+}
+
+function getTrackedSymbolNames(
+  toolName: string,
+  input: Record<string, unknown>,
+): string[] {
+  if (toolName === "find_path") {
+    const names = [input.from, input.to]
+      .filter((value): value is string => typeof value === "string" && value.length > 0);
+    return [...new Set(names)];
+  }
+
+  const name = input.symbol ?? input.symbolName ?? input.name ?? input.query;
+  return typeof name === "string" && name.length > 0 ? [name] : [];
+}
+
+function trackStructuralFileReads(
+  toolName: string,
+  projectIndex: ProjectIndex | undefined,
+  input: Record<string, unknown>,
+  filesRead: Set<string>,
+): void {
+  if (!projectIndex || !STRUCTURAL_TOOLS.has(toolName)) {
+    return;
+  }
+
+  for (const symbolName of getTrackedSymbolNames(toolName, input)) {
+    const symbol = projectIndex.getSymbol(symbolName);
+    if (symbol) {
+      filesRead.add(symbol.filePath);
+    }
+  }
+}
 
 /**
  * Run a single benchmark task and return the captured trace.
@@ -59,80 +165,97 @@ export async function runBenchmarkTask(
   task: BenchmarkTask,
   options: RunnerOptions,
 ): Promise<BenchmarkTrace> {
+  const workspace = await prepareTaskWorkspace(task, options);
   const captured: CapturedToolCall[] = [];
   const filesRead = new Set<string>();
   const symbolsQueried = new Set<string>();
 
-  // Wrap each tool to capture calls
-  const instrumentedTools: ToolDefinition[] = options.tools.map((tool) => ({
-    ...tool,
-    execute: async (input: Record<string, unknown>) => {
-      const start = performance.now();
-      const output = await tool.execute(input);
-      const durationMs = performance.now() - start;
+  try {
+    const taskConfig: AgentConfig = {
+      ...options.config,
+      workspaceRoot: workspace.workspaceRoot,
+    };
+    const toolset = options.createToolset
+      ? await options.createToolset(taskConfig, task)
+      : { tools: options.tools ?? [] };
 
-      captured.push({
-        name: tool.name,
-        input,
-        output:
-          output.length > 2000 ? output.slice(0, 2000) + "…[truncated]" : output,
-        durationMs,
-      });
+    // Wrap each tool to capture calls
+    const instrumentedTools: ToolDefinition[] = toolset.tools.map((tool) => ({
+      ...tool,
+      execute: async (input: Record<string, unknown>) => {
+        const start = performance.now();
+        const output = await tool.execute(input);
+        const durationMs = performance.now() - start;
 
-      // Track files read
-      if (tool.name === "read_file" || tool.name === "read_symbol") {
-        const filePath = input.path ?? input.file_path ?? input.filePath;
-        if (typeof filePath === "string") filesRead.add(filePath);
-      }
+        captured.push({
+          name: tool.name,
+          input,
+          output:
+            output.length > 2000 ? output.slice(0, 2000) + "…[truncated]" : output,
+          durationMs,
+        });
 
-      // Track symbol queries
-      if (STRUCTURAL_TOOLS.has(tool.name)) {
-        const sym =
-          input.symbol ?? input.symbolName ?? input.name ?? input.query;
-        if (typeof sym === "string") symbolsQueried.add(sym);
-      }
+        if (tool.name === "read_file") {
+          const filePath = input.path ?? input.file_path ?? input.filePath;
+          if (typeof filePath === "string") {
+            filesRead.add(filePath);
+          }
+        }
 
-      return output;
-    },
-  }));
+        trackStructuralFileReads(tool.name, toolset.projectIndex, input, filesRead);
 
-  const registry = new ToolRegistry(instrumentedTools);
-  const session = new Session();
+        if (STRUCTURAL_TOOLS.has(tool.name)) {
+          for (const symbolName of getTrackedSymbolNames(tool.name, input)) {
+            symbolsQueried.add(symbolName);
+          }
+        }
 
-  const agent = new CodingAgent({
-    config: options.config,
-    modelClient: options.modelClient,
-    toolRegistry: registry,
-    session,
-  });
+        return output;
+      },
+    }));
 
-  const startedAt = new Date().toISOString();
-  const start = performance.now();
+    const registry = new ToolRegistry(instrumentedTools);
+    const session = new Session();
 
-  const { text, usage } = await agent.runTurn(task.prompt);
+    const agent = new CodingAgent({
+      config: taskConfig,
+      modelClient: options.modelClient,
+      toolRegistry: registry,
+      session,
+    });
 
-  const durationMs = performance.now() - start;
+    const startedAt = new Date().toISOString();
+    const start = performance.now();
 
-  const trace: BenchmarkTrace = {
-    taskId: task.id,
-    model: options.config.model,
-    variant: options.variant,
-    commitSha: getGitCommitSha(),
-    response: text,
-    toolCalls: captured,
-    filesRead: [...filesRead],
-    symbolsQueried: [...symbolsQueried],
-    usage: {
-      inputTokens: usage?.inputTokens ?? 0,
-      outputTokens: usage?.outputTokens ?? 0,
-      totalTokens: (usage?.inputTokens ?? 0) + (usage?.outputTokens ?? 0),
-    },
-    durationMs,
-    startedAt,
-  };
+    const { text, usage } = await agent.runTurn(task.prompt);
 
-  options.onTaskComplete?.(task.id, trace);
-  return trace;
+    const durationMs = performance.now() - start;
+
+    const trace: BenchmarkTrace = {
+      taskId: task.id,
+      model: taskConfig.model,
+      variant: options.variant,
+      commitSha: getGitCommitSha(),
+      sourceWorkspaceRoot: workspace.sourceWorkspaceRoot,
+      workspaceRoot: workspace.workspaceRoot,
+      response: text,
+      toolCalls: captured,
+      filesRead: [...filesRead],
+      symbolsQueried: [...symbolsQueried],
+      usage: {
+        inputTokens: usage?.inputTokens ?? 0,
+        outputTokens: usage?.outputTokens ?? 0,
+        totalTokens: (usage?.inputTokens ?? 0) + (usage?.outputTokens ?? 0),
+      },
+      durationMs,
+      startedAt,
+    };
+
+    options.onTaskComplete?.(task.id, trace);
+    return trace;
+  } finally {
+    await workspace.cleanup();
+  }
 }
 
 /**

--- a/src/benchmark/types.ts
+++ b/src/benchmark/types.ts
@@ -21,7 +21,7 @@ export interface BenchmarkTask {
   category: BenchmarkCategory;
   /** The prompt sent to the agent. */
   prompt: string;
-  /** Optional workspace root override (relative to repo root). Defaults to fixture or repo root. */
+  /** Optional workspace root override (relative to the benchmark repo root). */
   workspaceRoot?: string | undefined;
   /** Rubric for evaluating the result. */
   rubric: BenchmarkRubric;
@@ -63,6 +63,10 @@ export interface BenchmarkTrace {
   variant: string;
   /** Git commit SHA of the codebase under test. */
   commitSha: string;
+  /** Source workspace selected for the task before isolation. */
+  sourceWorkspaceRoot: string;
+  /** Actual workspace path used during the run. */
+  workspaceRoot: string;
   /** Agent's final text response. */
   response: string;
   /** Ordered list of tool calls made during the run. */

--- a/tests/benchmark-harness.test.ts
+++ b/tests/benchmark-harness.test.ts
@@ -70,6 +70,8 @@ function makeTrace(overrides: Partial<BenchmarkTrace> = {}): BenchmarkTrace {
     model: "test-model",
     variant: "baseline",
     commitSha: "abc123",
+    sourceWorkspaceRoot: "/workspace/source",
+    workspaceRoot: "/tmp/minicode-benchmark/task",
     response: "Found foo in src/foo.ts at line 10.",
     toolCalls: [
       { name: "search", input: { query: "foo" }, output: "src/foo.ts:10", durationMs: 50 },
@@ -190,6 +192,28 @@ test("loadBenchmarkTask loads a single task by id", async () => {
     assert.equal(task.category, "navigation");
   } finally {
     await rm(tmpDir, { recursive: true });
+  }
+});
+
+test("loadBenchmarkTask preserves workspaceRoot when provided", async () => {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), "bench-workspace-root-"));
+  await mkdir(path.join(tmpDir, "navigation", "fixture-task"), { recursive: true });
+  await writeFile(
+    path.join(tmpDir, "navigation", "fixture-task", "task.json"),
+    JSON.stringify({
+      title: "Fixture task",
+      prompt: "Use a fixture workspace",
+      workspaceRoot: "test-programs/benchmark-index",
+      rubric: {},
+    }),
+  );
+
+  try {
+    const task = await loadBenchmarkTask(tmpDir, "navigation/fixture-task");
+    assert.ok(task);
+    assert.equal(task.workspaceRoot, "test-programs/benchmark-index");
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
   }
 });
 
@@ -495,6 +519,96 @@ test("runBenchmarkTask tracks symbols from structural tools", async () => {
   });
 
   assert.ok(trace.symbolsQueried.includes("CodingAgent"));
+});
+
+test("runBenchmarkTask resolves task workspace overrides and isolates the run", async () => {
+  const repoRoot = await mkdtemp(path.join(tmpdir(), "bench-repo-root-"));
+  const sourceWorkspace = path.join(repoRoot, "fixtures", "sample-project");
+  await mkdir(path.join(sourceWorkspace, "src"), { recursive: true });
+  await writeFile(path.join(sourceWorkspace, "src", "index.ts"), "export const answer = 42;\n");
+
+  const task: BenchmarkTask = {
+    id: "navigation/workspace-root",
+    title: "Workspace root test",
+    category: "navigation",
+    prompt: "Inspect the fixture workspace",
+    workspaceRoot: "fixtures/sample-project",
+    rubric: {},
+  };
+
+  try {
+    const config = createTestAgentConfig(repoRoot);
+    const trace = await runBenchmarkTask(task, {
+      modelClient: new MockModelClient("done"),
+      config,
+      tools: [],
+      variant: "test",
+      repoRoot,
+    });
+
+    assert.equal(trace.sourceWorkspaceRoot, sourceWorkspace);
+    assert.notEqual(trace.workspaceRoot, sourceWorkspace);
+    assert.ok(trace.workspaceRoot.includes("minicode-benchmark-"));
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("runBenchmarkTask uses project index metadata to count read_symbol as a file read", async () => {
+  const workspaceRoot = path.resolve(import.meta.dirname, "..");
+  const task: BenchmarkTask = {
+    id: "navigation/structural-file-tracking",
+    title: "Structural file tracking",
+    category: "navigation",
+    prompt: "Read the CodingAgent symbol",
+    rubric: {},
+  };
+
+  let callCount = 0;
+  const mockClient: ModelClient = {
+    async chat(params) {
+      void params;
+      callCount += 1;
+      if (callCount === 1) {
+        return {
+          text: "Looking up symbol",
+          toolCalls: [{ id: "t1", name: "read_symbol", input: { name: "CodingAgent" } }],
+          stopReason: "tool_use" as const,
+          usage: { inputTokens: 100, outputTokens: 50 },
+        };
+      }
+      return {
+        text: "Found CodingAgent",
+        toolCalls: [],
+        stopReason: "end_turn" as const,
+        usage: { inputTokens: 100, outputTokens: 50 },
+      };
+    },
+  };
+
+  const config = createTestAgentConfig(workspaceRoot);
+  const trace = await runBenchmarkTask(task, {
+    modelClient: mockClient,
+    config,
+    variant: "v1",
+    isolateWorkspace: false,
+    createToolset: async (taskConfig) => {
+      const { buildProjectIndex } = await import("../src/indexer/project-index.js");
+      const { createToolRegistry } = await import("../src/tools/registry.js");
+      const projectIndex = await buildProjectIndex(taskConfig.workspaceRoot);
+      const toolRegistry = createToolRegistry(taskConfig, projectIndex);
+      return {
+        tools: toolRegistry.getDefinitions(),
+        projectIndex,
+      };
+    },
+  });
+
+  assert.ok(trace.symbolsQueried.includes("CodingAgent"));
+  assert.ok(
+    trace.filesRead.some((file) => file.endsWith("packages/agent-sdk/src/agent/agent.ts")),
+    "read_symbol should count the owning file as read",
+  );
 });
 
 // ─── Reporter Tests ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- run each benchmark task in an isolated workspace and honor task-specific workspace roots
- build benchmark toolsets from the real indexed registry so structural tools are available during runs
- improve benchmark trace coverage for structural file reads and workspace metadata

## Verification
- TMPDIR=/tmp TEMP=/tmp TMP=/tmp PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm test
- TMPDIR=/tmp TEMP=/tmp TMP=/tmp PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm run build
- TMPDIR=/tmp TEMP=/tmp TMP=/tmp PATH=/tmp/node-v22.14.0-linux-x64/bin:$PATH npm run lint