### PR TITLE
[codex] Preview recent messages when loading sessions

### DIFF
--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -15,6 +15,7 @@ import { serializeSymbolMatch } from "../shared/symbol-resolution.js";
 import type { ServerMessage } from "./types.js";
 import type { WebSocketServer } from "ws";
 import { handleMcpRequest } from "./mcp-server.js";
+import { buildSessionPreview } from "../session/session-preview.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -235,7 +236,10 @@ export function createRequestHandler(
           sendJson(res, 404, { error: "Session not found" });
           return;
         }
-        sendJson(res, 200, { label: result.label });
+        sendJson(res, 200, {
+          label: result.label,
+          messages: buildSessionPreview(result.session.getMessages()),
+        });
         return;
       }
 

--- a/src/session/session-preview.ts
+++ b/src/session/session-preview.ts
@@ -1,0 +1,24 @@
+import type { SessionMessage } from "@minicode/agent-sdk";
+
+export const DEFAULT_SESSION_PREVIEW_LIMIT = 10;
+const COMPACTION_SUMMARY_PREFIX = "[Conversation Summary";
+
+export function isCompactionSummaryMessage(message: SessionMessage): boolean {
+  return (
+    message.role === "user" &&
+    message.content.startsWith(COMPACTION_SUMMARY_PREFIX)
+  );
+}
+
+export function buildSessionPreview(
+  messages: readonly SessionMessage[],
+  limit = DEFAULT_SESSION_PREVIEW_LIMIT,
+): SessionMessage[] {
+  if (limit <= 0) {
+    return [];
+  }
+
+  return messages
+    .filter((message) => !isCompactionSummaryMessage(message))
+    .slice(-limit);
+}

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -27,6 +27,40 @@ interface SessionMeta {
   messageCount: number;
 }
 
+interface SessionPreviewToolCall {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+interface SessionPreviewUserMessage {
+  role: "user";
+  content: string;
+}
+
+interface SessionPreviewAssistantMessage {
+  role: "assistant";
+  content: string;
+  toolCalls?: SessionPreviewToolCall[];
+}
+
+interface SessionPreviewToolMessage {
+  role: "tool";
+  toolCallId: string;
+  toolName: string;
+  content: string;
+}
+
+type SessionPreviewMessage =
+  | SessionPreviewUserMessage
+  | SessionPreviewAssistantMessage
+  | SessionPreviewToolMessage;
+
+interface LoadSessionResponse {
+  label: string;
+  messages: SessionPreviewMessage[];
+}
+
 interface SessionsResponse {
   sessions: SessionMeta[];
   currentSessionId: string;
@@ -297,6 +331,61 @@ function addMessage(text: string, type: string, markdown = false): HTMLElement {
   return el;
 }
 
+function clearChatTranscript(): void {
+  messagesEl.innerHTML = "";
+  currentAssistantEl = null;
+  assistantText = "";
+  hadToolCalls = false;
+}
+
+function stringifyToolInput(input: Record<string, unknown>): Record<string, string> {
+  const entries = Object.entries(input).flatMap(([key, value]) => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+
+    if (typeof value === "string") {
+      return [[key, value] as const];
+    }
+
+    return [[key, JSON.stringify(value)] as const];
+  });
+
+  return Object.fromEntries(entries);
+}
+
+function addToolResultPreview(name: string, result: string): void {
+  const toolEls = messagesEl.querySelectorAll(`.tool-call[data-tool-name="${name}"]`);
+  if (toolEls.length === 0) {
+    addToolCall(name, {});
+  }
+  finalizeToolCall(name, result);
+}
+
+function renderLoadedSessionMessages(messages: SessionPreviewMessage[]): void {
+  clearChatTranscript();
+
+  for (const message of messages) {
+    if (message.role === "user") {
+      addMessage(message.content, "user");
+      continue;
+    }
+
+    if (message.role === "assistant") {
+      if (message.content.trim().length > 0) {
+        addMessage(message.content, "assistant", true);
+      }
+
+      for (const toolCall of message.toolCalls ?? []) {
+        addToolCall(toolCall.name, stringifyToolInput(toolCall.input));
+      }
+      continue;
+    }
+
+    addToolResultPreview(message.toolName, message.content);
+  }
+}
+
 function summarizeToolInput(name: string, input: Record<string, string>): string {
   const key =
     input.path ?? input.file_path ?? input.command ?? input.query ??
@@ -347,14 +436,14 @@ function addToolCall(name: string, input: Record<string, string>): void {
   scrollToBottom();
 }
 
-function finalizeToolCall(name: string, result: string, elapsedMs: number): void {
+function finalizeToolCall(name: string, result: string, elapsedMs?: number): void {
   const toolEls = messagesEl.querySelectorAll(`.tool-call[data-tool-name="${name}"]`);
   const el = toolEls[toolEls.length - 1] as HTMLElement | undefined;
   if (!el) return;
 
   const timeEl = el.querySelector(".tool-time");
   if (timeEl) {
-    timeEl.textContent = `${elapsedMs}ms`;
+    timeEl.textContent = elapsedMs && elapsedMs > 0 ? `${elapsedMs}ms` : "";
   }
 
   const resultEl = el.querySelector(".tool-result");
@@ -857,9 +946,12 @@ async function loadSession(label: string): Promise<void> {
       body: JSON.stringify({ label }),
     });
     if (res.ok) {
+      const body = await res.json() as LoadSessionResponse;
       sessionDropdown.classList.add("hidden");
-      messagesEl.innerHTML = "";
-      addMessage(`Session "${label}" restored`, "thinking");
+      renderLoadedSessionMessages(body.messages);
+      if (body.messages.length === 0) {
+        addMessage(`Session "${body.label}" restored`, "thinking");
+      }
       void refreshSessionList();
     }
   } catch {

--- a/tests/serve.integration.test.ts
+++ b/tests/serve.integration.test.ts
@@ -6,7 +6,7 @@ import { mkdirSync, writeFileSync, rmSync } from "node:fs";
 import type { StructuralAnalysisReport } from "../src/analysis/structural-analysis.js";
 import { createRequestHandler, shutdownServe } from "../src/serve/server.js";
 import { AgentBridge } from "../src/serve/agent-bridge.js";
-import type { UiUpdate } from "@minicode/agent-sdk";
+import { Session, type UiUpdate } from "@minicode/agent-sdk";
 import type { IndexedSymbol } from "../src/indexer/types.js";
 import type { ServerMessage } from "../src/serve/types.js";
 import { createTestAgentConfig } from "./test-utils.js";
@@ -77,7 +77,18 @@ class MockBridge extends AgentBridge {
 
   override async loadSess(label: string) {
     if (label === "nonexistent") return null;
-    return { session: {} as never, label };
+    const session = new Session("sess-1");
+    session.addMessage({
+      role: "user",
+      content: "[Conversation Summary — earlier messages were compacted to save context]\nOlder summary",
+    });
+    for (let i = 1; i <= 11; i += 1) {
+      session.addMessage({
+        role: i % 2 === 0 ? "assistant" : "user",
+        content: `message-${i}`,
+      });
+    }
+    return { session, label };
   }
 
   override getCurrentSessionId(): string {
@@ -511,8 +522,17 @@ test("POST /api/sessions/load returns success for known session", async () => {
   });
   assert.equal(res.status, 200);
 
-  const body = (await res.json()) as { label: string };
+  const body = (await res.json()) as {
+    label: string;
+    messages: Array<{ role: string; content: string }>;
+  };
   assert.equal(body.label, "test-session");
+  assert.equal(body.messages.length, 10);
+  assert.equal(body.messages[0]?.content, "message-2");
+  assert.equal(body.messages[9]?.content, "message-11");
+  assert.ok(
+    body.messages.every((message) => !message.content.startsWith("[Conversation Summary")),
+  );
 });
 
 test("POST /api/chat returns agent response", async () => {

--- a/tests/session-preview.test.ts
+++ b/tests/session-preview.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildSessionPreview,
+  isCompactionSummaryMessage,
+} from "../src/session/session-preview.js";
+
+test("isCompactionSummaryMessage detects compacted summary stubs", () => {
+  assert.equal(
+    isCompactionSummaryMessage({
+      role: "user",
+      content: "[Conversation Summary — earlier messages were compacted to save context]\nSummary text",
+    }),
+    true,
+  );
+  assert.equal(
+    isCompactionSummaryMessage({
+      role: "assistant",
+      content: "[Conversation Summary — earlier messages were compacted to save context]\nSummary text",
+    }),
+    false,
+  );
+});
+
+test("buildSessionPreview filters compaction summaries and keeps the last ten messages", () => {
+  const preview = buildSessionPreview([
+    {
+      role: "user",
+      content: "[Conversation Summary — earlier messages were compacted using LLM summarization]\nSummary text",
+    },
+    { role: "user", content: "message-1" },
+    { role: "assistant", content: "message-2" },
+    { role: "user", content: "message-3" },
+    { role: "assistant", content: "message-4" },
+    { role: "user", content: "message-5" },
+    { role: "assistant", content: "message-6" },
+    { role: "user", content: "message-7" },
+    { role: "assistant", content: "message-8" },
+    { role: "user", content: "message-9" },
+    { role: "assistant", content: "message-10" },
+    { role: "user", content: "message-11" },
+  ]);
+
+  assert.equal(preview.length, 10);
+  assert.equal(preview[0]?.content, "message-2");
+  assert.equal(preview[9]?.content, "message-11");
+  assert.ok(
+    preview.every((message) => !message.content.startsWith("[Conversation Summary")),
+  );
+});
+
+test("buildSessionPreview preserves tool messages in order", () => {
+  const preview = buildSessionPreview([
+    {
+      role: "assistant",
+      content: "Let me check that",
+      toolCalls: [{ id: "tool-1", name: "search", input: { query: "foo" } }],
+    },
+    {
+      role: "tool",
+      toolCallId: "tool-1",
+      toolName: "search",
+      content: "search output",
+    },
+    {
+      role: "assistant",
+      content: "Found it",
+    },
+  ]);
+
+  assert.deepEqual(
+    preview.map((message) => message.role),
+    ["assistant", "tool", "assistant"],
+  );
+});

--- a/tests/session-ui.test.ts
+++ b/tests/session-ui.test.ts
@@ -24,4 +24,6 @@ test("built JS contains active saved session update logic", () => {
   assert.ok(js.includes("Session updated:"), "JS should emit the update confirmation message");
   assert.ok(js.includes("sessionRefreshTracker"), "JS should guard session list refreshes against stale responses");
   assert.ok(js.includes('saveBtn.setAttribute("disabled", "true")'), "JS should disable saving while the first save is in flight");
+  assert.ok(js.includes("renderLoadedSessionMessages"), "JS should render session previews after load");
+  assert.ok(js.includes("body.messages"), "JS should read preview messages from the load session response");
 });


### PR DESCRIPTION
## Summary

Preview the most recent saved session messages when loading a session in the web UI.

## What changed

- add a shared session preview helper that filters out compaction summary stub messages and returns the last 10 previewable messages
- update `POST /api/sessions/load` to return those preview messages alongside the session label
- rehydrate loaded `user`, `assistant`, and `tool` messages into the existing chat pane instead of only showing a generic restore notice
- keep the existing fallback restore notice when a session has no previewable messages
- add coverage for the preview helper, the load-session API response, and the built web session UI bundle

## Why

Previously, loading a saved session cleared the transcript and replaced it with a single "Session restored" message. That made it hard to regain context after switching back into prior work. Returning a filtered preview from the server lets the UI restore recent context immediately without surfacing compaction summaries as if they were normal chat messages.

## Validation

- `npm run build`
- `npm run lint`
- `node --test --import tsx tests/session-preview.test.ts tests/serve.integration.test.ts tests/session-ui.test.ts`
- `npm test`
