### PR TITLE
Add file search for graph subviews

### DIFF
--- a/src/shared/graph-search.ts
+++ b/src/shared/graph-search.ts
@@ -1,0 +1,144 @@
+import {
+  compareGraphNodeIds,
+  getGraphNodeLabel,
+  matchesGraphNodeQuery,
+  type GraphSymbolNodeLike,
+} from "./graph-symbols.js";
+
+export interface GraphSearchNodeLike extends GraphSymbolNodeLike {
+  kind?: string;
+  filePath?: string;
+  file?: string;
+}
+
+export interface GraphSymbolSearchResult {
+  type: "symbol";
+  id: string;
+  label: string;
+  subtitle: string;
+  kind: string;
+}
+
+export interface GraphFileSearchResult {
+  type: "file";
+  id: string;
+  label: string;
+  subtitle: string;
+  kind: "file";
+  symbolCount: number;
+}
+
+export type GraphSearchResult = GraphSymbolSearchResult | GraphFileSearchResult;
+
+export function getGraphNodeFilePath(node: GraphSearchNodeLike): string {
+  return node.filePath || node.file || "";
+}
+
+export function buildGraphFileIndex(
+  nodes: ReadonlyMap<string, GraphSearchNodeLike>,
+): Map<string, string[]> {
+  const files = new Map<string, string[]>();
+
+  for (const [id, node] of nodes) {
+    const filePath = getGraphNodeFilePath(node);
+    if (!filePath) continue;
+
+    const existing = files.get(filePath);
+    if (existing) {
+      existing.push(id);
+    } else {
+      files.set(filePath, [id]);
+    }
+  }
+
+  for (const symbolIds of files.values()) {
+    symbolIds.sort((a, b) => compareGraphNodeIds(a, b, nodes));
+  }
+
+  return files;
+}
+
+export function compareGraphFilePaths(
+  a: string,
+  b: string,
+  fileIndex: ReadonlyMap<string, readonly string[]>,
+): number {
+  const countDifference = (fileIndex.get(b)?.length ?? 0) - (fileIndex.get(a)?.length ?? 0);
+  if (countDifference !== 0) {
+    return countDifference;
+  }
+
+  return a.localeCompare(b, undefined, { sensitivity: "base" });
+}
+
+export function matchesGraphFileQuery(query: string, filePath: string): boolean {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (normalizedQuery.length === 0) {
+    return false;
+  }
+
+  return filePath.toLowerCase().includes(normalizedQuery);
+}
+
+interface BuildGraphSearchResultsOptions {
+  query: string;
+  symbolIds: readonly string[];
+  nodes: ReadonlyMap<string, GraphSearchNodeLike>;
+  fileIndex: ReadonlyMap<string, readonly string[]>;
+  symbolLimit?: number;
+  fileLimit?: number;
+}
+
+export function buildGraphSearchResults({
+  query,
+  symbolIds,
+  nodes,
+  fileIndex,
+  symbolLimit = 12,
+  fileLimit = 8,
+}: BuildGraphSearchResultsOptions): GraphSearchResult[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  const showDefaultResults = normalizedQuery.length < 2;
+  const rankedFiles = [...fileIndex.keys()].sort((a, b) => compareGraphFilePaths(a, b, fileIndex));
+
+  const symbolResults: GraphSymbolSearchResult[] = symbolIds
+    .filter((id) => {
+      if (showDefaultResults) {
+        return true;
+      }
+      return matchesGraphNodeQuery(normalizedQuery, nodes.get(id) || {}, id);
+    })
+    .slice(0, symbolLimit)
+    .map((id) => {
+      const node = nodes.get(id) || {};
+      return {
+        type: "symbol",
+        id,
+        label: getGraphNodeLabel(node, id),
+        subtitle: getGraphNodeFilePath(node),
+        kind: (node.kind || "symbol").toLowerCase(),
+      };
+    });
+
+  const fileResults: GraphFileSearchResult[] = rankedFiles
+    .filter((filePath) => {
+      if (showDefaultResults) {
+        return true;
+      }
+      return matchesGraphFileQuery(normalizedQuery, filePath);
+    })
+    .slice(0, fileLimit)
+    .map((filePath) => {
+      const symbolCount = fileIndex.get(filePath)?.length ?? 0;
+      return {
+        type: "file",
+        id: filePath,
+        label: filePath,
+        subtitle: `${symbolCount} symbol${symbolCount === 1 ? "" : "s"}`,
+        kind: "file",
+        symbolCount,
+      };
+    });
+
+  return [...symbolResults, ...fileResults];
+}

--- a/src/shared/graph-selection.ts
+++ b/src/shared/graph-selection.ts
@@ -1,0 +1,67 @@
+export interface GraphSelectionEdgeLike {
+  source: string;
+  target: string;
+  kind: string;
+}
+
+export function buildGraphEdgeId(edge: GraphSelectionEdgeLike): string {
+  return `${edge.source}->${edge.target}:${edge.kind}`;
+}
+
+export function buildGraphEdgeIndex<T extends GraphSelectionEdgeLike>(
+  edges: readonly T[],
+): Map<string, T[]> {
+  const edgeIndex = new Map<string, T[]>();
+
+  for (const edge of edges) {
+    const sourceEdges = edgeIndex.get(edge.source);
+    if (sourceEdges) {
+      sourceEdges.push(edge);
+    } else {
+      edgeIndex.set(edge.source, [edge]);
+    }
+
+    const targetEdges = edgeIndex.get(edge.target);
+    if (targetEdges) {
+      targetEdges.push(edge);
+    } else {
+      edgeIndex.set(edge.target, [edge]);
+    }
+  }
+
+  return edgeIndex;
+}
+
+interface BuildFileFocusedSelectionOptions<T extends GraphSelectionEdgeLike> {
+  filePath: string;
+  fileIndex: ReadonlyMap<string, readonly string[]>;
+  edgeIndex: ReadonlyMap<string, readonly T[]>;
+}
+
+export function buildFileFocusedSelection<T extends GraphSelectionEdgeLike>({
+  filePath,
+  fileIndex,
+  edgeIndex,
+}: BuildFileFocusedSelectionOptions<T>): {
+  nodeIds: string[];
+  edges: T[];
+} {
+  const fileSymbolIds = fileIndex.get(filePath) || [];
+  const nodeIds = new Set<string>();
+  const edges = new Map<string, T>();
+
+  for (const symbolId of fileSymbolIds) {
+    nodeIds.add(symbolId);
+
+    for (const edge of edgeIndex.get(symbolId) || []) {
+      nodeIds.add(edge.source);
+      nodeIds.add(edge.target);
+      edges.set(buildGraphEdgeId(edge), edge);
+    }
+  }
+
+  return {
+    nodeIds: [...nodeIds],
+    edges: [...edges.values()],
+  };
+}

--- a/src/web/graph.ts
+++ b/src/web/graph.ts
@@ -15,9 +15,13 @@ import {
 } from './analysis-helpers.ts';
 import { KIND_COLORS, buildStylesheet } from '../shared/graph-styles.ts';
 import {
+  buildGraphFileIndex,
+  buildGraphSearchResults,
+  type GraphSearchResult,
+} from '../shared/graph-search.ts';
+import {
   compareGraphNodeIds,
   getGraphNodeLabel,
-  matchesGraphNodeQuery,
   resolveGraphNodeIds,
 } from '../shared/graph-symbols.ts';
 
@@ -92,6 +96,7 @@ interface RawEdge {
 let cy: CyInstance | null = null;
 const graphNodes = new Map<string, GraphNode>();
 let graphEdges: GraphEdge[] = [];
+let fileToSymbolIds = new Map<string, string[]>();
 // Adjacency index: node id → edges touching that node (O(1) neighbor lookup)
 const edgeIndex = new Map<string, GraphEdge[]>();
 const pinnedNames = new Set<string>();
@@ -157,6 +162,7 @@ export async function initGraph(): Promise<void> {
       kind: (e.kind || e.type || 'references').toLowerCase(),
     }));
     buildEdgeIndex();
+    fileToSymbolIds = buildGraphFileIndex(graphNodes);
 
     allSymbolNames = Array.from(graphNodes.keys()).sort();
 
@@ -220,7 +226,7 @@ function showOnboardingHint(container: HTMLElement): void {
   hint.innerHTML =
     '<div class="graph-onboarding-icon">&#9670; &#8212; &#9670;</div>' +
     '<div class="graph-onboarding-title">Code dependency graph</div>' +
-    '<div class="graph-onboarding-subtitle">Search for a symbol above to start exploring.<br/>Nodes expand on click to reveal connections.</div>';
+    '<div class="graph-onboarding-subtitle">Search for a symbol or file above to start exploring.<br/>Nodes expand on click to reveal connections.</div>';
   container.appendChild(hint);
 }
 
@@ -278,6 +284,28 @@ function renderNodeNeighborhoodAndLayout(symbolId: string, maxDegrees = 1): void
   if (cy.nodes().length > beforeNodeCount) {
     runLayout();
   }
+}
+
+function focusFileInGraph(filePath: string): void {
+  if (!cy) return;
+
+  const symbolIds = fileToSymbolIds.get(filePath) || [];
+  cy.elements().remove();
+  document.getElementById('symbol-detail')?.classList.add('hidden');
+
+  if (symbolIds.length === 0) {
+    const cyEl = document.getElementById('cy');
+    if (cyEl) showOnboardingHint(cyEl);
+    refreshAnalysisGraphState();
+    return;
+  }
+
+  for (const symbolId of symbolIds) {
+    addNodeToGraph(symbolId);
+  }
+  connectExistingNodes();
+  refreshAnalysisGraphState();
+  runLayout();
 }
 
 interface FocusSymbolOptions {
@@ -1201,20 +1229,22 @@ function setupToolbar(): void {
   // Rank symbols: exported first, then alphabetical by short name
   const rankedSymbols = allSymbolNames.slice().sort((a, b) => compareGraphNodeIds(a, b, graphNodes));
 
-  function showDropdownResults(matches: string[]): void {
-    if (matches.length === 0) {
+  function showDropdownResults(results: GraphSearchResult[]): void {
+    if (results.length === 0) {
       dropdown.classList.add('hidden');
       return;
     }
 
-    dropdown.innerHTML = matches.map((name) => {
-      const node = graphNodes.get(name);
-      const kind = node ? (node.kind || '').toLowerCase() : '';
-      const shortName = getGraphNodeLabel(node || {}, name);
-      const kindColor = KIND_COLORS[kind] ? KIND_COLORS[kind]!.border : '#565f89';
-      return `<div class="search-result" data-id="${escapeHtml(name)}">
-        <span class="search-result-name">${escapeHtml(shortName)}</span>
-        <span class="search-result-kind" style="color:${kindColor}">${kind}</span>
+    dropdown.innerHTML = results.map((result) => {
+      const kindColor = result.type === 'file'
+        ? 'var(--accent)'
+        : (KIND_COLORS[result.kind] ? KIND_COLORS[result.kind]!.border : '#565f89');
+      return `<div class="search-result" data-id="${escapeHtml(result.id)}" data-type="${result.type}">
+        <div class="search-result-body">
+          <span class="search-result-name">${escapeHtml(result.label)}</span>
+          <span class="search-result-subtitle">${escapeHtml(result.subtitle)}</span>
+        </div>
+        <span class="search-result-kind${result.type === 'file' ? ' file' : ''}" style="color:${kindColor}">${escapeHtml(result.kind)}</span>
       </div>`;
     }).join('');
 
@@ -1223,8 +1253,13 @@ function setupToolbar(): void {
     dropdown.querySelectorAll('.search-result').forEach((el) => {
       el.addEventListener('click', () => {
         const id = (el as HTMLElement).dataset.id || '';
+        const type = (el as HTMLElement).dataset.type || 'symbol';
         searchInput.value = '';
         dropdown.classList.add('hidden');
+        if (type === 'file') {
+          focusFileInGraph(id);
+          return;
+        }
         void focusSymbolInGraph(id, {
           maxDegrees: 1,
           animate: true,
@@ -1236,26 +1271,24 @@ function setupToolbar(): void {
     });
   }
 
+  function updateDropdownResults(): void {
+    const results = buildGraphSearchResults({
+      query: searchInput.value,
+      symbolIds: rankedSymbols,
+      nodes: graphNodes,
+      fileIndex: fileToSymbolIds,
+    });
+    showDropdownResults(results);
+  }
+
   searchInput.addEventListener('focus', () => {
-    if (searchInput.value.trim().length < 2) {
-      showDropdownResults(rankedSymbols.slice(0, 20));
-    }
+    updateDropdownResults();
   });
 
   searchInput.addEventListener('input', () => {
     clearTimeout(searchTimeout);
     searchTimeout = setTimeout(() => {
-      const query = searchInput.value.trim().toLowerCase();
-      if (query.length < 2) {
-        showDropdownResults(rankedSymbols.slice(0, 20));
-        return;
-      }
-
-      const matches = rankedSymbols.filter((name) => {
-        return matchesGraphNodeQuery(query, graphNodes.get(name) || {}, name);
-      }).slice(0, 15);
-
-      showDropdownResults(matches);
+      updateDropdownResults();
     }, 150);
   });
 

--- a/src/web/graph.ts
+++ b/src/web/graph.ts
@@ -301,7 +301,7 @@ function focusFileInGraph(filePath: string): void {
   }
 
   for (const symbolId of symbolIds) {
-    addNodeToGraph(symbolId);
+    addNodeNeighborhood(symbolId, 1);
   }
   connectExistingNodes();
   refreshAnalysisGraphState();

--- a/src/web/graph.ts
+++ b/src/web/graph.ts
@@ -20,6 +20,10 @@ import {
   type GraphSearchResult,
 } from '../shared/graph-search.ts';
 import {
+  buildFileFocusedSelection,
+  buildGraphEdgeIndex,
+} from '../shared/graph-selection.ts';
+import {
   compareGraphNodeIds,
   getGraphNodeLabel,
   resolveGraphNodeIds,
@@ -98,7 +102,7 @@ const graphNodes = new Map<string, GraphNode>();
 let graphEdges: GraphEdge[] = [];
 let fileToSymbolIds = new Map<string, string[]>();
 // Adjacency index: node id → edges touching that node (O(1) neighbor lookup)
-const edgeIndex = new Map<string, GraphEdge[]>();
+let edgeIndex = new Map<string, GraphEdge[]>();
 const pinnedNames = new Set<string>();
 let allSymbolNames: string[] = [];
 let initialized = false;
@@ -161,7 +165,7 @@ export async function initGraph(): Promise<void> {
       target: e.target || e.to || '',
       kind: (e.kind || e.type || 'references').toLowerCase(),
     }));
-    buildEdgeIndex();
+    edgeIndex = buildGraphEdgeIndex(graphEdges);
     fileToSymbolIds = buildGraphFileIndex(graphNodes);
 
     allSymbolNames = Array.from(graphNodes.keys()).sort();
@@ -235,18 +239,6 @@ function removeOnboardingHint(): void {
   if (hint) hint.remove();
 }
 
-function buildEdgeIndex(): void {
-  edgeIndex.clear();
-  for (const edge of graphEdges) {
-    let srcList = edgeIndex.get(edge.source);
-    if (!srcList) { srcList = []; edgeIndex.set(edge.source, srcList); }
-    srcList.push(edge);
-    let tgtList = edgeIndex.get(edge.target);
-    if (!tgtList) { tgtList = []; edgeIndex.set(edge.target, tgtList); }
-    tgtList.push(edge);
-  }
-}
-
 function addNodeNeighborhood(symbolId: string, maxDegrees = 1): void {
   const visited = new Set<string>();
   let frontier = new Set<string>([symbolId]);
@@ -289,21 +281,27 @@ function renderNodeNeighborhoodAndLayout(symbolId: string, maxDegrees = 1): void
 function focusFileInGraph(filePath: string): void {
   if (!cy) return;
 
-  const symbolIds = fileToSymbolIds.get(filePath) || [];
+  const selection = buildFileFocusedSelection({
+    filePath,
+    fileIndex: fileToSymbolIds,
+    edgeIndex,
+  });
   cy.elements().remove();
   document.getElementById('symbol-detail')?.classList.add('hidden');
 
-  if (symbolIds.length === 0) {
+  if (selection.nodeIds.length === 0) {
     const cyEl = document.getElementById('cy');
     if (cyEl) showOnboardingHint(cyEl);
     refreshAnalysisGraphState();
     return;
   }
 
-  for (const symbolId of symbolIds) {
-    addNodeNeighborhood(symbolId, 1);
+  for (const symbolId of selection.nodeIds) {
+    addNodeToGraph(symbolId);
   }
-  connectExistingNodes();
+  for (const edge of selection.edges) {
+    addEdgeToGraph(edge);
+  }
   refreshAnalysisGraphState();
   runLayout();
 }

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -101,7 +101,7 @@ MODEL=your-model-name</pre>
       <div id="pane-divider"></div>
       <div id="graph-pane">
         <div id="graph-toolbar">
-          <input id="graph-search" type="text" placeholder="Search symbols..." autocomplete="off" />
+          <input id="graph-search" type="text" placeholder="Search symbols or files..." autocomplete="off" />
           <button id="graph-analyze" class="header-btn">Analyze</button>
           <button id="graph-fit" class="header-btn">Fit</button>
           <button id="graph-relayout" class="header-btn">Re-layout</button>

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -1126,6 +1126,7 @@ main::-webkit-scrollbar-thumb {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 12px;
   padding: 6px 10px;
   cursor: pointer;
   font-size: 12px;
@@ -1136,14 +1137,39 @@ main::-webkit-scrollbar-thumb {
   background: var(--bg-hover);
 }
 
+.search-result-body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+}
+
 .search-result-name {
   color: var(--text);
   font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.search-result-subtitle {
+  color: var(--text-dim);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .search-result-kind {
   font-size: 11px;
   opacity: 0.7;
+  flex-shrink: 0;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.search-result-kind.file {
+  opacity: 0.9;
 }
 
 #cy {

--- a/tests/graph-onboarding.test.ts
+++ b/tests/graph-onboarding.test.ts
@@ -11,6 +11,7 @@ test('built CSS contains graph-onboarding styles', () => {
   assert.ok(css.includes('.graph-onboarding-icon'), 'CSS should contain .graph-onboarding-icon class');
   assert.ok(css.includes('.graph-onboarding-title'), 'CSS should contain .graph-onboarding-title class');
   assert.ok(css.includes('.graph-onboarding-subtitle'), 'CSS should contain .graph-onboarding-subtitle class');
+  assert.ok(css.includes('.search-result-subtitle'), 'CSS should contain secondary search result text styling');
   assert.ok(css.includes('pointer-events: none'), 'onboarding overlay should not block interactions');
   assert.ok(css.includes('width: 380px;'), 'symbol detail panel should have a wider default width');
 });
@@ -26,6 +27,7 @@ test('built HTML contains #cy graph container', () => {
   const html = readFileSync(join(distWeb, 'index.html'), 'utf-8');
   assert.ok(html.includes('id="cy"'), 'HTML should contain the #cy graph container');
   assert.ok(html.includes('id="graph-pane"'), 'HTML should contain the #graph-pane wrapper');
+  assert.ok(html.includes('Search symbols or files...'), 'HTML should expose mixed symbol/file search');
 });
 
 test('onboarding hint includes user-facing guidance text in built JS', () => {
@@ -35,7 +37,7 @@ test('onboarding hint includes user-facing guidance text in built JS', () => {
     'onboarding title should mention the code dependency graph',
   );
   assert.ok(
-    js.includes('Search for a symbol'),
+    js.includes('Search for a symbol or file'),
     'onboarding subtitle should guide users to search',
   );
 });
@@ -90,5 +92,21 @@ test('built JS auto-opens symbol details for agent activity and graph search sel
   assert.ok(
     js.includes('await showDetail(node, detailEl)'),
     'JS should populate the symbol detail panel when focus requests it',
+  );
+});
+
+test('built JS supports file search results and file-local subgraph rendering', () => {
+  const js = readFileSync(join(distWeb, 'app.js'), 'utf-8');
+  assert.ok(
+    js.includes('focusFileInGraph'),
+    'JS should define a file-focused graph seeding helper',
+  );
+  assert.ok(
+    js.includes('buildGraphSearchResults'),
+    'JS should use the shared mixed search result helper',
+  );
+  assert.ok(
+    js.includes('el.dataset.type') && js.includes('focusFileInGraph(id)'),
+    'JS should branch on file search results when handling selection',
   );
 });

--- a/tests/graph-onboarding.test.ts
+++ b/tests/graph-onboarding.test.ts
@@ -95,7 +95,7 @@ test('built JS auto-opens symbol details for agent activity and graph search sel
   );
 });
 
-test('built JS supports file search results and file-local subgraph rendering', () => {
+test('built JS supports file search results and file-centered neighborhood rendering', () => {
   const js = readFileSync(join(distWeb, 'app.js'), 'utf-8');
   assert.ok(
     js.includes('focusFileInGraph'),
@@ -108,5 +108,9 @@ test('built JS supports file search results and file-local subgraph rendering', 
   assert.ok(
     js.includes('el.dataset.type') && js.includes('focusFileInGraph(id)'),
     'JS should branch on file search results when handling selection',
+  );
+  assert.ok(
+    js.includes('addNodeNeighborhood(symbolId, 1)'),
+    'file-focused graph seeding should render one-hop connections for file symbols',
   );
 });

--- a/tests/graph-onboarding.test.ts
+++ b/tests/graph-onboarding.test.ts
@@ -110,7 +110,7 @@ test('built JS supports file search results and file-centered neighborhood rende
     'JS should branch on file search results when handling selection',
   );
   assert.ok(
-    js.includes('addNodeNeighborhood(symbolId, 1)'),
-    'file-focused graph seeding should render one-hop connections for file symbols',
+    js.includes('buildFileFocusedSelection'),
+    'file-focused graph seeding should use the shared file selection helper',
   );
 });

--- a/tests/graph-search.test.ts
+++ b/tests/graph-search.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildGraphFileIndex,
+  buildGraphSearchResults,
+  compareGraphFilePaths,
+  matchesGraphFileQuery,
+} from "../src/shared/graph-search.js";
+
+test("buildGraphFileIndex groups graph nodes by file path", () => {
+  const nodes = new Map([
+    ["Review#class", { name: "Review (class)", qualifiedName: "Review#class", filePath: "src/review.ts", exported: true }],
+    ["Review#type", { name: "Review (type)", qualifiedName: "Review#type", filePath: "src/review.ts", exported: true }],
+    ["Session.trim", { name: "trim", qualifiedName: "Session.trim", filePath: "src/session.ts", exported: false }],
+  ]);
+
+  const fileIndex = buildGraphFileIndex(nodes);
+
+  assert.deepEqual(fileIndex.get("src/review.ts"), ["Review#class", "Review#type"]);
+  assert.deepEqual(fileIndex.get("src/session.ts"), ["Session.trim"]);
+});
+
+test("compareGraphFilePaths prefers files with more indexed symbols", () => {
+  const fileIndex = new Map<string, string[]>([
+    ["src/review.ts", ["Review#class", "Review#type"]],
+    ["src/session.ts", ["Session.trim"]],
+  ]);
+
+  const ranked = [...fileIndex.keys()].sort((a, b) => compareGraphFilePaths(a, b, fileIndex));
+
+  assert.deepEqual(ranked, ["src/review.ts", "src/session.ts"]);
+});
+
+test("matchesGraphFileQuery matches file path substrings case-insensitively", () => {
+  assert.equal(matchesGraphFileQuery("review", "src/review.ts"), true);
+  assert.equal(matchesGraphFileQuery("SRC/REVIEW", "src/review.ts"), true);
+  assert.equal(matchesGraphFileQuery("session", "src/review.ts"), false);
+});
+
+test("buildGraphSearchResults returns mixed symbol and file matches", () => {
+  const nodes = new Map([
+    ["Review#class", { name: "Review (class)", qualifiedName: "Review#class", kind: "class", filePath: "src/review.ts", exported: true }],
+    ["Review#type", { name: "Review (type)", qualifiedName: "Review#type", kind: "type", filePath: "src/review.ts", exported: true }],
+    ["Session.trim", { name: "trim", qualifiedName: "Session.trim", kind: "method", filePath: "src/session.ts", exported: false }],
+  ]);
+  const rankedSymbols = [...nodes.keys()];
+  const fileIndex = buildGraphFileIndex(nodes);
+
+  const results = buildGraphSearchResults({
+    query: "review",
+    symbolIds: rankedSymbols,
+    nodes,
+    fileIndex,
+  });
+
+  assert.equal(results[0]?.type, "symbol");
+  assert.equal(results[0]?.id, "Review#class");
+  assert.equal(results[1]?.type, "symbol");
+  assert.equal(results[2]?.type, "file");
+  assert.equal(results[2]?.id, "src/review.ts");
+});
+
+test("buildGraphSearchResults returns default file suggestions for short queries", () => {
+  const nodes = new Map([
+    ["Review#class", { name: "Review (class)", qualifiedName: "Review#class", kind: "class", filePath: "src/review.ts", exported: true }],
+    ["Review#type", { name: "Review (type)", qualifiedName: "Review#type", kind: "type", filePath: "src/review.ts", exported: true }],
+    ["Session.trim", { name: "trim", qualifiedName: "Session.trim", kind: "method", filePath: "src/session.ts", exported: false }],
+  ]);
+  const rankedSymbols = [...nodes.keys()];
+  const fileIndex = buildGraphFileIndex(nodes);
+
+  const results = buildGraphSearchResults({
+    query: "",
+    symbolIds: rankedSymbols,
+    nodes,
+    fileIndex,
+    symbolLimit: 2,
+    fileLimit: 1,
+  });
+
+  assert.equal(results.length, 3);
+  assert.equal(results[2]?.type, "file");
+  assert.equal(results[2]?.id, "src/review.ts");
+});

--- a/tests/graph-selection.test.ts
+++ b/tests/graph-selection.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildFileFocusedSelection,
+  buildGraphEdgeId,
+  buildGraphEdgeIndex,
+} from "../src/shared/graph-selection.js";
+
+test("buildGraphEdgeIndex indexes edges by both source and target", () => {
+  const edges = [
+    { source: "Review#class", target: "Session.trim", kind: "references" },
+    { source: "renderReview", target: "Review#type", kind: "references" },
+  ];
+
+  const edgeIndex = buildGraphEdgeIndex(edges);
+
+  assert.deepEqual(edgeIndex.get("Review#class"), [edges[0]]);
+  assert.deepEqual(edgeIndex.get("Session.trim"), [edges[0]]);
+  assert.deepEqual(edgeIndex.get("renderReview"), [edges[1]]);
+  assert.deepEqual(edgeIndex.get("Review#type"), [edges[1]]);
+});
+
+test("buildFileFocusedSelection includes file symbols and touching neighbors", () => {
+  const fileIndex = new Map<string, string[]>([
+    ["src/review.ts", ["Review#class", "Review#type"]],
+  ]);
+  const edges = [
+    { source: "Review#class", target: "Session.trim", kind: "references" },
+    { source: "renderReview", target: "Review#type", kind: "references" },
+    { source: "Review#class", target: "Review#type", kind: "references" },
+  ];
+
+  const selection = buildFileFocusedSelection({
+    filePath: "src/review.ts",
+    fileIndex,
+    edgeIndex: buildGraphEdgeIndex(edges),
+  });
+
+  assert.deepEqual(
+    new Set(selection.nodeIds),
+    new Set(["Review#class", "Review#type", "Session.trim", "renderReview"]),
+  );
+  assert.deepEqual(
+    new Set(selection.edges.map((edge) => buildGraphEdgeId(edge))),
+    new Set(edges.map((edge) => buildGraphEdgeId(edge))),
+  );
+});
+
+test("buildFileFocusedSelection excludes edges between external neighbors", () => {
+  const fileIndex = new Map<string, string[]>([
+    ["src/review.ts", ["Review#class"]],
+  ]);
+  const reviewToSession = { source: "Review#class", target: "Session.trim", kind: "references" };
+  const reviewToRender = { source: "Review#class", target: "renderReview", kind: "references" };
+  const sessionToRender = { source: "Session.trim", target: "renderReview", kind: "references" };
+  const edges = [reviewToSession, reviewToRender, sessionToRender];
+
+  const selection = buildFileFocusedSelection({
+    filePath: "src/review.ts",
+    fileIndex,
+    edgeIndex: buildGraphEdgeIndex(edges),
+  });
+
+  assert.deepEqual(
+    new Set(selection.nodeIds),
+    new Set(["Review#class", "Session.trim", "renderReview"]),
+  );
+  assert.deepEqual(
+    new Set(selection.edges.map((edge) => buildGraphEdgeId(edge))),
+    new Set([
+      buildGraphEdgeId(reviewToSession),
+      buildGraphEdgeId(reviewToRender),
+    ]),
+  );
+});
+
+test("buildFileFocusedSelection returns an empty selection for unknown files", () => {
+  const selection = buildFileFocusedSelection({
+    filePath: "src/missing.ts",
+    fileIndex: new Map<string, string[]>(),
+    edgeIndex: buildGraphEdgeIndex([]),
+  });
+
+  assert.deepEqual(selection, { nodeIds: [], edges: [] });
+});


### PR DESCRIPTION
## Summary
- add mixed symbol/file graph search using a shared search helper
- render a file-local symbol subgraph when a file search result is selected
- update the graph toolbar and onboarding copy to reflect file search
- add unit and built-bundle coverage for the new search behavior

## Testing
- npm run build
- npm run lint
- npm test

Closes #96
