### PR TITLE
Handle colliding graph symbol names

### DIFF
--- a/packages/agent-sdk/src/indexer/types.ts
+++ b/packages/agent-sdk/src/indexer/types.ts
@@ -83,6 +83,7 @@ export interface ProjectIndex {
   workspaceRoot: string;
 
   getSymbol(name: string): IndexedSymbol | undefined;
+  getSymbolMatches(name: string): IndexedSymbol[];
   getSymbolsInFile(filePath: string): IndexedSymbol[];
   getDependencyCone(symbolName: string, depth?: number): IndexedSymbol[];
   getCodeMap(tokenBudget?: number, focusSymbols?: Set<string>): CodeMapResult;

--- a/src/indexer/project-index.ts
+++ b/src/indexer/project-index.ts
@@ -67,18 +67,18 @@ function buildAdjacencyTo(edges: DependencyEdge[]): Map<string, DependencyEdge[]
   return map;
 }
 
-function resolveSymbol(
+function resolveSymbols(
   name: string,
   symbols: Map<string, IndexedSymbol>,
-): IndexedSymbol | undefined {
+): IndexedSymbol[] {
   const direct = symbols.get(name);
-  if (direct) return direct;
+  if (direct) return [direct];
 
   const matches = [...symbols.values()].filter((sym) =>
     getSymbolLookupNames(sym).includes(name),
   );
   if (matches.length === 0) {
-    return undefined;
+    return [];
   }
 
   matches.sort((a, b) =>
@@ -87,7 +87,14 @@ function resolveSymbol(
     a.startLine - b.startLine ||
     a.qualifiedName.localeCompare(b.qualifiedName),
   );
-  return matches[0];
+  return matches;
+}
+
+function resolveSymbol(
+  name: string,
+  symbols: Map<string, IndexedSymbol>,
+): IndexedSymbol | undefined {
+  return resolveSymbols(name, symbols)[0];
 }
 
 export function createProjectIndex(
@@ -160,6 +167,10 @@ export function createProjectIndex(
 
     getSymbol(name: string): IndexedSymbol | undefined {
       return resolveSymbol(name, symbols);
+    },
+
+    getSymbolMatches(name: string): IndexedSymbol[] {
+      return resolveSymbols(name, symbols);
     },
 
     getSymbolsInFile(filePath: string): IndexedSymbol[] {

--- a/src/serve/agent-bridge.ts
+++ b/src/serve/agent-bridge.ts
@@ -335,6 +335,11 @@ export class AgentBridge {
     return this.projectIndex.getSymbol(name);
   }
 
+  getSymbolMatches(name: string) {
+    if (!this.projectIndex) return [];
+    return this.projectIndex.getSymbolMatches(name);
+  }
+
   getDependencies(symbolName: string, depth?: number) {
     if (!this.projectIndex) return undefined;
     const cone = this.projectIndex.getDependencyCone(symbolName, depth);

--- a/src/serve/agent-bridge.ts
+++ b/src/serve/agent-bridge.ts
@@ -342,7 +342,9 @@ export class AgentBridge {
 
   getDependencies(symbolName: string, depth?: number) {
     if (!this.projectIndex) return undefined;
-    const cone = this.projectIndex.getDependencyCone(symbolName, depth);
+    const matches = this.projectIndex.getSymbolMatches(symbolName);
+    if (matches.length !== 1) return undefined;
+    const cone = this.projectIndex.getDependencyCone(matches[0]!.qualifiedName, depth);
     if (cone.length === 0) return undefined;
     return cone.map((sym) => ({
       name: getSymbolDisplayName(sym),
@@ -355,8 +357,9 @@ export class AgentBridge {
 
   getReferences(symbolName: string) {
     if (!this.projectIndex) return undefined;
-    const sym = this.projectIndex.getSymbol(symbolName);
-    if (!sym) return undefined;
+    const matches = this.projectIndex.getSymbolMatches(symbolName);
+    if (matches.length !== 1) return undefined;
+    const sym = matches[0]!;
     // Find all edges pointing TO this symbol
     const refs = this.projectIndex.dependencyEdges
       .filter((e) => e.to === sym.qualifiedName || e.to === sym.name)

--- a/src/serve/mcp-server.ts
+++ b/src/serve/mcp-server.ts
@@ -12,6 +12,10 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { z } from "zod";
 import { getSymbolDisplayName } from "../indexer/symbol-names.js";
+import {
+  formatAmbiguousSymbolMatches,
+  resolveSymbolInput,
+} from "../shared/symbol-resolution.js";
 import type { AgentBridge } from "./agent-bridge.js";
 import type { ServerMessage } from "./types.js";
 
@@ -69,25 +73,20 @@ function createMcpServer(bridge: AgentBridge, emit: (msg: ServerMessage) => void
     { name: z.string().describe("The symbol name or qualified name (e.g. 'Session' or 'Session.trim')") },
     async ({ name }) => {
       return wrapToolCall("read_symbol", { name }, async () => {
-        const matches = bridge.getSymbolMatches(name);
-        if (matches.length === 0) {
+        const resolution = resolveSymbolInput(bridge, name);
+        if (resolution.status === "missing") {
           return { content: [{ type: "text" as const, text: `Symbol "${name}" not found in the project index.` }], isError: true };
         }
-        if (matches.length > 1) {
-          const lines = [
-            `Symbol "${name}" is ambiguous; ${matches.length} matches were found.`,
-            "Re-run read_symbol with one of these qualified or disambiguated names:",
-            "",
-            ...matches.map((match) =>
-              `- ${getSymbolDisplayName(match)} (${match.kind}) — ${match.filePath}:${match.startLine} — qualified: ${match.qualifiedName}`,
-            ),
-          ];
-          return { content: [{ type: "text" as const, text: lines.join("\n") }], isError: true };
+        if (resolution.status === "ambiguous") {
+          return {
+            content: [{ type: "text" as const, text: formatAmbiguousSymbolMatches("read_symbol", name, resolution.matches) }],
+            isError: true,
+          };
         }
-        const sym = matches[0]!;
+        const sym = resolution.symbol;
 
-        const deps = bridge.getDependencies(name, 1);
-        const refs = bridge.getReferences(name);
+        const deps = bridge.getDependencies(sym.qualifiedName, 1);
+        const refs = bridge.getReferences(sym.qualifiedName);
 
         const lines: string[] = [
           `## ${sym.kind}: ${getSymbolDisplayName(sym)}`,
@@ -134,17 +133,32 @@ function createMcpServer(bridge: AgentBridge, emit: (msg: ServerMessage) => void
   server.tool(
     "find_references",
     "Find all symbols that call, import, or reference a given symbol. Essential for understanding impact before making changes.",
-    { name: z.string().describe("The symbol name to find references for") },
+    { name: z.string().describe("The symbol name or qualified name to find references for") },
     async ({ name }) => {
       return wrapToolCall("find_references", { name }, async () => {
-        const refs = bridge.getReferences(name);
+        const resolution = resolveSymbolInput(bridge, name);
+        if (resolution.status === "missing") {
+          return { content: [{ type: "text" as const, text: `Symbol "${name}" not found.` }], isError: true };
+        }
+        if (resolution.status === "ambiguous") {
+          return {
+            content: [{ type: "text" as const, text: formatAmbiguousSymbolMatches("find_references", name, resolution.matches) }],
+            isError: true,
+          };
+        }
+
+        const symbol = resolution.symbol;
+        const refs = bridge.getReferences(symbol.qualifiedName);
         if (!refs || refs.length === 0) {
           return { content: [{ type: "text" as const, text: `No references found for "${name}".` }] };
         }
 
-        const lines = [`References to "${name}":`, ...refs.map((r) => `  - ${r.name ?? r.from} (${r.kind})`)];
+        const lines = [
+          `References to ${getSymbolDisplayName(symbol)}:`,
+          ...refs.map((r) => `  - ${r.name ?? r.from} (${r.kind})`),
+        ];
 
-        const annotations = bridge.getAnnotationsForSymbol(name);
+        const annotations = bridge.getAnnotationsForSymbol(symbol.qualifiedName);
         if (annotations.length > 0) {
           lines.push("", `[User annotation: ${annotations.join("; ")}]`);
         }
@@ -158,22 +172,34 @@ function createMcpServer(bridge: AgentBridge, emit: (msg: ServerMessage) => void
     "get_dependencies",
     "Get the dependency cone of a symbol — everything it calls, imports, extends, or references. Essential for understanding implementation and data flow.",
     {
-      name: z.string().describe("The symbol name to get dependencies for"),
+      name: z.string().describe("The symbol name or qualified name to get dependencies for"),
       depth: z.number().optional().default(2).describe("How many levels deep to traverse (default: 2)"),
     },
     async ({ name, depth }) => {
       return wrapToolCall("get_dependencies", { name, depth }, async () => {
-        const deps = bridge.getDependencies(name, depth);
+        const resolution = resolveSymbolInput(bridge, name);
+        if (resolution.status === "missing") {
+          return { content: [{ type: "text" as const, text: `Symbol "${name}" not found.` }], isError: true };
+        }
+        if (resolution.status === "ambiguous") {
+          return {
+            content: [{ type: "text" as const, text: formatAmbiguousSymbolMatches("get_dependencies", name, resolution.matches) }],
+            isError: true,
+          };
+        }
+
+        const symbol = resolution.symbol;
+        const deps = bridge.getDependencies(symbol.qualifiedName, depth);
         if (!deps || deps.length === 0) {
           return { content: [{ type: "text" as const, text: `No dependencies found for "${name}".` }] };
         }
 
         const lines = [
-          `Dependencies of "${name}" (depth=${depth}):`,
+          `Dependencies of ${getSymbolDisplayName(symbol)} (depth=${depth}):`,
           ...deps.map((d) => `  - ${d.qualifiedName} (${d.kind}) — ${d.filePath}`),
         ];
 
-        const annotations = bridge.getAnnotationsForSymbol(name);
+        const annotations = bridge.getAnnotationsForSymbol(symbol.qualifiedName);
         if (annotations.length > 0) {
           lines.push("", `[User annotation: ${annotations.join("; ")}]`);
         }
@@ -213,7 +239,9 @@ function createMcpServer(bridge: AgentBridge, emit: (msg: ServerMessage) => void
 
         const lines = [
           `Found ${matches.length} symbol(s) matching "${query}":`,
-          ...matches.map((s) => `  - ${s.name} (${s.kind}) — ${s.filePath}:${s.startLine}${s.signature ? `\n    ${s.signature}` : ""}`),
+          ...matches.map((s) =>
+            `  - ${s.name} (${s.kind}) — ${s.filePath}:${s.startLine} — qualified: ${s.qualifiedName}${s.signature ? `\n    ${s.signature}` : ""}`,
+          ),
         ];
 
         return { content: [{ type: "text" as const, text: lines.join("\n") }] };
@@ -225,8 +253,8 @@ function createMcpServer(bridge: AgentBridge, emit: (msg: ServerMessage) => void
     "find_path",
     "Find the shortest dependency path between two symbols, or trace a symbol back to an entry point. Useful for understanding how code connects.",
     {
-      from: z.string().describe("Source symbol name"),
-      to: z.string().optional().describe("Target symbol name. If omitted, traces back to the nearest entry point."),
+      from: z.string().describe("Source symbol name or qualified name"),
+      to: z.string().optional().describe("Target symbol name or qualified name. If omitted, traces back to the nearest entry point."),
     },
     async ({ from, to }) => {
       return wrapToolCall("find_path", { from, to }, async () => {
@@ -234,16 +262,28 @@ function createMcpServer(bridge: AgentBridge, emit: (msg: ServerMessage) => void
           return { content: [{ type: "text" as const, text: "No project index available." }], isError: true };
         }
 
-        // Use the bridge's project index via getSymbol to verify symbols exist
-        const fromSym = bridge.getSymbol(from);
-        if (!fromSym) {
+        const fromResolution = resolveSymbolInput(bridge, from);
+        if (fromResolution.status === "missing") {
           return { content: [{ type: "text" as const, text: `Symbol "${from}" not found.` }], isError: true };
         }
+        if (fromResolution.status === "ambiguous") {
+          return {
+            content: [{ type: "text" as const, text: formatAmbiguousSymbolMatches("find_path", from, fromResolution.matches) }],
+            isError: true,
+          };
+        }
+        const fromSym = fromResolution.symbol;
 
         if (to) {
-          const toSym = bridge.getSymbol(to);
-          if (!toSym) {
+          const toResolution = resolveSymbolInput(bridge, to);
+          if (toResolution.status === "missing") {
             return { content: [{ type: "text" as const, text: `Symbol "${to}" not found.` }], isError: true };
+          }
+          if (toResolution.status === "ambiguous") {
+            return {
+              content: [{ type: "text" as const, text: formatAmbiguousSymbolMatches("find_path", to, toResolution.matches) }],
+              isError: true,
+            };
           }
         }
 
@@ -269,7 +309,11 @@ function createMcpServer(bridge: AgentBridge, emit: (msg: ServerMessage) => void
         const startId = fromSym.qualifiedName;
 
         if (to) {
-          const toSym = bridge.getSymbol(to)!;
+          const toResolution = resolveSymbolInput(bridge, to);
+          if (toResolution.status !== "resolved") {
+            return { content: [{ type: "text" as const, text: `Symbol "${to}" could not be resolved.` }], isError: true };
+          }
+          const toSym = toResolution.symbol;
           const endId = toSym.qualifiedName;
           // BFS shortest path
           const visited = new Set<string>([startId]);

--- a/src/serve/mcp-server.ts
+++ b/src/serve/mcp-server.ts
@@ -69,10 +69,22 @@ function createMcpServer(bridge: AgentBridge, emit: (msg: ServerMessage) => void
     { name: z.string().describe("The symbol name or qualified name (e.g. 'Session' or 'Session.trim')") },
     async ({ name }) => {
       return wrapToolCall("read_symbol", { name }, async () => {
-        const sym = bridge.getSymbol(name);
-        if (!sym) {
+        const matches = bridge.getSymbolMatches(name);
+        if (matches.length === 0) {
           return { content: [{ type: "text" as const, text: `Symbol "${name}" not found in the project index.` }], isError: true };
         }
+        if (matches.length > 1) {
+          const lines = [
+            `Symbol "${name}" is ambiguous; ${matches.length} matches were found.`,
+            "Re-run read_symbol with one of these qualified or disambiguated names:",
+            "",
+            ...matches.map((match) =>
+              `- ${getSymbolDisplayName(match)} (${match.kind}) — ${match.filePath}:${match.startLine} — qualified: ${match.qualifiedName}`,
+            ),
+          ];
+          return { content: [{ type: "text" as const, text: lines.join("\n") }], isError: true };
+        }
+        const sym = matches[0]!;
 
         const deps = bridge.getDependencies(name, 1);
         const refs = bridge.getReferences(name);

--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -11,6 +11,7 @@ import { handleChatCompletions, handleModels } from "./openai-compat.js";
 import { formatConfigForDisplay, getConfigMissing } from "../agent/config.js";
 import { applyPersistedConfigUpdates, buildStructuredConfigPayload } from "../agent/editable-config.js";
 import { sortModelsAlphabetically } from "../model-utils.js";
+import { serializeSymbolMatch } from "../shared/symbol-resolution.js";
 import type { ServerMessage } from "./types.js";
 import type { WebSocketServer } from "ws";
 import { handleMcpRequest } from "./mcp-server.js";
@@ -253,7 +254,19 @@ export function createRequestHandler(
         const name = decodeURIComponent(pathname.slice("/api/symbols/".length, -"/dependencies".length));
         const depthParam = url.searchParams.get("depth");
         const depth = depthParam ? Number(depthParam) : undefined;
-        const result = bridge.getDependencies(name, depth);
+        const matches = bridge.getSymbolMatches(name);
+        if (matches.length === 0) {
+          sendJson(res, 404, { error: `Symbol "${name}" not found` });
+          return;
+        }
+        if (matches.length > 1) {
+          sendJson(res, 409, {
+            error: `Symbol "${name}" is ambiguous`,
+            candidates: matches.map(serializeSymbolMatch),
+          });
+          return;
+        }
+        const result = bridge.getDependencies(matches[0]!.qualifiedName, depth);
         if (!result) {
           sendJson(res, 404, { error: `Symbol "${name}" not found` });
           return;
@@ -264,7 +277,19 @@ export function createRequestHandler(
 
       if (pathname.startsWith("/api/symbols/") && pathname.endsWith("/references") && method === "GET") {
         const name = decodeURIComponent(pathname.slice("/api/symbols/".length, -"/references".length));
-        const result = bridge.getReferences(name);
+        const matches = bridge.getSymbolMatches(name);
+        if (matches.length === 0) {
+          sendJson(res, 404, { error: `Symbol "${name}" not found` });
+          return;
+        }
+        if (matches.length > 1) {
+          sendJson(res, 409, {
+            error: `Symbol "${name}" is ambiguous`,
+            candidates: matches.map(serializeSymbolMatch),
+          });
+          return;
+        }
+        const result = bridge.getReferences(matches[0]!.qualifiedName);
         if (!result) {
           sendJson(res, 404, { error: `Symbol "${name}" not found` });
           return;
@@ -275,11 +300,19 @@ export function createRequestHandler(
 
       if (pathname.startsWith("/api/symbols/") && pathname.endsWith("/source") && method === "GET") {
         const name = decodeURIComponent(pathname.slice("/api/symbols/".length, -"/source".length));
-        const sym = bridge.getSymbol(name);
-        if (!sym) {
+        const matches = bridge.getSymbolMatches(name);
+        if (matches.length === 0) {
           sendJson(res, 404, { error: `Symbol "${name}" not found` });
           return;
         }
+        if (matches.length > 1) {
+          sendJson(res, 409, {
+            error: `Symbol "${name}" is ambiguous`,
+            candidates: matches.map(serializeSymbolMatch),
+          });
+          return;
+        }
+        const sym = matches[0]!;
         try {
           const fileContent = await readFile(path.resolve(config.workspaceRoot, sym.filePath), "utf8");
           const lines = fileContent.split(/\r?\n/);

--- a/src/shared/graph-symbols.ts
+++ b/src/shared/graph-symbols.ts
@@ -1,0 +1,119 @@
+export interface GraphSymbolNodeLike {
+  id?: string;
+  qualifiedName?: string;
+  name?: string;
+  exported?: boolean;
+}
+
+function dedupe(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.length > 0))];
+}
+
+function stripCollisionSuffix(value: string): string {
+  const hashIndex = value.indexOf("#");
+  return hashIndex >= 0 ? value.slice(0, hashIndex) : value;
+}
+
+function stripDisplayKindSuffix(value: string): string {
+  return value.replace(/\s+\([^()]+\)$/, "");
+}
+
+export function getGraphNodeId(node: GraphSymbolNodeLike, fallbackId = ""): string {
+  return node.qualifiedName || node.id || fallbackId || node.name || "";
+}
+
+export function getGraphNodeLabel(node: GraphSymbolNodeLike, fallbackId = ""): string {
+  const label = node.name?.trim();
+  if (label && label.length > 0) {
+    return label;
+  }
+
+  const id = getGraphNodeId(node, fallbackId);
+  return id.split(".").pop() || id;
+}
+
+export function getGraphNodeAliases(node: GraphSymbolNodeLike, fallbackId = ""): string[] {
+  const id = getGraphNodeId(node, fallbackId);
+  const label = getGraphNodeLabel(node, fallbackId);
+  const shortId = id.split(".").pop() || id;
+
+  return dedupe([
+    id,
+    node.id ?? "",
+    node.qualifiedName ?? "",
+    label,
+    stripDisplayKindSuffix(label),
+    shortId,
+    stripCollisionSuffix(shortId),
+    stripCollisionSuffix(id),
+  ]);
+}
+
+function compareLabels(a: string, b: string): number {
+  return a.localeCompare(b, undefined, { sensitivity: "base" });
+}
+
+export function compareGraphNodeIds(
+  a: string,
+  b: string,
+  nodes: ReadonlyMap<string, GraphSymbolNodeLike>,
+): number {
+  const nodeA = nodes.get(a);
+  const nodeB = nodes.get(b);
+  const exportedA = nodeA ? Number(!!nodeA.exported) : 0;
+  const exportedB = nodeB ? Number(!!nodeB.exported) : 0;
+  if (exportedA !== exportedB) {
+    return exportedB - exportedA;
+  }
+
+  const labelA = getGraphNodeLabel(nodeA ?? {}, a);
+  const labelB = getGraphNodeLabel(nodeB ?? {}, b);
+  const labelComparison = compareLabels(labelA, labelB);
+  if (labelComparison !== 0) {
+    return labelComparison;
+  }
+
+  return compareLabels(a, b);
+}
+
+export function matchesGraphNodeQuery(
+  query: string,
+  node: GraphSymbolNodeLike,
+  fallbackId = "",
+): boolean {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (normalizedQuery.length === 0) {
+    return false;
+  }
+
+  return getGraphNodeAliases(node, fallbackId).some((alias) =>
+    alias.toLowerCase().includes(normalizedQuery),
+  );
+}
+
+export function resolveGraphNodeIds(
+  nodes: ReadonlyMap<string, GraphSymbolNodeLike>,
+  symbolName: string,
+): string[] {
+  const query = symbolName.trim();
+  if (query.length === 0) {
+    return [];
+  }
+
+  if (nodes.has(query)) {
+    return [query];
+  }
+
+  const exactMatches = [...nodes.entries()]
+    .filter(([id, node]) => getGraphNodeAliases(node, id).includes(query))
+    .map(([id]) => id)
+    .sort((a, b) => compareGraphNodeIds(a, b, nodes));
+  if (exactMatches.length > 0) {
+    return exactMatches;
+  }
+
+  return [...nodes.entries()]
+    .filter(([id, node]) => matchesGraphNodeQuery(query, node, id))
+    .map(([id]) => id)
+    .sort((a, b) => compareGraphNodeIds(a, b, nodes));
+}

--- a/src/shared/symbol-resolution.ts
+++ b/src/shared/symbol-resolution.ts
@@ -1,0 +1,58 @@
+import { getSymbolDisplayName } from "../indexer/symbol-names.js";
+import type { IndexedSymbol } from "../indexer/types.js";
+
+export type SymbolResolution =
+  | { status: "missing" }
+  | { status: "ambiguous"; matches: IndexedSymbol[] }
+  | { status: "resolved"; symbol: IndexedSymbol };
+
+export function resolveSymbolInput(
+  projectIndex: { getSymbolMatches(name: string): IndexedSymbol[] },
+  name: string,
+): SymbolResolution {
+  const matches = projectIndex.getSymbolMatches(name);
+  if (matches.length === 0) {
+    return { status: "missing" };
+  }
+  if (matches.length > 1) {
+    return { status: "ambiguous", matches };
+  }
+  return { status: "resolved", symbol: matches[0]! };
+}
+
+export function formatSymbolMatch(match: IndexedSymbol): string {
+  return `${getSymbolDisplayName(match)} (${match.kind}) — ${match.filePath}:${match.startLine} — qualified: ${match.qualifiedName}`;
+}
+
+export function formatAmbiguousSymbolMatches(
+  toolName: string,
+  name: string,
+  matches: IndexedSymbol[],
+): string {
+  return [
+    `Symbol "${name}" is ambiguous; ${matches.length} matches were found.`,
+    `Re-run ${toolName} with one of these qualified or disambiguated names:`,
+    "",
+    ...matches.map((match) => `- ${formatSymbolMatch(match)}`),
+  ].join("\n");
+}
+
+export function serializeSymbolMatch(match: IndexedSymbol): {
+  name: string;
+  qualifiedName: string;
+  kind: string;
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  signature: string;
+} {
+  return {
+    name: getSymbolDisplayName(match),
+    qualifiedName: match.qualifiedName,
+    kind: match.kind,
+    filePath: match.filePath,
+    startLine: match.startLine,
+    endLine: match.endLine,
+    signature: match.signature,
+  };
+}

--- a/src/tools/find-path.ts
+++ b/src/tools/find-path.ts
@@ -2,6 +2,10 @@ import type { ToolDefinition } from "@minicode/agent-sdk";
 import { expectNonEmptyString, expectOptionalNumber } from "@minicode/agent-sdk";
 import { getSymbolDisplayName } from "../indexer/symbol-names.js";
 import type { ProjectIndex } from "../indexer/types.js";
+import {
+  formatAmbiguousSymbolMatches,
+  resolveSymbolInput,
+} from "../shared/symbol-resolution.js";
 
 export function createFindPathTool(
   projectIndex: ProjectIndex,
@@ -37,19 +41,31 @@ export function createFindPathTool(
       const to = typeof input.to === "string" && input.to.length > 0 ? input.to : undefined;
       const maxDepth = expectOptionalNumber(input, "max_depth");
 
-      const fromSymbol = projectIndex.getSymbol(from);
-      if (!fromSymbol) {
+      const fromResolution = resolveSymbolInput(projectIndex, from);
+      if (fromResolution.status === "missing") {
         return `Symbol "${from}" not found in the project index.`;
       }
+      if (fromResolution.status === "ambiguous") {
+        return formatAmbiguousSymbolMatches("find_path", from, fromResolution.matches);
+      }
+      const fromSymbol = fromResolution.symbol;
 
       if (to) {
         // Path between two symbols
-        const toSymbol = projectIndex.getSymbol(to);
-        if (!toSymbol) {
+        const toResolution = resolveSymbolInput(projectIndex, to);
+        if (toResolution.status === "missing") {
           return `Symbol "${to}" not found in the project index.`;
         }
+        if (toResolution.status === "ambiguous") {
+          return formatAmbiguousSymbolMatches("find_path", to, toResolution.matches);
+        }
+        const toSymbol = toResolution.symbol;
 
-        const path = projectIndex.findPath(from, to, maxDepth ?? 10);
+        const path = projectIndex.findPath(
+          fromSymbol.qualifiedName,
+          toSymbol.qualifiedName,
+          maxDepth ?? 10,
+        );
         if (path.length === 0) {
           return `No path found between "${from}" and "${to}".`;
         }
@@ -66,7 +82,7 @@ export function createFindPathTool(
         ].join("\n");
       } else {
         // Trace to entry point(s)
-        const paths = projectIndex.findPathToEntryPoint(from, maxDepth ?? 20);
+        const paths = projectIndex.findPathToEntryPoint(fromSymbol.qualifiedName, maxDepth ?? 20);
 
         if (paths.length === 0) {
           return `No entry point paths found for "${from}". It may itself be an entry point.`;

--- a/src/tools/find-references.ts
+++ b/src/tools/find-references.ts
@@ -2,6 +2,10 @@ import type { ToolDefinition } from "@minicode/agent-sdk";
 import { expectNonEmptyString, expectOptionalNumber } from "@minicode/agent-sdk";
 import { getSymbolDisplayName } from "../indexer/symbol-names.js";
 import type { ProjectIndex } from "../indexer/types.js";
+import {
+  formatAmbiguousSymbolMatches,
+  resolveSymbolInput,
+} from "../shared/symbol-resolution.js";
 
 const DEFAULT_LIMIT = 50;
 
@@ -38,10 +42,14 @@ export function createFindReferencesTool(
       const skip = Math.max(0, expectOptionalNumber(input, "skip") ?? 0);
       const limit = Math.max(1, Math.min(100, expectOptionalNumber(input, "limit") ?? DEFAULT_LIMIT));
 
-      const symbol = projectIndex.getSymbol(name);
-      if (!symbol) {
+      const resolution = resolveSymbolInput(projectIndex, name);
+      if (resolution.status === "missing") {
         return `Symbol "${name}" not found in the project index.`;
       }
+      if (resolution.status === "ambiguous") {
+        return formatAmbiguousSymbolMatches("find_references", name, resolution.matches);
+      }
+      const symbol = resolution.symbol;
 
       const refs = projectIndex.dependencyEdges.filter(
         (e) => e.to === symbol.qualifiedName || e.to === symbol.name,

--- a/src/tools/get-dependencies.ts
+++ b/src/tools/get-dependencies.ts
@@ -2,6 +2,10 @@ import type { ToolDefinition } from "@minicode/agent-sdk";
 import { expectNonEmptyString, expectOptionalNumber } from "@minicode/agent-sdk";
 import { getSymbolDisplayName } from "../indexer/symbol-names.js";
 import type { ProjectIndex } from "../indexer/types.js";
+import {
+  formatAmbiguousSymbolMatches,
+  resolveSymbolInput,
+} from "../shared/symbol-resolution.js";
 
 export function createGetDependenciesTool(
   projectIndex: ProjectIndex,
@@ -42,12 +46,16 @@ export function createGetDependenciesTool(
       const skip = Math.max(0, expectOptionalNumber(input, "skip") ?? 0);
       const limit = Math.max(1, Math.min(100, expectOptionalNumber(input, "limit") ?? 50));
 
-      const symbol = projectIndex.getSymbol(name);
-      if (!symbol) {
+      const resolution = resolveSymbolInput(projectIndex, name);
+      if (resolution.status === "missing") {
         return `Symbol "${name}" not found in the project index.`;
       }
+      if (resolution.status === "ambiguous") {
+        return formatAmbiguousSymbolMatches("get_dependencies", name, resolution.matches);
+      }
+      const symbol = resolution.symbol;
 
-      const cone = projectIndex.getDependencyCone(name, depth);
+      const cone = projectIndex.getDependencyCone(symbol.qualifiedName, depth);
 
       const shown = cone.slice(skip, skip + limit);
       const lines = shown.map((s) => {

--- a/src/tools/read-symbol.ts
+++ b/src/tools/read-symbol.ts
@@ -8,21 +8,13 @@ import {
   expectOptionalBoolean,
 } from "@minicode/agent-sdk";
 import { getSymbolDisplayName } from "../indexer/symbol-names.js";
-import type { IndexedSymbol, ProjectIndex } from "../indexer/types.js";
+import type { ProjectIndex } from "../indexer/types.js";
+import {
+  formatAmbiguousSymbolMatches,
+  resolveSymbolInput,
+} from "../shared/symbol-resolution.js";
 
 const LEADING_CONTEXT_LINES = 3;
-
-function formatAmbiguousSymbolMatches(name: string, matches: IndexedSymbol[]): string {
-  return [
-    `Symbol "${name}" is ambiguous; ${matches.length} matches were found.`,
-    "Re-run read_symbol with one of these qualified or disambiguated names:",
-    "",
-    ...matches.map(
-      (match) =>
-        `- ${getSymbolDisplayName(match)} (${match.kind}) — ${match.filePath}:${match.startLine} — qualified: ${match.qualifiedName}`,
-    ),
-  ].join("\n");
-}
 
 export function createReadSymbolTool(
   config: AgentConfig,
@@ -56,14 +48,14 @@ export function createReadSymbolTool(
       const name = expectNonEmptyString(input, "name");
       const includeBody = expectOptionalBoolean(input, "includeBody") ?? true;
 
-      const matches = projectIndex.getSymbolMatches(name);
-      if (matches.length === 0) {
+      const resolution = resolveSymbolInput(projectIndex, name);
+      if (resolution.status === "missing") {
         return `Symbol "${name}" not found in the project index. Try using search to find it, or use read_file to read the full file.`;
       }
-      if (matches.length > 1) {
-        return formatAmbiguousSymbolMatches(name, matches);
+      if (resolution.status === "ambiguous") {
+        return formatAmbiguousSymbolMatches("read_symbol", name, resolution.matches);
       }
-      const symbol = matches[0]!;
+      const symbol = resolution.symbol;
 
       const filePath = resolveWorkspacePath(
         symbol.filePath,
@@ -128,7 +120,7 @@ export function createReadSymbolTool(
           parts.push("", "## Calls", "", calls.map((s) => `- ${s}`).join("\n"));
         }
 
-        const cone = projectIndex.getDependencyCone(name, 1);
+        const cone = projectIndex.getDependencyCone(symbol.qualifiedName, 1);
         const typeRefs = cone.filter(
           (s) =>
             s.qualifiedName !== symbol.qualifiedName &&

--- a/src/tools/read-symbol.ts
+++ b/src/tools/read-symbol.ts
@@ -8,9 +8,21 @@ import {
   expectOptionalBoolean,
 } from "@minicode/agent-sdk";
 import { getSymbolDisplayName } from "../indexer/symbol-names.js";
-import type { ProjectIndex } from "../indexer/types.js";
+import type { IndexedSymbol, ProjectIndex } from "../indexer/types.js";
 
 const LEADING_CONTEXT_LINES = 3;
+
+function formatAmbiguousSymbolMatches(name: string, matches: IndexedSymbol[]): string {
+  return [
+    `Symbol "${name}" is ambiguous; ${matches.length} matches were found.`,
+    "Re-run read_symbol with one of these qualified or disambiguated names:",
+    "",
+    ...matches.map(
+      (match) =>
+        `- ${getSymbolDisplayName(match)} (${match.kind}) — ${match.filePath}:${match.startLine} — qualified: ${match.qualifiedName}`,
+    ),
+  ].join("\n");
+}
 
 export function createReadSymbolTool(
   config: AgentConfig,
@@ -21,6 +33,7 @@ export function createReadSymbolTool(
     description:
       "Read a specific function, class, or type definition by name. " +
       "Returns the symbol's source code, referenced types, callers, and callees. " +
+      "If a bare name matches multiple symbols, returns disambiguation candidates. " +
       "PREFER this over read_file for .ts/.tsx/.js/.jsx — use the code map to find symbol names.",
     inputSchema: {
       type: "object",
@@ -43,10 +56,14 @@ export function createReadSymbolTool(
       const name = expectNonEmptyString(input, "name");
       const includeBody = expectOptionalBoolean(input, "includeBody") ?? true;
 
-      const symbol = projectIndex.getSymbol(name);
-      if (!symbol) {
+      const matches = projectIndex.getSymbolMatches(name);
+      if (matches.length === 0) {
         return `Symbol "${name}" not found in the project index. Try using search to find it, or use read_file to read the full file.`;
       }
+      if (matches.length > 1) {
+        return formatAmbiguousSymbolMatches(name, matches);
+      }
+      const symbol = matches[0]!;
 
       const filePath = resolveWorkspacePath(
         symbol.filePath,

--- a/src/tools/search-code-map.ts
+++ b/src/tools/search-code-map.ts
@@ -1,9 +1,26 @@
 import type { ToolDefinition } from "@minicode/agent-sdk";
 import { expectNonEmptyString, expectOptionalNumber } from "@minicode/agent-sdk";
 import { getSymbolDisplayName, getSymbolLookupNames } from "../indexer/symbol-names.js";
-import type { ProjectIndex } from "../indexer/types.js";
+import type { IndexedSymbol, ProjectIndex } from "../indexer/types.js";
 
 const DEFAULT_LIMIT = 30;
+
+function compareMatchedSymbols(pattern: string, a: IndexedSymbol, b: IndexedSymbol): number {
+  const lowerPattern = pattern.toLowerCase();
+  const aDisplay = getSymbolDisplayName(a).toLowerCase();
+  const bDisplay = getSymbolDisplayName(b).toLowerCase();
+  const aExact = Number(aDisplay === lowerPattern || a.qualifiedName.toLowerCase() === lowerPattern || a.name.toLowerCase() === lowerPattern);
+  const bExact = Number(bDisplay === lowerPattern || b.qualifiedName.toLowerCase() === lowerPattern || b.name.toLowerCase() === lowerPattern);
+  if (aExact !== bExact) {
+    return bExact - aExact;
+  }
+
+  return Number(b.exported) - Number(a.exported) ||
+    aDisplay.localeCompare(bDisplay) ||
+    a.filePath.localeCompare(b.filePath) ||
+    a.startLine - b.startLine ||
+    a.qualifiedName.localeCompare(b.qualifiedName);
+}
 
 function matchesPattern(
   text: string,
@@ -22,7 +39,7 @@ export function createSearchCodeMapTool(
     description:
       "Search the full project index for symbols by name or substring. " +
       "Use when the code map is truncated and you need to find a symbol not listed. " +
-      "Returns qualified names and file paths; use read_symbol with the result.",
+      "Returns disambiguated display names, qualified names, and file paths; use read_symbol with the result.",
     inputSchema: {
       type: "object",
       properties: {
@@ -73,11 +90,12 @@ export function createSearchCodeMapTool(
           return false;
         }
         return true;
-      });
+      }).sort((a, b) => compareMatchedSymbols(pattern, a, b));
 
       const shown = matches.slice(skip, skip + limit);
       const lines = shown.map(
-        (s) => `- ${getSymbolDisplayName(s)} (${s.kind}) — ${s.filePath}`,
+        (s) =>
+          `- ${getSymbolDisplayName(s)} (${s.kind}) — ${s.filePath}:${s.startLine} — qualified: ${s.qualifiedName}`,
       );
       const remaining = matches.length - skip - shown.length;
       const footer =

--- a/src/web/graph.ts
+++ b/src/web/graph.ts
@@ -14,6 +14,12 @@ import {
   type StructuralAnalysisReport,
 } from './analysis-helpers.ts';
 import { KIND_COLORS, buildStylesheet } from '../shared/graph-styles.ts';
+import {
+  compareGraphNodeIds,
+  getGraphNodeLabel,
+  matchesGraphNodeQuery,
+  resolveGraphNodeIds,
+} from '../shared/graph-symbols.ts';
 
 declare const cytoscape: (opts: unknown) => CyInstance;
 declare const hljs: { highlightElement(el: HTMLElement): void };
@@ -191,7 +197,7 @@ export async function initGraph(): Promise<void> {
 
 export function highlightAgentActivity(symbolName: string): void {
   if (!cy) return;
-  void focusSymbolInGraph(symbolName, {
+  void focusResolvedSymbolsInGraph(symbolName, {
     maxDegrees: 0,
     pulse: true,
     pulseDuration: 2000,
@@ -285,6 +291,19 @@ interface FocusSymbolOptions {
 }
 
 async function focusSymbolInGraph(symbolId: string, options: FocusSymbolOptions = {}): Promise<void> {
+  await focusSymbolsInGraph([symbolId], options);
+}
+
+async function focusResolvedSymbolsInGraph(symbolName: string, options: FocusSymbolOptions = {}): Promise<void> {
+  const matches = resolveGraphNodeIds(graphNodes, symbolName);
+  if (matches.length === 0) {
+    return;
+  }
+
+  await focusSymbolsInGraph(matches, options);
+}
+
+async function focusSymbolsInGraph(symbolIds: string[], options: FocusSymbolOptions = {}): Promise<void> {
   if (!cy) return;
 
   const {
@@ -297,24 +316,45 @@ async function focusSymbolInGraph(symbolId: string, options: FocusSymbolOptions 
     openDetail = false,
   } = options;
 
-  renderNodeNeighborhoodAndLayout(symbolId, maxDegrees);
-  const node = findNode(symbolId);
-  if (!node) return;
-
-  if (animate) {
-    cy.animate({ center: { eles: node }, zoom }, { duration: 300 });
+  const uniqueIds = [...new Set(symbolIds)];
+  let addedNodes = false;
+  for (const symbolId of uniqueIds) {
+    const beforeNodeCount = cy.nodes().length;
+    addNodeNeighborhood(symbolId, maxDegrees);
+    if (cy.nodes().length > beforeNodeCount) {
+      addedNodes = true;
+    }
   }
 
-  if (pulse) {
-    node.addClass('agent-pulse');
-    setTimeout(() => node.removeClass('agent-pulse'), pulseDuration);
-  } else {
-    node.flashClass('highlighted', flashDuration);
+  connectExistingNodes();
+  refreshAnalysisGraphState();
+  if (addedNodes) {
+    runLayout();
   }
 
-  if (openDetail) {
+  const nodes = uniqueIds
+    .map((symbolId) => findNode(symbolId))
+    .filter((node): node is CyCollection => node !== null);
+  if (nodes.length === 0) return;
+  const primaryNode = nodes[0];
+
+  if (animate && primaryNode) {
+    cy.animate({ center: { eles: primaryNode }, zoom }, { duration: 300 });
+  }
+
+  for (const node of nodes) {
+    if (pulse) {
+      node.addClass('agent-pulse');
+      setTimeout(() => node.removeClass('agent-pulse'), pulseDuration);
+    } else {
+      node.flashClass('highlighted', flashDuration);
+    }
+  }
+
+  if (openDetail && primaryNode && uniqueIds.length === 1) {
     const detailEl = document.getElementById('symbol-detail');
     if (detailEl) {
+      const node = primaryNode;
       await showDetail(node, detailEl);
     }
   }
@@ -334,7 +374,7 @@ function addNodeToGraph(id: string): void {
   if (!nodeData) return;
 
   const kind = (nodeData.kind || 'function').toLowerCase();
-  const name = nodeData.name || id.split('.').pop() || id;
+  const name = getGraphNodeLabel(nodeData, id);
   const file = nodeData.filePath || nodeData.file || '';
 
   cy.add({
@@ -380,11 +420,10 @@ function findNode(name: string): CyCollection | null {
   if (!cy) return null;
   const node = cy.getElementById(name);
   if (node.length > 0) return node;
-  const match = cy.nodes().filter((n: CyElement) => {
-    const nName = (n.data('name') || '') as string;
-    const qName = (n.data('qualifiedName') || '') as string;
-    return nName === name || qName.endsWith('.' + name);
-  });
+  const matchingIds = new Set(resolveGraphNodeIds(graphNodes, name));
+  const match = cy.nodes().filter((n: CyElement) =>
+    matchingIds.has((n.data('qualifiedName') || n.data('id') || '') as string),
+  );
   return match.length > 0 ? match : null;
 }
 
@@ -1160,16 +1199,7 @@ function setupToolbar(): void {
   searchInput.parentNode!.appendChild(dropdown);
 
   // Rank symbols: exported first, then alphabetical by short name
-  const rankedSymbols = allSymbolNames.slice().sort((a, b) => {
-    const nodeA = graphNodes.get(a);
-    const nodeB = graphNodes.get(b);
-    const expA = nodeA ? !!nodeA.exported : false;
-    const expB = nodeB ? !!nodeB.exported : false;
-    if (expA !== expB) return expA ? -1 : 1;
-    const nameA = (a.split('.').pop() || '').toLowerCase();
-    const nameB = (b.split('.').pop() || '').toLowerCase();
-    return nameA.localeCompare(nameB);
-  });
+  const rankedSymbols = allSymbolNames.slice().sort((a, b) => compareGraphNodeIds(a, b, graphNodes));
 
   function showDropdownResults(matches: string[]): void {
     if (matches.length === 0) {
@@ -1180,7 +1210,7 @@ function setupToolbar(): void {
     dropdown.innerHTML = matches.map((name) => {
       const node = graphNodes.get(name);
       const kind = node ? (node.kind || '').toLowerCase() : '';
-      const shortName = name.split('.').pop() || name;
+      const shortName = getGraphNodeLabel(node || {}, name);
       const kindColor = KIND_COLORS[kind] ? KIND_COLORS[kind]!.border : '#565f89';
       return `<div class="search-result" data-id="${escapeHtml(name)}">
         <span class="search-result-name">${escapeHtml(shortName)}</span>
@@ -1222,8 +1252,7 @@ function setupToolbar(): void {
       }
 
       const matches = rankedSymbols.filter((name) => {
-        const shortName = (name.split('.').pop() || '').toLowerCase();
-        return shortName.includes(query) || name.toLowerCase().includes(query);
+        return matchesGraphNodeQuery(query, graphNodes.get(name) || {}, name);
       }).slice(0, 15);
 
       showDropdownResults(matches);

--- a/tests/find-path.test.ts
+++ b/tests/find-path.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import path from "node:path";
 import { test } from "node:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 
-import { createProjectIndex } from "../src/indexer/project-index.js";
+import { buildProjectIndex, createProjectIndex } from "../src/indexer/project-index.js";
 import { createFindPathTool } from "../src/tools/find-path.js";
 import type { DependencyEdge, IndexedSymbol } from "../src/indexer/types.js";
 
@@ -202,7 +204,6 @@ test("find_path tool reports no path when symbols are disconnected", async () =>
 });
 
 test("find_path tool works with real project index", async () => {
-  const { buildProjectIndex } = await import("../src/indexer/project-index.js");
   const root = path.resolve(import.meta.dirname, "..");
   const projectIndex = await buildProjectIndex(root);
   const tool = createFindPathTool(projectIndex);
@@ -214,4 +215,60 @@ test("find_path tool works with real project index", async () => {
   });
   assert.ok(result.includes("# Path from createModelClient to AgentConfig"));
   assert.ok(result.includes("symbols"));
+});
+
+test("find_path returns disambiguation list for ambiguous bare target symbols", async () => {
+  const workspaceRoot = await mkdtemp(path.join(tmpdir(), "minicode-find-path-collisions-"));
+  await writeFile(
+    path.join(workspaceRoot, "sample.ts"),
+    `export type Review = { id: string };
+
+export class Review {
+  constructor(public id: string) {}
+}
+
+export function createReview(id: string) {
+  return new Review(id);
+}
+`,
+    "utf8",
+  );
+
+  const projectIndex = await buildProjectIndex(workspaceRoot);
+  const tool = createFindPathTool(projectIndex);
+
+  const result = await tool.execute({ from: "createReview", to: "Review" });
+
+  assert.ok(result.includes('Symbol "Review" is ambiguous'));
+  assert.ok(result.includes("Review (type)"));
+  assert.ok(result.includes("Review (class)"));
+  assert.ok(result.includes("qualified: Review#type"));
+  assert.ok(result.includes("qualified: Review#class"));
+});
+
+test("find_path accepts qualified names for colliding symbols", async () => {
+  const workspaceRoot = await mkdtemp(path.join(tmpdir(), "minicode-find-path-qualified-"));
+  await writeFile(
+    path.join(workspaceRoot, "sample.ts"),
+    `export type Review = { id: string };
+
+export class Review {
+  constructor(public id: string) {}
+}
+
+export function createReview(id: string) {
+  return new Review(id);
+}
+`,
+    "utf8",
+  );
+
+  const projectIndex = await buildProjectIndex(workspaceRoot);
+  const tool = createFindPathTool(projectIndex);
+
+  const result = await tool.execute({ from: "createReview", to: "Review#class" });
+
+  assert.ok(result.includes("# Path from createReview to Review (class)"));
+  assert.ok(result.includes("[function] createReview"));
+  assert.ok(result.includes("[class] Review (class)"));
 });

--- a/tests/find-references.test.ts
+++ b/tests/find-references.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import path from "node:path";
 import { test } from "node:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 
 import { buildProjectIndex } from "../src/indexer/project-index.js";
 import { createFindReferencesTool } from "../src/tools/find-references.js";
@@ -40,4 +42,67 @@ test("find_references appears in tool registry when projectIndex provided", asyn
   const findRefs = schemas.find((s) => s.name === "find_references");
 
   assert.ok(findRefs);
+});
+
+test("find_references returns disambiguation list for ambiguous bare symbol names", async () => {
+  const workspaceRoot = await mkdtemp(path.join(tmpdir(), "minicode-find-references-collisions-"));
+  await writeFile(
+    path.join(workspaceRoot, "sample.ts"),
+    `export type Review = { id: string };
+
+export function serializeReview(review: Review) {
+  return review.id;
+}
+
+export class Review {
+  constructor(public id: string) {}
+}
+
+export function createReview(id: string) {
+  return new Review(id);
+}
+`,
+    "utf8",
+  );
+
+  const projectIndex = await buildProjectIndex(workspaceRoot);
+  const tool = createFindReferencesTool(projectIndex);
+
+  const result = await tool.execute({ name: "Review" });
+
+  assert.ok(result.includes('Symbol "Review" is ambiguous'));
+  assert.ok(result.includes("Review (type)"));
+  assert.ok(result.includes("Review (class)"));
+  assert.ok(result.includes("qualified: Review#type"));
+  assert.ok(result.includes("qualified: Review#class"));
+});
+
+test("find_references accepts qualified names for colliding symbols", async () => {
+  const workspaceRoot = await mkdtemp(path.join(tmpdir(), "minicode-find-references-qualified-"));
+  await writeFile(
+    path.join(workspaceRoot, "sample.ts"),
+    `export type Review = { id: string };
+
+export function serializeReview(review: Review) {
+  return review.id;
+}
+
+export class Review {
+  constructor(public id: string) {}
+}
+
+export function createReview(id: string) {
+  return new Review(id);
+}
+`,
+    "utf8",
+  );
+
+  const projectIndex = await buildProjectIndex(workspaceRoot);
+  const tool = createFindReferencesTool(projectIndex);
+
+  const result = await tool.execute({ name: "Review#class" });
+
+  assert.ok(result.includes("# References to Review (class)"));
+  assert.ok(result.includes("createReview"));
 });

--- a/tests/get-dependencies.test.ts
+++ b/tests/get-dependencies.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import path from "node:path";
 import { test } from "node:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 
 import { buildProjectIndex } from "../src/indexer/project-index.js";
 import { createGetDependenciesTool } from "../src/tools/get-dependencies.js";
@@ -42,4 +44,33 @@ test("get_dependencies returns error for unknown symbol", async () => {
   const result = await tool.execute({ name: "NonExistent" });
 
   assert.ok(result.includes("not found"));
+});
+
+test("get_dependencies returns disambiguation list for ambiguous bare symbol names", async () => {
+  const workspaceRoot = await mkdtemp(path.join(tmpdir(), "minicode-get-dependencies-collisions-"));
+  await writeFile(
+    path.join(workspaceRoot, "sample.ts"),
+    `export type Review = { id: string };
+
+export class Review {
+  constructor(public id: string) {}
+}
+
+export function createReview(id: string) {
+  return new Review(id);
+}
+`,
+    "utf8",
+  );
+
+  const projectIndex = await buildProjectIndex(workspaceRoot);
+  const tool = createGetDependenciesTool(projectIndex);
+
+  const result = await tool.execute({ name: "Review" });
+
+  assert.ok(result.includes('Symbol "Review" is ambiguous'));
+  assert.ok(result.includes("Review (type)"));
+  assert.ok(result.includes("Review (class)"));
+  assert.ok(result.includes("qualified: Review#type"));
+  assert.ok(result.includes("qualified: Review#class"));
 });

--- a/tests/graph-symbols.test.ts
+++ b/tests/graph-symbols.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  compareGraphNodeIds,
+  getGraphNodeLabel,
+  matchesGraphNodeQuery,
+  resolveGraphNodeIds,
+} from "../src/shared/graph-symbols.js";
+
+test("getGraphNodeLabel prefers display names for graph collisions", () => {
+  assert.equal(
+    getGraphNodeLabel({ name: "Review (class)", qualifiedName: "Review#class" }),
+    "Review (class)",
+  );
+  assert.equal(
+    getGraphNodeLabel({ qualifiedName: "Session.trim" }),
+    "trim",
+  );
+});
+
+test("resolveGraphNodeIds returns all exact bare-name collisions", () => {
+  const nodes = new Map([
+    ["Review#type", { name: "Review (type)", qualifiedName: "Review#type", exported: true }],
+    ["Review#class", { name: "Review (class)", qualifiedName: "Review#class", exported: true }],
+    ["Review.constructor", { name: "Review.constructor", qualifiedName: "Review.constructor", exported: false }],
+  ]);
+
+  assert.deepEqual(resolveGraphNodeIds(nodes, "Review"), [
+    "Review#class",
+    "Review#type",
+  ]);
+  assert.deepEqual(resolveGraphNodeIds(nodes, "Review (class)"), [
+    "Review#class",
+  ]);
+  assert.deepEqual(resolveGraphNodeIds(nodes, "Review#type"), [
+    "Review#type",
+  ]);
+});
+
+test("matchesGraphNodeQuery supports disambiguated labels and bare collision names", () => {
+  const typeNode = { name: "Review (type)", qualifiedName: "Review#type" };
+  const classNode = { name: "Review (class)", qualifiedName: "Review#class" };
+
+  assert.equal(matchesGraphNodeQuery("Review", typeNode, "Review#type"), true);
+  assert.equal(matchesGraphNodeQuery("Review", classNode, "Review#class"), true);
+  assert.equal(matchesGraphNodeQuery("class", classNode, "Review#class"), true);
+  assert.equal(matchesGraphNodeQuery("type", classNode, "Review#class"), false);
+});
+
+test("compareGraphNodeIds sorts exported collisions by label", () => {
+  const nodes = new Map([
+    ["Review#type", { name: "Review (type)", qualifiedName: "Review#type", exported: true }],
+    ["Review#class", { name: "Review (class)", qualifiedName: "Review#class", exported: true }],
+    ["internalReviewHelper", { name: "internalReviewHelper", qualifiedName: "internalReviewHelper", exported: false }],
+  ]);
+
+  const sorted = [...nodes.keys()].sort((a, b) => compareGraphNodeIds(a, b, nodes));
+
+  assert.deepEqual(sorted, [
+    "Review#class",
+    "Review#type",
+    "internalReviewHelper",
+  ]);
+});

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -306,6 +306,25 @@ export class Employee {
     resolved!.displayName === "Employee (class)" || resolved!.displayName === "Employee (interface)",
     "resolved symbol should use a disambiguated display name",
   );
+
+  const matches = index.getSymbolMatches("Employee");
+  assert.equal(matches.length, 2, "should list every colliding symbol for ambiguous lookups");
+  assert.deepEqual(
+    matches.map((symbol) => symbol.displayName).sort(),
+    ["Employee (class)", "Employee (interface)"].sort(),
+  );
+  assert.deepEqual(
+    matches.map((symbol) => symbol.qualifiedName).sort(),
+    [employeeClass!.qualifiedName, employeeInterface!.qualifiedName].sort(),
+  );
+  assert.deepEqual(
+    index.getSymbolMatches("Employee (class)").map((symbol) => symbol.qualifiedName),
+    [employeeClass!.qualifiedName],
+  );
+  assert.deepEqual(
+    index.getSymbolMatches("Employee#class").map((symbol) => symbol.qualifiedName),
+    [employeeClass!.qualifiedName],
+  );
 });
 
 test("TypeScript plugin indexes class expressions assigned to variables", () => {

--- a/tests/read-symbol.test.ts
+++ b/tests/read-symbol.test.ts
@@ -2,6 +2,9 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import { test } from "node:test";
 
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+
 import { buildProjectIndex } from "../src/indexer/project-index.js";
 import { createReadSymbolTool } from "../src/tools/read-symbol.js";
 import { createToolRegistry } from "../src/tools/registry.js";
@@ -92,6 +95,55 @@ test("read_symbol includes Referenced Types section for createToolRegistry", asy
 
   assert.ok(result.includes("# createToolRegistry"));
   assert.ok(result.includes("src/tools/registry.ts"));
+});
+
+test("read_symbol returns disambiguation list for ambiguous bare symbol names", async () => {
+  const workspaceRoot = await mkdtemp(path.join(tmpdir(), "minicode-read-symbol-collisions-"));
+  await writeFile(
+    path.join(workspaceRoot, "sample.ts"),
+    `export type Review = { id: string };
+
+export class Review {
+  constructor(public id: string) {}
+}
+`,
+    "utf8",
+  );
+
+  const config = createTestAgentConfig(workspaceRoot);
+  const projectIndex = await buildProjectIndex(workspaceRoot);
+  const tool = createReadSymbolTool(config, projectIndex);
+
+  const result = await tool.execute({ name: "Review" });
+
+  assert.ok(result.includes('Symbol "Review" is ambiguous'));
+  assert.ok(result.includes("Review (type)"));
+  assert.ok(result.includes("Review (class)"));
+  assert.ok(result.includes("qualified: Review#type"));
+  assert.ok(result.includes("qualified: Review#class"));
+});
+
+test("read_symbol accepts qualified names for colliding symbols", async () => {
+  const workspaceRoot = await mkdtemp(path.join(tmpdir(), "minicode-read-symbol-qualified-"));
+  await writeFile(
+    path.join(workspaceRoot, "sample.ts"),
+    `export type Review = { id: string };
+
+export class Review {
+  constructor(public id: string) {}
+}
+`,
+    "utf8",
+  );
+
+  const config = createTestAgentConfig(workspaceRoot);
+  const projectIndex = await buildProjectIndex(workspaceRoot);
+  const tool = createReadSymbolTool(config, projectIndex);
+
+  const result = await tool.execute({ name: "Review#class", includeBody: false });
+
+  assert.ok(result.includes("# Review (class) (class)"));
+  assert.ok(result.includes("sample.ts"));
 });
 
 test("read_symbol is not in tool registry when projectIndex is undefined", () => {

--- a/tests/search-code-map.test.ts
+++ b/tests/search-code-map.test.ts
@@ -66,4 +66,6 @@ export class Employee {
 
   assert.ok(result.includes("Employee (interface)"));
   assert.ok(result.includes("Employee (class)"));
+  assert.ok(result.includes("qualified: Employee#interface"));
+  assert.ok(result.includes("qualified: Employee#class"));
 });

--- a/tests/serve.integration.test.ts
+++ b/tests/serve.integration.test.ts
@@ -7,6 +7,7 @@ import type { StructuralAnalysisReport } from "../src/analysis/structural-analys
 import { createRequestHandler, shutdownServe } from "../src/serve/server.js";
 import { AgentBridge } from "../src/serve/agent-bridge.js";
 import type { UiUpdate } from "@minicode/agent-sdk";
+import type { IndexedSymbol } from "../src/indexer/types.js";
 import type { ServerMessage } from "../src/serve/types.js";
 import { createTestAgentConfig } from "./test-utils.js";
 
@@ -99,11 +100,20 @@ class MockBridge extends AgentBridge {
     ];
   }
 
-  override getSymbol(name: string) {
-    const syms = this.getSymbols();
-    const match = syms.find((s) => s.qualifiedName === name || s.name === name);
+  override getSymbol(name: string): IndexedSymbol | undefined {
+    const [match] = this.getSymbolMatches(name);
     if (!match) return undefined;
-    return { ...match, dependencies: [], kind: match.kind as "function" | "class" | "method" } as never;
+    return match;
+  }
+
+  override getSymbolMatches(name: string): IndexedSymbol[] {
+    return this.getSymbols()
+      .filter((s) => s.qualifiedName === name || s.name === name)
+      .map((match) => ({
+        ...match,
+        dependencies: [],
+        kind: match.kind as "function" | "class" | "method",
+      }));
   }
 
   override getDependencies(symbolName: string) {
@@ -277,6 +287,48 @@ class MockBridge extends AgentBridge {
     }
     onEvent({ type: "streaming_chunk", content: `Interpreting ${findingId}...` } as UiUpdate);
     return `Interpreting ${findingId}...`;
+  }
+}
+
+class AmbiguousMockBridge extends MockBridge {
+  override getSymbols() {
+    return [
+      ...super.getSymbols(),
+      {
+        name: "Review (type)",
+        qualifiedName: "Review#type",
+        kind: "type",
+        filePath: "src/review.ts",
+        startLine: 1,
+        endLine: 1,
+        signature: "type Review = { id: string }",
+        exported: true,
+      },
+      {
+        name: "Review (class)",
+        qualifiedName: "Review#class",
+        kind: "class",
+        filePath: "src/review.ts",
+        startLine: 3,
+        endLine: 7,
+        signature: "class Review",
+        exported: true,
+      },
+    ];
+  }
+
+  override getSymbolMatches(name: string): IndexedSymbol[] {
+    if (name === "Review") {
+      return this.getSymbols()
+        .filter((symbol) => symbol.qualifiedName.startsWith("Review#"))
+        .map((match) => ({
+          ...match,
+          dependencies: [],
+          kind: match.kind as IndexedSymbol["kind"],
+        }));
+    }
+
+    return super.getSymbolMatches(name);
   }
 }
 
@@ -739,6 +791,24 @@ test("GET /api/symbols/:name/dependencies returns 404 for unknown symbol", async
   assert.equal(res.status, 404);
 });
 
+test("GET /api/symbols/:name/dependencies returns 409 for ambiguous symbol", async () => {
+  const bridge = new AmbiguousMockBridge();
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/symbols/Review/dependencies`);
+  assert.equal(res.status, 409);
+
+  const body = (await res.json()) as {
+    error: string;
+    candidates: Array<{ qualifiedName: string }>;
+  };
+  assert.equal(body.error, 'Symbol "Review" is ambiguous');
+  assert.deepEqual(
+    body.candidates.map((candidate) => candidate.qualifiedName).sort(),
+    ["Review#class", "Review#type"],
+  );
+});
+
 test("GET /api/symbols/:name/references returns references", async () => {
   const bridge = new MockBridge();
   const base = await startTestServer(bridge);
@@ -758,6 +828,24 @@ test("GET /api/symbols/:name/references returns 404 for unknown symbol", async (
 
   const res = await fetch(`${base}/api/symbols/nonexistent/references`);
   assert.equal(res.status, 404);
+});
+
+test("GET /api/symbols/:name/references returns 409 for ambiguous symbol", async () => {
+  const bridge = new AmbiguousMockBridge();
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/symbols/Review/references`);
+  assert.equal(res.status, 409);
+
+  const body = (await res.json()) as {
+    error: string;
+    candidates: Array<{ qualifiedName: string }>;
+  };
+  assert.equal(body.error, 'Symbol "Review" is ambiguous');
+  assert.deepEqual(
+    body.candidates.map((candidate) => candidate.qualifiedName).sort(),
+    ["Review#class", "Review#type"],
+  );
 });
 
 test("GET /api/code-map returns code map", async () => {
@@ -954,6 +1042,24 @@ test("GET /api/symbols/:name/source returns 404 for unknown symbol", async () =>
 
   const body = (await res.json()) as { error: string };
   assert.ok(body.error.includes("nonexistent"));
+});
+
+test("GET /api/symbols/:name/source returns 409 for ambiguous symbol", async () => {
+  const bridge = new AmbiguousMockBridge();
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/symbols/Review/source`);
+  assert.equal(res.status, 409);
+
+  const body = (await res.json()) as {
+    error: string;
+    candidates: Array<{ qualifiedName: string }>;
+  };
+  assert.equal(body.error, 'Symbol "Review" is ambiguous');
+  assert.deepEqual(
+    body.candidates.map((candidate) => candidate.qualifiedName).sort(),
+    ["Review#class", "Review#type"],
+  );
 });
 
 test("GET /api/symbols/:name/source returns 500 when file is missing", async () => {


### PR DESCRIPTION
## Summary
- make the graph resolve ambiguous bare symbol names like `Review` to all matching colliding nodes
- use display labels in graph search/dropdowns so collisions stay human-readable
- add focused unit coverage for graph collision matching and ranking

## Testing
- `npm test`
- `npm run build`
- `npm run lint`