### PR TITLE
Add full file preview modal to graph

### DIFF
--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -74,6 +74,26 @@ function sendJson(res: ServerResponse, status: number, body: unknown): void {
   res.end(JSON.stringify(body));
 }
 
+function resolveWorkspaceFilePath(
+  workspaceRoot: string,
+  requestedPath: string,
+): { absolutePath: string; relativePath: string } | null {
+  const trimmedPath = requestedPath.trim();
+  if (trimmedPath.length === 0) {
+    return null;
+  }
+
+  const root = path.resolve(workspaceRoot);
+  const absolutePath = path.resolve(root, trimmedPath);
+  const relativePath = path.relative(root, absolutePath);
+
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    return null;
+  }
+
+  return { absolutePath, relativePath };
+}
+
 function readBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
@@ -516,6 +536,23 @@ export function createRequestHandler(
           sendJson(res, 200, { symbol: name, filePath: sym.filePath, startLine: sym.startLine, endLine: sym.endLine, source });
         } catch {
           sendJson(res, 500, { error: `Could not read file: ${sym.filePath}` });
+        }
+        return;
+      }
+
+      if (pathname === "/api/file-source" && method === "GET") {
+        const requestedPath = url.searchParams.get("path") ?? "";
+        const resolved = resolveWorkspaceFilePath(config.workspaceRoot, requestedPath);
+        if (!resolved) {
+          sendJson(res, 403, { error: "Invalid workspace file path" });
+          return;
+        }
+
+        try {
+          const source = await readFile(resolved.absolutePath, "utf8");
+          sendJson(res, 200, { filePath: resolved.relativePath, source });
+        } catch {
+          sendJson(res, 404, { error: `Could not read file: ${resolved.relativePath}` });
         }
         return;
       }

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,4 +1,5 @@
 import { initGraph, highlightAgentActivity, resizeGraph } from './graph.ts';
+import { closeModal, openModal } from './modal-state.ts';
 import { createLatestRequestTracker } from './request-tracker.ts';
 import { escapeHtml, renderMarkdownInto } from './utils.ts';
 
@@ -717,19 +718,6 @@ function closeHeaderMenus(): void {
   sessionDropdown.classList.add("hidden");
 }
 
-function isSettingsModalOpen(): boolean {
-  return !settingsModal.classList.contains("hidden");
-}
-
-function isOpenRouterConnectModalOpen(): boolean {
-  return !openRouterConnectModal.classList.contains("hidden");
-}
-
-function syncModalOpenState(): void {
-  const anyModalOpen = isSettingsModalOpen() || isOpenRouterConnectModalOpen();
-  document.body.classList.toggle("modal-open", anyModalOpen);
-}
-
 function formatSettingsValue(value: SettingsValue): string {
   return value === null ? "(unset)" : String(value);
 }
@@ -986,33 +974,25 @@ function updateSettingsActions(): void {
 
 function openSettings(): void {
   closeHeaderMenus();
-  settingsModal.classList.remove("hidden");
-  settingsModal.setAttribute("aria-hidden", "false");
-  syncModalOpenState();
+  openModal(settingsModal);
   void loadSettings();
 }
 
 function closeSettings(): void {
-  settingsModal.classList.add("hidden");
-  settingsModal.setAttribute("aria-hidden", "true");
-  syncModalOpenState();
+  closeModal(settingsModal);
   clearSettingsBanner();
 }
 
 function openOpenRouterConnectModal(): void {
   closeHeaderMenus();
-  openRouterConnectModal.classList.remove("hidden");
-  openRouterConnectModal.setAttribute("aria-hidden", "false");
+  openModal(openRouterConnectModal);
   openRouterPersistCheckbox.checked = false;
   openRouterConnectContinueBtn.disabled = false;
-  syncModalOpenState();
 }
 
 function closeOpenRouterConnectModal(): void {
-  openRouterConnectModal.classList.add("hidden");
-  openRouterConnectModal.setAttribute("aria-hidden", "true");
+  closeModal(openRouterConnectModal);
   openRouterConnectContinueBtn.disabled = false;
-  syncModalOpenState();
 }
 
 // Form handling

--- a/src/web/graph.ts
+++ b/src/web/graph.ts
@@ -2,6 +2,7 @@
 // Start empty. User searches for a symbol, selects it to seed the graph.
 // Clicking a node expands its 1-hop neighbors. Walk the graph in real time.
 
+import { closeModal, openModal } from './modal-state.ts';
 import { escapeHtml, renderMarkdownInto } from './utils.ts';
 import {
   buildFindingGraphContext,
@@ -110,6 +111,8 @@ let analysisReport: StructuralAnalysisReport | null = null;
 let activeAnalysisFindingId: string | null = null;
 let activeAnalysisFilter: AnalysisFindingFilter = 'all';
 const analysisExplanationCache = new Map<string, string>();
+let filePreviewModalInitialized = false;
+let latestFilePreviewRequestId = 0;
 
 const LAYOUT_OPTIONS: Record<string, unknown> = {
   name: 'cose',
@@ -134,6 +137,7 @@ export async function initGraph(): Promise<void> {
 
   const cyEl = document.getElementById('cy')!;
   const detailEl = document.getElementById('symbol-detail')!;
+  setupFilePreviewModal();
 
   try {
     const [graphRes, symbolsRes, focusRes] = await Promise.all([
@@ -304,6 +308,89 @@ function focusFileInGraph(filePath: string): void {
   }
   refreshAnalysisGraphState();
   runLayout();
+}
+
+function getFilePreviewLanguage(filePath: string): string {
+  const ext = filePath.split('.').pop()?.toLowerCase() || '';
+  const langMap: Record<string, string> = {
+    ts: 'typescript',
+    tsx: 'typescript',
+    js: 'javascript',
+    jsx: 'javascript',
+    json: 'json',
+    md: 'markdown',
+    css: 'css',
+    html: 'xml',
+  };
+  return langMap[ext] || 'plaintext';
+}
+
+function closeFilePreview(): void {
+  const modal = document.getElementById('file-preview-modal');
+  if (!modal) return;
+  closeModal(modal);
+}
+
+function setupFilePreviewModal(): void {
+  if (filePreviewModalInitialized) return;
+  filePreviewModalInitialized = true;
+
+  const modal = document.getElementById('file-preview-modal') as HTMLElement | null;
+  const backdrop = document.getElementById('file-preview-backdrop') as HTMLElement | null;
+  const closeBtn = document.getElementById('file-preview-close') as HTMLButtonElement | null;
+  if (!modal || !backdrop || !closeBtn) {
+    return;
+  }
+
+  backdrop.addEventListener('click', () => closeFilePreview());
+  closeBtn.addEventListener('click', () => closeFilePreview());
+  document.addEventListener('keydown', (event: KeyboardEvent) => {
+    if (event.key === 'Escape' && !modal.classList.contains('hidden')) {
+      closeFilePreview();
+    }
+  });
+}
+
+async function openFilePreview(filePath: string): Promise<void> {
+  const modal = document.getElementById('file-preview-modal') as HTMLElement | null;
+  const pathEl = document.getElementById('file-preview-path') as HTMLElement | null;
+  const codeEl = document.getElementById('file-preview-code') as HTMLPreElement | null;
+  if (!modal || !pathEl || !codeEl) {
+    return;
+  }
+
+  latestFilePreviewRequestId += 1;
+  const requestId = latestFilePreviewRequestId;
+
+  pathEl.textContent = filePath;
+  codeEl.className = 'file-preview-code';
+  codeEl.textContent = 'Loading...';
+  openModal(modal);
+
+  try {
+    const res = await fetch(`/api/file-source?path=${encodeURIComponent(filePath)}`);
+    if (!res.ok) {
+      codeEl.textContent = '(file unavailable)';
+      return;
+    }
+
+    const data = await res.json() as { filePath: string; source: string };
+    if (requestId !== latestFilePreviewRequestId) {
+      return;
+    }
+
+    pathEl.textContent = data.filePath;
+    codeEl.className = `file-preview-code language-${getFilePreviewLanguage(data.filePath)}`;
+    codeEl.textContent = data.source;
+    if (typeof hljs !== 'undefined') {
+      hljs.highlightElement(codeEl);
+    }
+  } catch {
+    if (requestId !== latestFilePreviewRequestId) {
+      return;
+    }
+    codeEl.textContent = '(file unavailable)';
+  }
 }
 
 interface FocusSymbolOptions {
@@ -946,7 +1033,11 @@ async function showDetail(node: CyCollection, detailEl: HTMLElement): Promise<vo
       <span class="detail-name">${escapeHtml(data.label)}</span>
       <span class="detail-kind-badge" style="background:${kindColor}20;color:${kindColor}">${kind}</span>
     </div>
-    <div class="detail-file">${escapeHtml(data.file || 'unknown')}${data.startLine ? ':' + data.startLine : ''}</div>
+    <div class="detail-file">${
+      data.file
+        ? `<button type="button" class="detail-file-link" data-file="${escapeHtml(data.file)}">${escapeHtml(data.file)}${data.startLine ? ':' + data.startLine : ''}</button>`
+        : 'unknown'
+    }</div>
   `;
 
   // Action buttons row
@@ -1001,6 +1092,13 @@ async function showDetail(node: CyCollection, detailEl: HTMLElement): Promise<vo
   pinBtn.addEventListener('click', async () => {
     const name = pinBtn.dataset.name || '';
     await togglePin(name, node, pinBtn);
+  });
+
+  const fileLink = detailEl.querySelector('.detail-file-link') as HTMLButtonElement | null;
+  fileLink?.addEventListener('click', () => {
+    const filePath = fileLink.dataset.file || '';
+    if (!filePath) return;
+    void openFilePreview(filePath);
   });
 
   // Explain button
@@ -1256,6 +1354,7 @@ function setupToolbar(): void {
         dropdown.classList.add('hidden');
         if (type === 'file') {
           focusFileInGraph(id);
+          void openFilePreview(id);
           return;
         }
         void focusSymbolInGraph(id, {

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -235,6 +235,22 @@ MODEL=your-model-name</pre>
     </section>
   </div>
 
+  <div id="file-preview-modal" class="modal hidden" aria-hidden="true">
+    <div id="file-preview-backdrop" class="modal-backdrop"></div>
+    <section class="modal-panel modal-panel-file-preview" role="dialog" aria-modal="true" aria-labelledby="file-preview-title">
+      <div class="modal-header">
+        <div>
+          <h2 id="file-preview-title">File preview</h2>
+          <p id="file-preview-path" class="modal-subtitle">Loading…</p>
+        </div>
+        <button id="file-preview-close" class="header-btn" type="button">Close</button>
+      </div>
+      <div class="file-preview-body">
+        <pre id="file-preview-code" class="file-preview-code">Loading...</pre>
+      </div>
+    </section>
+  </div>
+
   <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/src/web/modal-state.ts
+++ b/src/web/modal-state.ts
@@ -1,0 +1,17 @@
+export function syncBodyModalOpenState(): void {
+  const anyModalOpen = [...document.querySelectorAll<HTMLElement>(".modal")]
+    .some((modal) => !modal.classList.contains("hidden"));
+  document.body.classList.toggle("modal-open", anyModalOpen);
+}
+
+export function openModal(modal: HTMLElement): void {
+  modal.classList.remove("hidden");
+  modal.setAttribute("aria-hidden", "false");
+  syncBodyModalOpenState();
+}
+
+export function closeModal(modal: HTMLElement): void {
+  modal.classList.add("hidden");
+  modal.setAttribute("aria-hidden", "true");
+  syncBodyModalOpenState();
+}

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -862,6 +862,13 @@ footer {
   width: min(640px, calc(100vw - 32px));
 }
 
+.modal-panel-file-preview {
+  width: min(1200px, 80vw);
+  height: 80vh;
+  max-width: 80vw;
+  max-height: 80vh;
+}
+
 .modal-header,
 .modal-footer,
 .settings-toolbar {
@@ -885,6 +892,29 @@ footer {
 .modal-subtitle {
   font-size: 12px;
   color: var(--text-dim);
+}
+
+.file-preview-body {
+  flex: 1;
+  min-height: 0;
+  padding: 0 20px 20px;
+  overflow: auto;
+  background: rgba(15, 16, 26, 0.92);
+}
+
+.file-preview-code {
+  margin: 0;
+  min-height: 100%;
+  padding: 18px;
+  border-radius: 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-size: 12px;
+  line-height: 1.6;
+  overflow: auto;
+  white-space: pre;
+  font-family: var(--font-mono);
 }
 
 .settings-toolbar {
@@ -1779,6 +1809,24 @@ main::-webkit-scrollbar-thumb {
   font-size: 12px;
   color: var(--text-dim);
   margin-bottom: 12px;
+}
+
+.detail-file-link {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  text-decoration: underline;
+  text-decoration-color: rgba(124, 92, 255, 0.35);
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.detail-file-link:hover {
+  color: var(--text);
+  text-decoration-color: var(--accent);
 }
 
 .detail-signature {

--- a/tests/graph-onboarding.test.ts
+++ b/tests/graph-onboarding.test.ts
@@ -28,6 +28,8 @@ test('built HTML contains #cy graph container', () => {
   assert.ok(html.includes('id="cy"'), 'HTML should contain the #cy graph container');
   assert.ok(html.includes('id="graph-pane"'), 'HTML should contain the #graph-pane wrapper');
   assert.ok(html.includes('Search symbols or files...'), 'HTML should expose mixed symbol/file search');
+  assert.ok(html.includes('id="file-preview-modal"'), 'HTML should contain the file preview modal shell');
+  assert.ok(html.includes('id="file-preview-code"'), 'HTML should contain the file preview code surface');
 });
 
 test('onboarding hint includes user-facing guidance text in built JS', () => {
@@ -113,4 +115,24 @@ test('built JS supports file search results and file-centered neighborhood rende
     js.includes('buildFileFocusedSelection'),
     'file-focused graph seeding should use the shared file selection helper',
   );
+  assert.ok(
+    js.includes('openFilePreview'),
+    'JS should define a file preview helper for file search selections',
+  );
+  assert.ok(
+    js.includes('/api/file-source?path='),
+    'JS should fetch full file contents for the preview modal',
+  );
+  assert.ok(
+    js.includes('detail-file-link'),
+    'JS should wire the symbol detail filename into the preview modal',
+  );
+});
+
+test('built CSS contains file preview modal sizing and link styling', () => {
+  const css = readFileSync(join(distWeb, 'style.css'), 'utf-8');
+  assert.ok(css.includes('.modal-panel-file-preview'), 'CSS should contain the file preview modal panel class');
+  assert.ok(css.includes('width: min(1200px, 80vw);'), 'file preview modal should open at roughly 80% width');
+  assert.ok(css.includes('height: 80vh;'), 'file preview modal should open at roughly 80% height');
+  assert.ok(css.includes('.detail-file-link'), 'CSS should style the clickable filename in the detail panel');
 });

--- a/tests/serve.integration.test.ts
+++ b/tests/serve.integration.test.ts
@@ -1378,6 +1378,38 @@ test("GET /api/symbols/:name/source returns 500 when file is missing", async () 
   assert.ok(body.error.includes("src/foo.ts"));
 });
 
+test("GET /api/file-source returns full file contents for a workspace file", async () => {
+  const bridge = new MockBridge();
+  const base = await startTestServer(bridge);
+
+  const wsRoot = "/tmp/test-workspace";
+  mkdirSync(`${wsRoot}/src`, { recursive: true });
+  writeFileSync(`${wsRoot}/src/foo.ts`, "line1\nfunction foo(): void {\n  return;\n}\nline5\n");
+
+  try {
+    const res = await fetch(`${base}/api/file-source?path=${encodeURIComponent("src/foo.ts")}`);
+    assert.equal(res.status, 200);
+
+    const body = (await res.json()) as { filePath: string; source: string };
+    assert.equal(body.filePath, "src/foo.ts");
+    assert.ok(body.source.includes("function foo(): void"));
+    assert.ok(body.source.includes("line5"));
+  } finally {
+    rmSync(wsRoot, { recursive: true, force: true });
+  }
+});
+
+test("GET /api/file-source rejects path traversal", async () => {
+  const bridge = new MockBridge();
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/file-source?path=${encodeURIComponent("../secret.txt")}`);
+  assert.equal(res.status, 403);
+
+  const body = (await res.json()) as { error: string };
+  assert.ok(body.error.includes("Invalid workspace file path"));
+});
+
 // ── Annotations API tests ──
 
 test("GET /api/annotations returns empty annotations initially", async () => {


### PR DESCRIPTION
Closes #107.

## Summary
- open a full-file modal when selecting a file result from the graph search dropdown
- make the filename in the symbol detail panel clickable so it opens the same modal
- add a safe file-source endpoint for full workspace file previews

## Verification
- npm run build
- node --test --import tsx tests/graph-onboarding.test.ts tests/serve.integration.test.ts --test-name-pattern "file-source|file preview|file search results|source returns"