### PR TITLE
Add fuzzy fallback for symbol search

### DIFF
--- a/src/serve/mcp-server.ts
+++ b/src/serve/mcp-server.ts
@@ -16,6 +16,7 @@ import {
   formatAmbiguousSymbolMatches,
   resolveSymbolInput,
 } from "../shared/symbol-resolution.js";
+import { searchSymbols } from "../shared/symbol-search.js";
 import type { AgentBridge } from "./agent-bridge.js";
 import type { ServerMessage } from "./types.js";
 
@@ -218,27 +219,34 @@ function createMcpServer(bridge: AgentBridge, emit: (msg: ServerMessage) => void
     },
     async ({ query, kind }) => {
       return wrapToolCall("search_code_map", { query, kind }, async () => {
-        const symbols = bridge.getSymbols();
-        const queryLower = query.toLowerCase();
+        const result = searchSymbols(
+          bridge.getSymbols().map((symbol) => ({
+            symbol,
+            record: {
+              name: symbol.name,
+              qualifiedName: symbol.qualifiedName,
+              kind: symbol.kind,
+              filePath: symbol.filePath,
+              startLine: symbol.startLine,
+              exported: symbol.exported,
+            },
+            lookupNames: [symbol.name, symbol.qualifiedName],
+          })),
+          query,
+          { kind, limit: 30 },
+        );
 
-        let matches = symbols.filter((s) => {
-          const nameMatch = s.name.toLowerCase().includes(queryLower) ||
-            s.qualifiedName.toLowerCase().includes(queryLower);
-          return nameMatch;
-        });
-
-        if (kind) {
-          matches = matches.filter((s) => s.kind === kind);
-        }
-
-        matches = matches.slice(0, 30);
-
-        if (matches.length === 0) {
+        if (result.total === 0) {
           return { content: [{ type: "text" as const, text: `No symbols matching "${query}"${kind ? ` (kind: ${kind})` : ""}.` }] };
         }
 
+        const matches = result.matches;
+        const heading = result.mode === "similar"
+          ? `No exact substring matches for "${query}"${kind ? ` (kind: ${kind})` : ""}. Showing ${matches.length} similar symbol(s):`
+          : `Found ${matches.length} symbol(s) matching "${query}":`;
+
         const lines = [
-          `Found ${matches.length} symbol(s) matching "${query}":`,
+          heading,
           ...matches.map((s) =>
             `  - ${s.name} (${s.kind}) — ${s.filePath}:${s.startLine} — qualified: ${s.qualifiedName}${s.signature ? `\n    ${s.signature}` : ""}`,
           ),

--- a/src/shared/symbol-search.ts
+++ b/src/shared/symbol-search.ts
@@ -1,0 +1,235 @@
+export interface SymbolSearchCandidateRecord {
+  name: string;
+  qualifiedName: string;
+  kind: string;
+  filePath: string;
+  startLine: number;
+  exported?: boolean;
+}
+
+export interface SymbolSearchCandidate<T> {
+  symbol: T;
+  record: SymbolSearchCandidateRecord;
+  lookupNames: string[];
+}
+
+export interface SearchSymbolsOptions {
+  kind?: string | undefined;
+  limit?: number | undefined;
+  skip?: number | undefined;
+}
+
+export interface SearchSymbolsResult<T> {
+  matches: T[];
+  mode: "substring" | "similar" | "none";
+  total: number;
+}
+
+const MIN_SIMILARITY_QUERY_LENGTH = 3;
+const MIN_SIMILARITY_SCORE = 0.62;
+
+function normalizeSearchText(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+function tokenizeSearchText(value: string): string[] {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+function levenshteinDistance(a: string, b: string): number {
+  if (a === b) {
+    return 0;
+  }
+
+  if (a.length === 0) {
+    return b.length;
+  }
+  if (b.length === 0) {
+    return a.length;
+  }
+
+  const previous = new Array<number>(b.length + 1);
+  const current = new Array<number>(b.length + 1);
+
+  for (let j = 0; j <= b.length; j += 1) {
+    previous[j] = j;
+  }
+
+  for (let i = 1; i <= a.length; i += 1) {
+    current[0] = i;
+    for (let j = 1; j <= b.length; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      current[j] = Math.min(
+        current[j - 1]! + 1,
+        previous[j]! + 1,
+        previous[j - 1]! + cost,
+      );
+    }
+
+    for (let j = 0; j <= b.length; j += 1) {
+      previous[j] = current[j]!;
+    }
+  }
+
+  return previous[b.length]!;
+}
+
+function diceCoefficient(a: string, b: string): number {
+  if (a === b) {
+    return 1;
+  }
+
+  if (a.length < 2 || b.length < 2) {
+    return 0;
+  }
+
+  const bigrams = new Map<string, number>();
+  for (let i = 0; i < a.length - 1; i += 1) {
+    const bigram = a.slice(i, i + 2);
+    bigrams.set(bigram, (bigrams.get(bigram) ?? 0) + 1);
+  }
+
+  let matches = 0;
+  for (let i = 0; i < b.length - 1; i += 1) {
+    const bigram = b.slice(i, i + 2);
+    const count = bigrams.get(bigram) ?? 0;
+    if (count > 0) {
+      bigrams.set(bigram, count - 1);
+      matches += 1;
+    }
+  }
+
+  return (2 * matches) / ((a.length - 1) + (b.length - 1));
+}
+
+function computeSimilarityScore(pattern: string, candidate: string): number {
+  const normalizedPattern = normalizeSearchText(pattern);
+  const normalizedCandidate = normalizeSearchText(candidate);
+  if (!normalizedPattern || !normalizedCandidate) {
+    return 0;
+  }
+
+  if (normalizedPattern === normalizedCandidate) {
+    return 1;
+  }
+
+  const maxLength = Math.max(normalizedPattern.length, normalizedCandidate.length, 1);
+  const lengthPenalty = Math.abs(normalizedCandidate.length - normalizedPattern.length) / maxLength;
+  let bestScore = 0;
+
+  if (
+    normalizedCandidate.startsWith(normalizedPattern) ||
+    normalizedPattern.startsWith(normalizedCandidate)
+  ) {
+    bestScore = Math.max(bestScore, 0.93 - (lengthPenalty * 0.2));
+  }
+
+  const tokens = tokenizeSearchText(candidate);
+  if (tokens.some((token) => token.startsWith(normalizedPattern) || normalizedPattern.startsWith(token))) {
+    bestScore = Math.max(bestScore, 0.88 - (lengthPenalty * 0.15));
+  }
+
+  const editDistance = levenshteinDistance(normalizedPattern, normalizedCandidate);
+  const maxDistance = Math.max(1, Math.ceil(normalizedPattern.length * 0.34));
+  if (editDistance <= maxDistance) {
+    const editSimilarity = 1 - (editDistance / maxLength);
+    bestScore = Math.max(bestScore, 0.62 + (editSimilarity * 0.3));
+  }
+
+  const dice = diceCoefficient(normalizedPattern, normalizedCandidate);
+  if (dice >= 0.5) {
+    bestScore = Math.max(bestScore, 0.45 + (dice * 0.35));
+  }
+
+  return bestScore;
+}
+
+function compareSubstringCandidates<T>(
+  pattern: string,
+  a: SymbolSearchCandidate<T>,
+  b: SymbolSearchCandidate<T>,
+): number {
+  const lowerPattern = pattern.toLowerCase();
+  const aExact = Number(a.lookupNames.some((value) => value.toLowerCase() === lowerPattern));
+  const bExact = Number(b.lookupNames.some((value) => value.toLowerCase() === lowerPattern));
+  if (aExact !== bExact) {
+    return bExact - aExact;
+  }
+
+  return Number(b.record.exported ?? false) - Number(a.record.exported ?? false) ||
+    a.record.name.localeCompare(b.record.name) ||
+    a.record.filePath.localeCompare(b.record.filePath) ||
+    a.record.startLine - b.record.startLine ||
+    a.record.qualifiedName.localeCompare(b.record.qualifiedName);
+}
+
+function compareSimilarCandidates<T>(
+  a: { candidate: SymbolSearchCandidate<T>; score: number },
+  b: { candidate: SymbolSearchCandidate<T>; score: number },
+): number {
+  return b.score - a.score ||
+    Number(b.candidate.record.exported ?? false) - Number(a.candidate.record.exported ?? false) ||
+    a.candidate.record.name.localeCompare(b.candidate.record.name) ||
+    a.candidate.record.filePath.localeCompare(b.candidate.record.filePath) ||
+    a.candidate.record.startLine - b.candidate.record.startLine ||
+    a.candidate.record.qualifiedName.localeCompare(b.candidate.record.qualifiedName);
+}
+
+export function searchSymbols<T>(
+  candidates: SymbolSearchCandidate<T>[],
+  pattern: string,
+  options: SearchSymbolsOptions = {},
+): SearchSymbolsResult<T> {
+  const lowerPattern = pattern.toLowerCase();
+  const normalizedKind = options.kind?.trim().toLowerCase();
+  const skip = Math.max(0, options.skip ?? 0);
+  const limit = Math.max(1, options.limit ?? 30);
+
+  const filtered = candidates.filter((candidate) => {
+    if (normalizedKind && candidate.record.kind.toLowerCase() !== normalizedKind) {
+      return false;
+    }
+    return true;
+  });
+
+  const substringMatches = filtered
+    .filter((candidate) =>
+      candidate.lookupNames.some((value) => value.toLowerCase().includes(lowerPattern)),
+    )
+    .sort((a, b) => compareSubstringCandidates(pattern, a, b));
+
+  if (substringMatches.length > 0) {
+    return {
+      matches: substringMatches.slice(skip, skip + limit).map((candidate) => candidate.symbol),
+      mode: "substring",
+      total: substringMatches.length,
+    };
+  }
+
+  const normalizedPattern = normalizeSearchText(pattern);
+  if (normalizedPattern.length < MIN_SIMILARITY_QUERY_LENGTH) {
+    return { matches: [], mode: "none", total: 0 };
+  }
+
+  const similarMatches = filtered
+    .map((candidate) => ({
+      candidate,
+      score: Math.max(...candidate.lookupNames.map((value) => computeSimilarityScore(pattern, value))),
+    }))
+    .filter((entry) => entry.score >= MIN_SIMILARITY_SCORE)
+    .sort(compareSimilarCandidates);
+
+  if (similarMatches.length === 0) {
+    return { matches: [], mode: "none", total: 0 };
+  }
+
+  return {
+    matches: similarMatches.slice(skip, skip + limit).map((entry) => entry.candidate.symbol),
+    mode: "similar",
+    total: similarMatches.length,
+  };
+}

--- a/src/tools/search-code-map.ts
+++ b/src/tools/search-code-map.ts
@@ -1,35 +1,10 @@
 import type { ToolDefinition } from "@minicode/agent-sdk";
 import { expectNonEmptyString, expectOptionalNumber } from "@minicode/agent-sdk";
 import { getSymbolDisplayName, getSymbolLookupNames } from "../indexer/symbol-names.js";
-import type { IndexedSymbol, ProjectIndex } from "../indexer/types.js";
+import type { ProjectIndex } from "../indexer/types.js";
+import { searchSymbols } from "../shared/symbol-search.js";
 
 const DEFAULT_LIMIT = 30;
-
-function compareMatchedSymbols(pattern: string, a: IndexedSymbol, b: IndexedSymbol): number {
-  const lowerPattern = pattern.toLowerCase();
-  const aDisplay = getSymbolDisplayName(a).toLowerCase();
-  const bDisplay = getSymbolDisplayName(b).toLowerCase();
-  const aExact = Number(aDisplay === lowerPattern || a.qualifiedName.toLowerCase() === lowerPattern || a.name.toLowerCase() === lowerPattern);
-  const bExact = Number(bDisplay === lowerPattern || b.qualifiedName.toLowerCase() === lowerPattern || b.name.toLowerCase() === lowerPattern);
-  if (aExact !== bExact) {
-    return bExact - aExact;
-  }
-
-  return Number(b.exported) - Number(a.exported) ||
-    aDisplay.localeCompare(bDisplay) ||
-    a.filePath.localeCompare(b.filePath) ||
-    a.startLine - b.startLine ||
-    a.qualifiedName.localeCompare(b.qualifiedName);
-}
-
-function matchesPattern(
-  text: string,
-  pattern: string,
-): boolean {
-  const lowerText = text.toLowerCase();
-  const lowerPattern = pattern.toLowerCase();
-  return lowerText.includes(lowerPattern);
-}
 
 export function createSearchCodeMapTool(
   projectIndex: ProjectIndex,
@@ -80,35 +55,51 @@ export function createSearchCodeMapTool(
       );
       const skip = Math.max(0, expectOptionalNumber(input, "skip") ?? 0);
 
-      const symbols = [...projectIndex.symbols.values()];
-      const matches = symbols.filter((sym) => {
-        const lookupNames = getSymbolLookupNames(sym);
-        if (!lookupNames.some((candidate) => matchesPattern(candidate, pattern))) {
-          return false;
-        }
-        if (kind && sym.kind !== kind) {
-          return false;
-        }
-        return true;
-      }).sort((a, b) => compareMatchedSymbols(pattern, a, b));
+      const result = searchSymbols(
+        [...projectIndex.symbols.values()].map((sym) => ({
+          symbol: sym,
+          record: {
+            name: getSymbolDisplayName(sym),
+            qualifiedName: sym.qualifiedName,
+            kind: sym.kind,
+            filePath: sym.filePath,
+            startLine: sym.startLine,
+            exported: sym.exported,
+          },
+          lookupNames: getSymbolLookupNames(sym),
+        })),
+        pattern,
+        { kind, limit, skip },
+      );
 
-      const shown = matches.slice(skip, skip + limit);
+      const shown = result.matches;
       const lines = shown.map(
         (s) =>
           `- ${getSymbolDisplayName(s)} (${s.kind}) — ${s.filePath}:${s.startLine} — qualified: ${s.qualifiedName}`,
       );
-      const remaining = matches.length - skip - shown.length;
+      const remaining = result.total - skip - shown.length;
       const footer =
         remaining > 0
           ? `\n... and ${remaining} more (use skip: ${skip + limit}, limit: ${limit} for next page)`
           : "";
 
-      if (matches.length === 0) {
+      if (result.total === 0) {
         return `No symbols matching "${pattern}"${kind ? ` (kind: ${kind})` : ""}. Try a shorter or different pattern.`;
       }
 
+      if (result.mode === "similar") {
+        return [
+          `# No exact substring matches for "${pattern}"${kind ? ` (kind: ${kind})` : ""}`,
+          "",
+          `Showing similar symbols instead (${result.total} total):`,
+          "",
+          ...lines,
+          footer,
+        ].join("\n");
+      }
+
       return [
-        `# Symbols matching "${pattern}" (${matches.length} total)`,
+        `# Symbols matching "${pattern}" (${result.total} total)`,
         "",
         ...lines,
         footer,

--- a/tests/search-code-map.test.ts
+++ b/tests/search-code-map.test.ts
@@ -28,6 +28,18 @@ test("search_code_map returns empty when no match", async () => {
   assert.ok(result.includes("No symbols matching"));
 });
 
+test("search_code_map returns similar matches when exact substring lookup fails", async () => {
+  const root = path.resolve(import.meta.dirname, "..");
+  const projectIndex = await buildProjectIndex(root);
+  const tool = createSearchCodeMapTool(projectIndex);
+
+  const result = await tool.execute({ pattern: "ModelRespnse" });
+
+  assert.ok(result.includes('No exact substring matches for "ModelRespnse"'));
+  assert.ok(result.includes("Showing similar symbols instead"));
+  assert.ok(result.includes("ModelResponse"));
+});
+
 test("search_code_map appears in tool registry when projectIndex provided", async () => {
   const root = path.resolve(import.meta.dirname, "..");
   const projectIndex = await buildProjectIndex(root);


### PR DESCRIPTION
Closes #116.

## Summary
- add a shared symbol search helper for substring and near-match lookups
- return similar symbol matches when search_code_map finds no exact substring hit
- keep MCP symbol search behavior aligned with the in-app tool behavior

## Verification
- node --test --import tsx tests/search-code-map.test.ts
- npm run build