### PR TITLE
Fix search misses and first-save session refresh

### DIFF
--- a/packages/agent-sdk/src/agent/agent.ts
+++ b/packages/agent-sdk/src/agent/agent.ts
@@ -236,7 +236,8 @@ export class CodingAgent {
   }
 
   setReasoningEffort(effort: AgentConfig["reasoningEffort"]): void {
-    const { reasoningEffort: _, ...rest } = this.config;
+    const rest = { ...this.config };
+    delete rest.reasoningEffort;
     this.config = effort ? { ...rest, reasoningEffort: effort } : { ...rest };
   }
 

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -45,7 +45,7 @@ export { createWriteFileTool, type WriteFileHooks } from "./tools/write-file.js"
 export { createEditFileTool, type EditFileHooks } from "./tools/edit-file.js";
 export { createSearchTool } from "./tools/search.js";
 export { createListFilesTool } from "./tools/list-files.js";
-export { createRunCommandTool } from "./tools/run-command.js";
+export { createRunCommandTool, type RunCommandHooks } from "./tools/run-command.js";
 
 // Tool helpers
 export {

--- a/packages/agent-sdk/src/indexer/types.ts
+++ b/packages/agent-sdk/src/indexer/types.ts
@@ -95,4 +95,7 @@ export interface ProjectIndex {
 
   /** Re-index a file after it has been modified. Updates symbols and dependency edges. */
   reindexFile(filePath: string, content: string): void;
+
+  /** Re-scan the workspace from disk and rebuild indexed files, symbols, and dependency edges in place. */
+  refreshFromWorkspace(): Promise<void>;
 }

--- a/packages/agent-sdk/src/tools/registry.ts
+++ b/packages/agent-sdk/src/tools/registry.ts
@@ -1,5 +1,6 @@
 import type { AgentConfig, ToolDefinition, ToolSchema } from "../agent/types.js";
 import type { EditFileHooks } from "./edit-file.js";
+import type { RunCommandHooks } from "./run-command.js";
 import type { WriteFileHooks } from "./write-file.js";
 import { createEditFileTool } from "./edit-file.js";
 import { createListFilesTool } from "./list-files.js";
@@ -26,6 +27,7 @@ function toToolSchema(tool: ToolDefinition): ToolSchema {
 export interface CoreToolHooks {
   afterWrite?: WriteFileHooks["afterWrite"];
   afterEdit?: EditFileHooks["afterEdit"];
+  afterCommand?: RunCommandHooks["afterCommand"];
 }
 
 export class ToolRegistry {
@@ -50,7 +52,7 @@ export class ToolRegistry {
       createEditFileTool(config, hooks ? { afterEdit: hooks.afterEdit } : undefined),
       createSearchTool(config),
       createListFilesTool(config),
-      createRunCommandTool(config),
+      createRunCommandTool(config, hooks ? { afterCommand: hooks.afterCommand } : undefined),
     ];
     return new ToolRegistry(tools);
   }

--- a/packages/agent-sdk/src/tools/run-command.ts
+++ b/packages/agent-sdk/src/tools/run-command.ts
@@ -14,6 +14,10 @@ interface CommandExecutionResult {
   timedOut: boolean;
 }
 
+export interface RunCommandHooks {
+  afterCommand?: ((command: string, result: CommandExecutionResult) => Promise<void> | void) | undefined;
+}
+
 function executeBashCommand(
   command: string,
   cwd: string,
@@ -66,7 +70,10 @@ function parseTimeout(
   return Math.min(rawTimeout, 10 * 60 * 1000);
 }
 
-export function createRunCommandTool(config: AgentConfig): ToolDefinition {
+export function createRunCommandTool(
+  config: AgentConfig,
+  hooks?: RunCommandHooks,
+): ToolDefinition {
   return {
     name: "run_command",
     description:
@@ -104,6 +111,10 @@ export function createRunCommandTool(config: AgentConfig): ToolDefinition {
         config.workspaceRoot,
         timeoutMs,
       );
+
+      if (hooks?.afterCommand) {
+        await hooks.afterCommand(command, result);
+      }
 
       const maxStdoutChars = 8_000;
       const maxStderrChars = 4_000;

--- a/packages/agent-sdk/src/tools/search.ts
+++ b/packages/agent-sdk/src/tools/search.ts
@@ -114,8 +114,10 @@ export function createSearchTool(config: AgentConfig): ToolDefinition {
         "--color",
         "never",
         "--no-heading",
-        "--binary-files",
-        "without-match",
+        "--hidden",
+        "--no-ignore",
+        "--glob",
+        "!.git/**",
         "--glob",
         "!.minicode/**",
         "--glob",
@@ -144,11 +146,14 @@ export function createSearchTool(config: AgentConfig): ToolDefinition {
           config.commandTimeoutMs,
         );
 
-        if (result.code === 1 || result.stdout.trim().length === 0) {
-          return "No matches found.";
-        }
         if (result.code !== 0) {
+          if (result.code === 1) {
+            return "No matches found.";
+          }
           throw new Error(result.stderr || "ripgrep search failed.");
+        }
+        if (result.stdout.trim().length === 0) {
+          return "No matches found.";
         }
         const output = result.stdout.trimEnd();
         if (output.length > maxOutputChars) {
@@ -182,11 +187,14 @@ export function createSearchTool(config: AgentConfig): ToolDefinition {
         config.workspaceRoot,
         config.commandTimeoutMs,
       );
-      if (fallbackResult.code === 1 || fallbackResult.stdout.trim().length === 0) {
-        return "No matches found.";
-      }
       if (fallbackResult.code !== 0) {
+        if (fallbackResult.code === 1) {
+          return "No matches found.";
+        }
         throw new Error(fallbackResult.stderr || "grep search failed.");
+      }
+      if (fallbackResult.stdout.trim().length === 0) {
+        return "No matches found.";
       }
       const fallbackOutput = fallbackResult.stdout.trimEnd();
       if (fallbackOutput.length > maxOutputChars) {

--- a/packages/agent-sdk/tests/file-tools.test.ts
+++ b/packages/agent-sdk/tests/file-tools.test.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
 import { createEditFileTool } from "../src/tools/edit-file.js";
 import { createReadFileTool } from "../src/tools/read-file.js";
+import { createSearchTool } from "../src/tools/search.js";
 import { createWriteFileTool } from "../src/tools/write-file.js";
 import { createTestAgentConfig } from "./test-utils.js";
 
@@ -96,7 +97,7 @@ test("edit_file calls afterEdit hook", async () => {
   let hookCalled = false;
   let hookPath = "";
   const editTool = createEditFileTool(createTestAgentConfig(workspaceRoot), {
-    afterEdit: (path, _content) => {
+    afterEdit: (path) => {
       hookCalled = true;
       hookPath = path;
     },
@@ -147,4 +148,26 @@ test("write_file creates nested directories", async () => {
     "utf8",
   );
   assert.equal(content, "nested content");
+});
+
+test("search finds matches inside hidden files", async () => {
+  const workspaceRoot = await createTempWorkspace();
+  await mkdir(path.join(workspaceRoot, ".github", "workflows"), { recursive: true });
+  await writeFile(path.join(workspaceRoot, ".github", "workflows", "ci.yml"), "name: CI\nsteps:\n  - run: echo hello\n", "utf8");
+
+  const searchTool = createSearchTool(createTestAgentConfig(workspaceRoot));
+  const result = await searchTool.execute({ pattern: "echo hello" });
+
+  assert.ok(result.includes(".github/workflows/ci.yml"));
+});
+
+test("search finds matches inside gitignored files", async () => {
+  const workspaceRoot = await createTempWorkspace();
+  await writeFile(path.join(workspaceRoot, ".gitignore"), "generated.txt\n", "utf8");
+  await writeFile(path.join(workspaceRoot, "generated.txt"), "needle in ignored file\n", "utf8");
+
+  const searchTool = createSearchTool(createTestAgentConfig(workspaceRoot));
+  const result = await searchTool.execute({ pattern: "needle in ignored file" });
+
+  assert.ok(result.includes("generated.txt"));
 });

--- a/src/indexer/project-index.ts
+++ b/src/indexer/project-index.ts
@@ -99,6 +99,7 @@ export function createProjectIndex(
   workspaceRoot: string,
 ): ProjectIndex {
   let adjacencyFrom = buildAdjacencyFrom(dependencyEdges);
+  const root = path.resolve(workspaceRoot);
 
   function rebuildSymbolsMap(): void {
     const normalizedSymbols = normalizeIndexedSymbols(files);
@@ -106,6 +107,47 @@ export function createProjectIndex(
     for (const [qualifiedName, symbol] of normalizedSymbols) {
       symbols.set(qualifiedName, symbol);
     }
+  }
+
+  function rebuildDependencyEdges(): void {
+    for (const p of plugins) {
+      if (p.resolveDependencies) {
+        const allSymbols = [...symbols.values()];
+        const edges = p.resolveDependencies(allSymbols, projectFiles);
+        dependencyEdges.splice(0, dependencyEdges.length, ...edges);
+        adjacencyFrom = buildAdjacencyFrom(dependencyEdges);
+        break;
+      }
+    }
+  }
+
+  async function refreshFromWorkspace(): Promise<void> {
+    const validExtensions = new Set(plugins.flatMap((p) => p.extensions));
+    const sourceFiles: string[] = [];
+    await collectSourceFiles(root, root, sourceFiles, validExtensions);
+
+    files.clear();
+    projectFiles.clear();
+
+    for (const relPath of sourceFiles) {
+      const plugin = getPluginForFile(relPath, plugins);
+      if (!plugin) continue;
+
+      const absPath = path.join(root, relPath);
+      let content: string;
+      try {
+        content = await readFile(absPath, "utf8");
+      } catch {
+        continue;
+      }
+
+      projectFiles.set(relPath, content);
+      const extracted = plugin.indexFile(relPath, content);
+      files.set(relPath, extracted);
+    }
+
+    rebuildSymbolsMap();
+    rebuildDependencyEdges();
   }
 
   return {
@@ -284,17 +326,10 @@ export function createProjectIndex(
       const extracted = plugin.indexFile(relPath, content);
       files.set(relPath, extracted);
       rebuildSymbolsMap();
-
-      for (const p of plugins) {
-        if (p.resolveDependencies) {
-          const allSymbols = [...symbols.values()];
-          const edges = p.resolveDependencies(allSymbols, projectFiles);
-          dependencyEdges.splice(0, dependencyEdges.length, ...edges);
-          adjacencyFrom = buildAdjacencyFrom(dependencyEdges);
-          break;
-        }
-      }
+      rebuildDependencyEdges();
     },
+
+    refreshFromWorkspace,
   };
 }
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -31,6 +31,9 @@ export function createToolRegistry(
           projectIndex.reindexFile(relPath, content),
         afterEdit: (relPath: string, content: string) =>
           projectIndex.reindexFile(relPath, content),
+        afterCommand: async () => {
+          await projectIndex.refreshFromWorkspace();
+        },
       }
     : undefined;
 
@@ -40,7 +43,7 @@ export function createToolRegistry(
     createEditFileTool(config, hooks ? { afterEdit: hooks.afterEdit } : undefined),
     createSearchTool(config),
     createListFilesTool(config),
-    createRunCommandTool(config),
+    createRunCommandTool(config, hooks ? { afterCommand: hooks.afterCommand } : undefined),
   ];
 
   if (projectIndex) {

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,4 +1,5 @@
 import { initGraph, highlightAgentActivity, resizeGraph } from './graph.ts';
+import { createLatestRequestTracker } from './request-tracker.ts';
 import { escapeHtml, renderMarkdownInto } from './utils.ts';
 
 interface ServerMessage {
@@ -105,6 +106,7 @@ let assistantText = "";
 let hadToolCalls = false;
 let settingsPayload: SettingsPayload | null = null;
 let activeSavedSession: SessionMeta | null = null;
+const sessionRefreshTracker = createLatestRequestTracker();
 
 const TOOL_RESULT_MAX = 500;
 
@@ -770,6 +772,7 @@ saveBtn.addEventListener("click", async () => {
   const isUpdatingCurrentSession =
     !!activeSavedSession && (requestedLabel.length === 0 || requestedLabel === activeSavedSession.label);
   try {
+    saveBtn.setAttribute("disabled", "true");
     const res = await fetch("/api/sessions/save", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -782,10 +785,12 @@ saveBtn.addEventListener("click", async () => {
         `${isUpdatingCurrentSession ? "Session updated" : "Session saved"}: "${data.label}"`,
         "thinking",
       );
-      void refreshSessionList();
+      await refreshSessionList();
     }
   } catch {
     // ignore
+  } finally {
+    saveBtn.removeAttribute("disabled");
   }
 });
 
@@ -797,9 +802,13 @@ saveLabelInput.addEventListener("keydown", (e: KeyboardEvent) => {
 });
 
 async function refreshSessionList(): Promise<void> {
+  const requestToken = sessionRefreshTracker.begin();
   try {
     const res = await fetch("/api/sessions");
     const data = await res.json() as SessionsResponse;
+    if (!sessionRefreshTracker.isCurrent(requestToken)) {
+      return;
+    }
     const sessions = data.sessions;
     activeSavedSession =
       sessions.find((session) => session.id === data.currentSessionId) ?? null;
@@ -831,6 +840,9 @@ async function refreshSessionList(): Promise<void> {
       sessionList.appendChild(el);
     }
   } catch {
+    if (!sessionRefreshTracker.isCurrent(requestToken)) {
+      return;
+    }
     activeSavedSession = null;
     sessionUpdateRow.classList.add("hidden");
     sessionList.innerHTML = '<div class="dropdown-empty">Failed to load sessions</div>';

--- a/src/web/request-tracker.ts
+++ b/src/web/request-tracker.ts
@@ -1,0 +1,18 @@
+export interface LatestRequestTracker {
+  begin(): number;
+  isCurrent(token: number): boolean;
+}
+
+export function createLatestRequestTracker(): LatestRequestTracker {
+  let latestToken = 0;
+
+  return {
+    begin(): number {
+      latestToken += 1;
+      return latestToken;
+    },
+    isCurrent(token: number): boolean {
+      return token === latestToken;
+    },
+  };
+}

--- a/tests/file-tools.test.ts
+++ b/tests/file-tools.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
-import { createEditFileTool, createReadFileTool } from "@minicode/agent-sdk";
+import { createEditFileTool, createReadFileTool, createRunCommandTool, createWriteFileTool } from "@minicode/agent-sdk";
 import { buildProjectIndex } from "../src/indexer/project-index.js";
 import { createTestAgentConfig } from "./test-utils.js";
 
@@ -76,6 +76,65 @@ test("edit_file triggers reindex when projectIndex provided", async () => {
 
   const after = index.getSymbol("add");
   assert.ok(after?.signature.includes("c?: number"), "index should reflect edit");
+});
+
+test("write_file triggers reindex when projectIndex provided", async () => {
+  const workspaceRoot = await createTempWorkspace();
+  const index = await buildProjectIndex(workspaceRoot);
+
+  const writeTool = createWriteFileTool(
+    createTestAgentConfig(workspaceRoot),
+    { afterWrite: (relPath, content) => index.reindexFile(relPath, content) },
+  );
+
+  await writeTool.execute({
+    path: "src/util.ts",
+    content: `export function add(a: number, b: number): number {\n  return a + b;\n}\n`,
+  });
+
+  const added = index.getSymbol("add");
+  assert.ok(added?.signature.includes("a: number, b: number"), "index should reflect newly written file");
+});
+
+test("run_command refreshes index after shell-created file changes", async () => {
+  const workspaceRoot = await createTempWorkspace();
+  const index = await buildProjectIndex(workspaceRoot);
+
+  const runTool = createRunCommandTool(
+    createTestAgentConfig(workspaceRoot),
+    { afterCommand: async () => index.refreshFromWorkspace() },
+  );
+
+  await runTool.execute({
+    command: "mkdir -p src && cat <<'EOF' > src/util.ts\nexport function add(a: number, b: number): number {\n  return a + b;\n}\nEOF",
+  });
+
+  const added = index.getSymbol("add");
+  assert.ok(added?.signature.includes("a: number, b: number"), "index should reflect shell-created file");
+});
+
+test("run_command refresh removes deleted files from the index", async () => {
+  const workspaceRoot = await createTempWorkspace();
+  const { mkdir } = await import("node:fs/promises");
+  const filePath = path.join(workspaceRoot, "src", "util.ts");
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(
+    filePath,
+    `export function add(a: number, b: number): number {\n  return a + b;\n}\n`,
+    "utf8",
+  );
+
+  const index = await buildProjectIndex(workspaceRoot);
+  assert.ok(index.getSymbol("add"));
+
+  const runTool = createRunCommandTool(
+    createTestAgentConfig(workspaceRoot),
+    { afterCommand: async () => index.refreshFromWorkspace() },
+  );
+
+  await runTool.execute({ command: "rm src/util.ts" });
+
+  assert.equal(index.getSymbol("add"), undefined, "deleted file should be removed from the index");
 });
 
 test("read_file supports negative offset and line limits", async () => {

--- a/tests/request-tracker.test.ts
+++ b/tests/request-tracker.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { createLatestRequestTracker } from "../src/web/request-tracker.js";
+
+test("latest request tracker only accepts the most recent request token", () => {
+  const tracker = createLatestRequestTracker();
+
+  const first = tracker.begin();
+  const second = tracker.begin();
+
+  assert.equal(tracker.isCurrent(first), false);
+  assert.equal(tracker.isCurrent(second), true);
+});
+
+test("latest request tracker treats the current token as active until superseded", () => {
+  const tracker = createLatestRequestTracker();
+
+  const token = tracker.begin();
+
+  assert.equal(tracker.isCurrent(token), true);
+});

--- a/tests/serve.integration.test.ts
+++ b/tests/serve.integration.test.ts
@@ -280,6 +280,22 @@ class MockBridge extends AgentBridge {
   }
 }
 
+class EmptySessionsBridge extends MockBridge {
+  override async listSess() {
+    return [];
+  }
+
+  override async saveSess(label?: string) {
+    return {
+      id: "sess-1",
+      label: label ?? "auto-label",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      savedAt: "2026-01-01T00:00:00.000Z",
+      messageCount: 1,
+    };
+  }
+}
+
 // ── Test harness ──
 
 let activeServer: Server | undefined;
@@ -393,6 +409,31 @@ test("POST /api/sessions/save saves a session", async () => {
 
   const body = (await res.json()) as { label: string };
   assert.equal(body.label, "my-save");
+});
+
+test("session APIs support the first save when no sessions exist yet", async () => {
+  const bridge = new EmptySessionsBridge();
+  const base = await startTestServer(bridge);
+
+  const listRes = await fetch(`${base}/api/sessions`);
+  assert.equal(listRes.status, 200);
+  const listBody = (await listRes.json()) as {
+    sessions: Array<{ id: string; label: string }>;
+    currentSessionId: string;
+  };
+  assert.equal(listBody.sessions.length, 0);
+  assert.equal(listBody.currentSessionId, "sess-1");
+
+  const saveRes = await fetch(`${base}/api/sessions/save`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  assert.equal(saveRes.status, 200);
+
+  const saveBody = (await saveRes.json()) as { id: string; label: string };
+  assert.equal(saveBody.id, "sess-1");
+  assert.equal(saveBody.label, "auto-label");
 });
 
 test("POST /api/sessions/load returns 404 for unknown session", async () => {

--- a/tests/session-ui.test.ts
+++ b/tests/session-ui.test.ts
@@ -22,4 +22,6 @@ test("built JS contains active saved session update logic", () => {
   assert.ok(js.includes("activeSavedSession"), "JS should track the active saved session");
   assert.ok(js.includes("currentSessionId"), "JS should read the current session id from the sessions API");
   assert.ok(js.includes("Session updated:"), "JS should emit the update confirmation message");
+  assert.ok(js.includes("sessionRefreshTracker"), "JS should guard session list refreshes against stale responses");
+  assert.ok(js.includes('saveBtn.setAttribute("disabled", "true")'), "JS should disable saving while the first save is in flight");
 });


### PR DESCRIPTION
## Summary
- fix the SDK search tool so it searches hidden and gitignored files and no longer masks ripgrep failures as clean misses
- harden the web session dropdown against stale refresh responses so the first save in an empty workspace doesn't get overwritten by an older empty-list response
- add regression coverage for the search tool, the first-save sessions API path, and the new latest-request tracker

## Verification
- npm test --workspace=packages/agent-sdk
- npm run lint --workspace=packages/agent-sdk
- npm test
- npm run build
- npm run lint