### PR TITLE
[codex] Add OpenAI-compatible provider onboarding

### DIFF
--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -71,6 +71,46 @@ export function getConfigMissing(config: AgentConfig): string[] {
   return missing;
 }
 
+export type ConfiguredProvider = "anthropic" | "openrouter" | "openai-compatible";
+
+function hasExplicitConfigValue(value: string | undefined): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function parseExplicitModelProvider(
+  value: string | undefined,
+): "anthropic" | "openai-compatible" | undefined {
+  if (!hasExplicitConfigValue(value)) {
+    return undefined;
+  }
+  return parseModelProvider(value);
+}
+
+export function getConfiguredProvider(
+  config: AgentConfig,
+  env: Record<string, string | undefined> = process.env,
+): ConfiguredProvider | null {
+  const explicitModelProvider = parseExplicitModelProvider(env.MODEL_PROVIDER);
+
+  if (config.modelProvider === "anthropic") {
+    return explicitModelProvider === "anthropic" || hasExplicitConfigValue(env.ANTHROPIC_API_KEY)
+      ? "anthropic"
+      : null;
+  }
+
+  const hasExplicitOpenAiCompatibleConfig =
+    explicitModelProvider === "openai-compatible" ||
+    hasExplicitConfigValue(env.OPENAI_BASE_URL) ||
+    hasExplicitConfigValue(env.OPENROUTER_API_KEY);
+
+  if (!hasExplicitOpenAiCompatibleConfig) {
+    return null;
+  }
+
+  const baseUrl = (env.OPENAI_BASE_URL ?? config.openAiBaseUrl).trim().toLowerCase();
+  return baseUrl.includes("openrouter") ? "openrouter" : "openai-compatible";
+}
+
 export function getConfigSetupMessage(config: AgentConfig): string | null {
   const missing = getConfigMissing(config);
 

--- a/src/serve/agent-bridge.ts
+++ b/src/serve/agent-bridge.ts
@@ -33,7 +33,7 @@ export class AgentBridge {
   private modelClient: ReturnType<typeof createModelClient> | undefined;
   private projectIndex: ProjectIndex | undefined;
   private toolRegistry: ReturnType<typeof createToolRegistry> | undefined;
-  private sessionOpenRouterConnected = false;
+  private sessionProviderConnection: "openrouter" | "openai-compatible" | null = null;
   private busy = false;
   private abortController: AbortController | null = null;
   private broadcast: (msg: ServerMessage) => void;
@@ -242,7 +242,11 @@ export class AgentBridge {
   }
 
   isOpenRouterSessionConnected(): boolean {
-    return this.sessionOpenRouterConnected;
+    return this.sessionProviderConnection === "openrouter";
+  }
+
+  isOpenAiCompatibleSessionConnected(): boolean {
+    return this.sessionProviderConnection === "openai-compatible";
   }
 
   connectOpenRouter(apiKey: string): void {
@@ -262,8 +266,37 @@ export class AgentBridge {
     }).modelProvider = "openai-compatible";
     (this.config as { openAiBaseUrl: string }).openAiBaseUrl = "https://openrouter.ai/api/v1";
     (this.config as { openAiApiKey: string }).openAiApiKey = trimmedKey;
-    this.sessionOpenRouterConnected = true;
+    this.sessionProviderConnection = "openrouter";
 
+    this.modelClient = createModelClient(this.config);
+    this.agent = this.createAgent(currentSession);
+  }
+
+  connectOpenAiCompatible(baseUrl: string, apiKey?: string): void {
+    const trimmedBaseUrl = baseUrl.trim().replace(/\/+$/, "");
+    if (!trimmedBaseUrl) {
+      throw new Error("OpenAI-compatible endpoint is required.");
+    }
+    if (this.busy) {
+      throw new Error("busy");
+    }
+
+    const currentSession = this.agent?.getSession();
+    (this.config as {
+      modelProvider: "openai-compatible";
+      openAiBaseUrl: string;
+      openAiApiKey?: string;
+    }).modelProvider = "openai-compatible";
+    (this.config as { openAiBaseUrl: string }).openAiBaseUrl = trimmedBaseUrl;
+
+    const trimmedApiKey = apiKey?.trim() ?? "";
+    if (trimmedApiKey) {
+      (this.config as { openAiApiKey: string }).openAiApiKey = trimmedApiKey;
+    } else {
+      delete (this.config as { openAiApiKey?: string }).openAiApiKey;
+    }
+
+    this.sessionProviderConnection = "openai-compatible";
     this.modelClient = createModelClient(this.config);
     this.agent = this.createAgent(currentSession);
   }
@@ -272,13 +305,28 @@ export class AgentBridge {
     if (this.busy) {
       throw new Error("busy");
     }
-    if (!this.sessionOpenRouterConnected) {
+    if (this.sessionProviderConnection !== "openrouter") {
       return false;
     }
 
+    return this.disconnectSessionProvider();
+  }
+
+  disconnectOpenAiCompatible(): boolean {
+    if (this.busy) {
+      throw new Error("busy");
+    }
+    if (this.sessionProviderConnection !== "openai-compatible") {
+      return false;
+    }
+
+    return this.disconnectSessionProvider();
+  }
+
+  private disconnectSessionProvider(): boolean {
     const currentSession = this.agent?.getSession();
     AgentBridge.applyConfig(this.config, this.baseConfig);
-    this.sessionOpenRouterConnected = false;
+    this.sessionProviderConnection = null;
 
     try {
       this.modelClient = createModelClient(this.config);

--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -75,7 +75,7 @@ interface OpenRouterDisconnectResponse {
   message: string;
 }
 
-interface OpenAiCompatibleDisconnectResponse extends OpenRouterDisconnectResponse {}
+type OpenAiCompatibleDisconnectResponse = OpenRouterDisconnectResponse;
 
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
   res.writeHead(status, { "Content-Type": "application/json" });

--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -57,6 +57,12 @@ interface OpenRouterConnectRequestBody {
   persistToEnv?: boolean;
 }
 
+interface OpenAiCompatibleConnectRequestBody {
+  baseUrl?: string;
+  apiKey?: string;
+  persistToEnv?: boolean;
+}
+
 interface OpenRouterDisconnectResponse {
   ok: boolean;
   disconnected: boolean;
@@ -68,6 +74,8 @@ interface OpenRouterDisconnectResponse {
   missing: string[];
   message: string;
 }
+
+interface OpenAiCompatibleDisconnectResponse extends OpenRouterDisconnectResponse {}
 
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
   res.writeHead(status, { "Content-Type": "application/json" });
@@ -101,6 +109,10 @@ function readBody(req: IncomingMessage): Promise<string> {
     req.on("end", () => resolve(Buffer.concat(chunks).toString()));
     req.on("error", reject);
   });
+}
+
+function normalizeBaseUrl(value: string): string {
+  return value.trim().replace(/\/+$/, "");
 }
 
 async function serveStatic(res: ServerResponse, urlPath: string): Promise<void> {
@@ -184,6 +196,7 @@ export function createRequestHandler(
           provider: config.modelProvider,
           baseUrl: config.openAiBaseUrl,
           sessionOpenRouterConnected: bridge.isOpenRouterSessionConnected(),
+          sessionOpenAiCompatibleConnected: bridge.isOpenAiCompatibleSessionConnected(),
           needsSetup: missing.length > 0,
           missing,
         });
@@ -308,6 +321,92 @@ export function createRequestHandler(
         return;
       }
 
+      if (pathname === "/api/openai-compatible/connect" && method === "POST") {
+        const body = JSON.parse(await readBody(req)) as OpenAiCompatibleConnectRequestBody;
+        if (!body.baseUrl || typeof body.baseUrl !== "string") {
+          sendJson(res, 400, { error: "baseUrl is required" });
+          return;
+        }
+
+        const normalizedBaseUrl = normalizeBaseUrl(body.baseUrl);
+        if (!normalizedBaseUrl) {
+          sendJson(res, 400, { error: "baseUrl is required" });
+          return;
+        }
+
+        try {
+          const parsedUrl = new URL(normalizedBaseUrl);
+          if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+            throw new Error("invalid protocol");
+          }
+        } catch {
+          sendJson(res, 400, { error: "baseUrl must be a valid absolute http(s) URL" });
+          return;
+        }
+
+        try {
+          bridge.connectOpenAiCompatible(normalizedBaseUrl, body.apiKey);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Failed to configure the OpenAI-compatible provider";
+          sendJson(res, message === "busy" ? 409 : 400, { error: message });
+          return;
+        }
+
+        let persistedToEnv = false;
+        let persistedEnvPath: string | null = null;
+        let persistWarning: string | null = null;
+        const trimmedApiKey = body.apiKey?.trim() ?? "";
+
+        if (body.persistToEnv === true) {
+          try {
+            const result = await upsertHomeEnvValues({
+              values: {
+                MODEL_PROVIDER: "openai-compatible",
+                OPENAI_BASE_URL: normalizedBaseUrl,
+                OPENAI_API_KEY: trimmedApiKey.length > 0 ? trimmedApiKey : null,
+              },
+              ...(minicodeHome ? { minicodeHome } : {}),
+            });
+            persistedToEnv = true;
+            persistedEnvPath = result.path;
+          } catch (error) {
+            const message = error instanceof Error ? error.message : "Failed to update ~/.minicode/.env";
+            persistedEnvPath = getHomeEnvPath(minicodeHome);
+            persistWarning = `The OpenAI-compatible provider connected for this serve session, but minicode could not update ${persistedEnvPath}: ${message}`;
+          }
+        }
+
+        const missing = getConfigMissing(config);
+        const onlyModelMissing = missing.length === 1 && missing[0] === "MODEL is not set";
+        const message = persistWarning
+          ? `${persistWarning}${onlyModelMissing ? " Select a model to continue." : ""}`
+          : persistedToEnv
+            ? (
+              onlyModelMissing
+                ? "The OpenAI-compatible provider connected for this serve session and was saved to ~/.minicode/.env. Select a model to continue, and minicode will remember this endpoint for future runs."
+                : "The OpenAI-compatible provider connected for this serve session and was saved to ~/.minicode/.env for future runs."
+            )
+            : (
+              onlyModelMissing
+                ? "The OpenAI-compatible provider connected for this serve session. Select a model to continue."
+                : "The OpenAI-compatible provider connected for this serve session."
+            );
+        sendJson(res, 200, {
+          ok: true,
+          sessionOnly: true,
+          persistedToEnv,
+          persistedEnvPath,
+          persistWarning,
+          provider: config.modelProvider,
+          model: config.model,
+          baseUrl: config.openAiBaseUrl,
+          needsSetup: missing.length > 0,
+          missing,
+          message,
+        });
+        return;
+      }
+
       if (pathname === "/api/openrouter/disconnect" && method === "POST") {
         let disconnected = false;
         try {
@@ -331,6 +430,34 @@ export function createRequestHandler(
           message: disconnected
             ? "Removed the session-only OpenRouter connection and restored your original provider settings."
             : "No session-only OpenRouter connection was active.",
+        };
+        sendJson(res, 200, body);
+        return;
+      }
+
+      if (pathname === "/api/openai-compatible/disconnect" && method === "POST") {
+        let disconnected = false;
+        try {
+          disconnected = bridge.disconnectOpenAiCompatible();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Failed to remove the OpenAI-compatible session";
+          sendJson(res, message === "busy" ? 409 : 400, { error: message });
+          return;
+        }
+
+        const missing = getConfigMissing(config);
+        const body: OpenAiCompatibleDisconnectResponse = {
+          ok: true,
+          disconnected,
+          sessionOnly: true,
+          provider: config.modelProvider,
+          model: config.model,
+          baseUrl: config.openAiBaseUrl,
+          needsSetup: missing.length > 0,
+          missing,
+          message: disconnected
+            ? "Removed the session-only OpenAI-compatible connection and restored your original provider settings."
+            : "No session-only OpenAI-compatible connection was active.",
         };
         sendJson(res, 200, body);
         return;

--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 import { AgentBridge } from "./agent-bridge.js";
 import { createWebSocketServer } from "./websocket.js";
 import { handleChatCompletions, handleModels } from "./openai-compat.js";
-import { formatConfigForDisplay, getConfigMissing } from "../agent/config.js";
+import { formatConfigForDisplay, getConfiguredProvider, getConfigMissing, resolveConfigEnv } from "../agent/config.js";
 import { applyPersistedConfigUpdates, buildStructuredConfigPayload } from "../agent/editable-config.js";
 import { getHomeEnvPath, upsertHomeEnvValues } from "../agent/home-env.js";
 import { sortModelsAlphabetically } from "../model-utils.js";
@@ -189,12 +189,14 @@ export function createRequestHandler(
       // Minicode REST API
       if (pathname === "/api/status" && method === "GET") {
         const missing = getConfigMissing(config);
+        const resolvedEnv = await resolveConfigEnv({ ...(minicodeHome ? { minicodeHome } : {}) });
         sendJson(res, 200, {
           status: bridge.isBusy() ? "busy" : "ready",
           workspace: config.workspaceRoot,
           model: config.model,
           provider: config.modelProvider,
           baseUrl: config.openAiBaseUrl,
+          configuredProvider: getConfiguredProvider(config, resolvedEnv.values),
           sessionOpenRouterConnected: bridge.isOpenRouterSessionConnected(),
           sessionOpenAiCompatibleConnected: bridge.isOpenAiCompatibleSessionConnected(),
           needsSetup: missing.length > 0,

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -138,9 +138,9 @@ interface OpenRouterDisconnectResponse {
   message: string;
 }
 
-interface OpenAiCompatibleConnectResponse extends OpenRouterConnectResponse {}
+type OpenAiCompatibleConnectResponse = OpenRouterConnectResponse;
 
-interface OpenAiCompatibleDisconnectResponse extends OpenRouterDisconnectResponse {}
+type OpenAiCompatibleDisconnectResponse = OpenRouterDisconnectResponse;
 
 interface ModelSwitchResponse {
   model: string;
@@ -323,19 +323,6 @@ function clearOpenAiCompatibleConnectStatus(): void {
 
 function normalizeBaseUrl(value: string): string {
   return value.trim().replace(/\/+$/, "");
-}
-
-function isLikelyLocalOpenAiEndpoint(baseUrl: string): boolean {
-  if (!baseUrl.trim()) {
-    return false;
-  }
-
-  try {
-    const url = new URL(baseUrl);
-    return ["localhost", "127.0.0.1", "0.0.0.0"].includes(url.hostname);
-  } catch {
-    return false;
-  }
 }
 
 function inferOpenAiCompatiblePreset(baseUrl: string): OpenAiCompatiblePreset {

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -21,6 +21,7 @@ interface StatusResponse {
   provider: string;
   baseUrl?: string;
   sessionOpenRouterConnected?: boolean;
+  sessionOpenAiCompatibleConnected?: boolean;
   needsSetup?: boolean;
   missing?: string[];
 }
@@ -135,6 +136,10 @@ interface OpenRouterDisconnectResponse {
   message: string;
 }
 
+interface OpenAiCompatibleConnectResponse extends OpenRouterConnectResponse {}
+
+interface OpenAiCompatibleDisconnectResponse extends OpenRouterDisconnectResponse {}
+
 interface ModelSwitchResponse {
   model: string;
   persistedToEnv?: boolean;
@@ -172,17 +177,35 @@ const openRouterConnectCloseBtn = document.getElementById("openrouter-connect-cl
 const openRouterConnectCancelBtn = document.getElementById("openrouter-connect-cancel") as HTMLButtonElement;
 const openRouterConnectContinueBtn = document.getElementById("openrouter-connect-continue") as HTMLButtonElement;
 const openRouterPersistCheckbox = document.getElementById("openrouter-persist-checkbox") as HTMLInputElement;
+const openAiCompatibleConnectModal = document.getElementById("openai-compatible-connect-modal")!;
+const openAiCompatibleConnectBackdrop = document.getElementById("openai-compatible-connect-backdrop")!;
+const openAiCompatibleConnectCloseBtn = document.getElementById("openai-compatible-connect-close") as HTMLButtonElement;
+const openAiCompatibleConnectCancelBtn = document.getElementById("openai-compatible-connect-cancel") as HTMLButtonElement;
+const openAiCompatibleConnectContinueBtn = document.getElementById("openai-compatible-connect-continue") as HTMLButtonElement;
+const openAiCompatiblePresetSelect = document.getElementById("openai-compatible-preset") as HTMLSelectElement;
+const openAiCompatiblePresetHelp = document.getElementById("openai-compatible-preset-help")!;
+const openAiCompatibleBaseUrlInput = document.getElementById("openai-compatible-base-url") as HTMLInputElement;
+const openAiCompatibleApiKeyInput = document.getElementById("openai-compatible-api-key") as HTMLInputElement;
+const openAiCompatiblePersistCheckbox = document.getElementById("openai-compatible-persist-checkbox") as HTMLInputElement;
+const openAiCompatibleConnectStatus = document.getElementById("openai-compatible-connect-status")!;
 const settingsPath = document.getElementById("settings-path")!;
 const settingsList = document.getElementById("settings-list")!;
 const settingsBanner = document.getElementById("settings-banner")!;
 const settingsOpenRouterSession = document.getElementById("settings-openrouter-session")!;
 const settingsOpenRouterSessionMeta = document.getElementById("settings-openrouter-session-meta")!;
+const settingsOpenAiCompatibleSession = document.getElementById("settings-openai-compatible-session")!;
+const settingsOpenAiCompatibleSessionMeta = document.getElementById("settings-openai-compatible-session-meta")!;
 const settingsSaveBtn = document.getElementById("settings-save") as HTMLButtonElement;
 const settingsResetBtn = document.getElementById("settings-reset") as HTMLButtonElement;
 const disconnectOpenRouterBtn = document.getElementById("disconnect-openrouter-btn") as HTMLButtonElement;
+const disconnectOpenAiCompatibleBtn = document.getElementById("disconnect-openai-compatible-btn") as HTMLButtonElement;
 const connectOpenRouterButtons = Array.from(
   document.querySelectorAll<HTMLButtonElement>("[data-openrouter-connect]"),
 );
+const connectOpenAiCompatibleButtons = Array.from(
+  document.querySelectorAll<HTMLButtonElement>("[data-openai-compatible-connect]"),
+);
+const configOverlayQuickConnects = document.getElementById("config-overlay-quick-connects");
 const configOverlaySpotlight = document.getElementById("config-overlay-spotlight");
 const configOverlayIntro = document.getElementById("config-overlay-intro");
 const configConnectStatus = document.getElementById("config-connect-status");
@@ -195,11 +218,40 @@ let settingsPayload: SettingsPayload | null = null;
 let activeSavedSession: SessionMeta | null = null;
 let activeBaseUrl = "";
 let sessionOpenRouterConnected = false;
+let sessionOpenAiCompatibleConnected = false;
 const sessionRefreshTracker = createLatestRequestTracker();
 
 const TOOL_RESULT_MAX = 500;
 const OPENROUTER_PKCE_VERIFIER_KEY = "minicode:openrouter:pkce-verifier";
 const OPENROUTER_PERSIST_TO_ENV_KEY = "minicode:openrouter:persist-to-env";
+type OpenAiCompatiblePreset = "lmstudio" | "openai" | "ollama" | "custom";
+
+const OPENAI_COMPATIBLE_PRESETS: Record<OpenAiCompatiblePreset, {
+  baseUrl: string;
+  helpText: string;
+  apiKeyPlaceholder: string;
+}> = {
+  lmstudio: {
+    baseUrl: "http://localhost:1234/v1",
+    helpText: "LM Studio pre-fills the default local server endpoint at http://localhost:1234/v1.",
+    apiKeyPlaceholder: "Leave blank for LM Studio unless local auth is enabled",
+  },
+  openai: {
+    baseUrl: "https://api.openai.com/v1",
+    helpText: "OpenAI uses https://api.openai.com/v1 and typically requires an API key.",
+    apiKeyPlaceholder: "Enter your OpenAI API key",
+  },
+  ollama: {
+    baseUrl: "http://localhost:11434/v1",
+    helpText: "Ollama pre-fills the default local server endpoint at http://localhost:11434/v1.",
+    apiKeyPlaceholder: "Leave blank for Ollama unless your proxy requires auth",
+  },
+  custom: {
+    baseUrl: "",
+    helpText: "Custom leaves the endpoint fully editable so you can point minicode at any OpenAI-compatible API.",
+    apiKeyPlaceholder: "Add an API key only if this endpoint requires auth",
+  },
+};
 
 function connect(): void {
   const protocol = location.protocol === "https:" ? "wss:" : "ws:";
@@ -255,6 +307,78 @@ function clearConfigConnectStatus(): void {
   }
   configConnectStatus.textContent = "";
   configConnectStatus.className = "config-connect-status hidden";
+}
+
+function setOpenAiCompatibleConnectStatus(message: string, tone: "info" | "success" | "error"): void {
+  openAiCompatibleConnectStatus.textContent = message;
+  openAiCompatibleConnectStatus.className = `config-connect-status ${tone}`;
+}
+
+function clearOpenAiCompatibleConnectStatus(): void {
+  openAiCompatibleConnectStatus.textContent = "";
+  openAiCompatibleConnectStatus.className = "config-connect-status hidden";
+}
+
+function normalizeBaseUrl(value: string): string {
+  return value.trim().replace(/\/+$/, "");
+}
+
+function isLikelyLocalOpenAiEndpoint(baseUrl: string): boolean {
+  if (!baseUrl.trim()) {
+    return false;
+  }
+
+  try {
+    const url = new URL(baseUrl);
+    return ["localhost", "127.0.0.1", "0.0.0.0"].includes(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function inferOpenAiCompatiblePreset(baseUrl: string): OpenAiCompatiblePreset {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl).toLowerCase();
+  if (normalizedBaseUrl === OPENAI_COMPATIBLE_PRESETS.lmstudio.baseUrl) {
+    return "lmstudio";
+  }
+  if (normalizedBaseUrl === OPENAI_COMPATIBLE_PRESETS.openai.baseUrl) {
+    return "openai";
+  }
+  if (normalizedBaseUrl === OPENAI_COMPATIBLE_PRESETS.ollama.baseUrl) {
+    return "ollama";
+  }
+  return "custom";
+}
+
+function applyOpenAiCompatiblePreset(
+  preset: OpenAiCompatiblePreset,
+  options: { preserveCustomValue?: boolean } = {},
+): void {
+  const presetConfig = OPENAI_COMPATIBLE_PRESETS[preset];
+  openAiCompatiblePresetHelp.textContent = presetConfig.helpText;
+  openAiCompatibleApiKeyInput.placeholder = presetConfig.apiKeyPlaceholder;
+
+  if (preset === "custom" && options.preserveCustomValue) {
+    return;
+  }
+
+  openAiCompatibleBaseUrlInput.value = presetConfig.baseUrl;
+}
+
+function isModalOpen(modal: HTMLElement): boolean {
+  return !modal.classList.contains("hidden");
+}
+
+function isSettingsModalOpen(): boolean {
+  return isModalOpen(settingsModal);
+}
+
+function isOpenRouterConnectModalOpen(): boolean {
+  return isModalOpen(openRouterConnectModal);
+}
+
+function isOpenAiCompatibleConnectModalOpen(): boolean {
+  return isModalOpen(openAiCompatibleConnectModal);
 }
 
 function encodeBase64Url(bytes: Uint8Array): string {
@@ -389,6 +513,90 @@ async function disconnectOpenRouter(): Promise<void> {
   }
 }
 
+async function connectOpenAiCompatible(): Promise<void> {
+  const baseUrl = normalizeBaseUrl(openAiCompatibleBaseUrlInput.value);
+  const apiKey = openAiCompatibleApiKeyInput.value.trim();
+
+  if (!baseUrl) {
+    setOpenAiCompatibleConnectStatus("Endpoint is required.", "error");
+    return;
+  }
+
+  clearOpenAiCompatibleConnectStatus();
+  clearSettingsBanner();
+  openAiCompatibleConnectContinueBtn.disabled = true;
+
+  try {
+    const res = await fetch("/api/openai-compatible/connect", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        baseUrl,
+        apiKey,
+        persistToEnv: openAiCompatiblePersistCheckbox.checked,
+      }),
+    });
+    const body = await res.json() as OpenAiCompatibleConnectResponse | { error: string };
+    if (!res.ok) {
+      throw new Error("error" in body ? body.error : `Failed to connect OpenAI-compatible provider (${res.status})`);
+    }
+
+    activeBaseUrl = body.baseUrl;
+    addMessage(body.message, "thinking");
+    const tone = body.persistWarning
+      ? "info"
+      : (body.needsSetup ? "info" : "success");
+    setConfigConnectStatus(body.message, tone);
+    setSettingsBanner(body.message, tone === "success" ? "success" : "info");
+    closeOpenAiCompatibleConnectModal();
+    await fetchStatus();
+    await refreshModelList();
+
+    const onlyModelMissing =
+      body.needsSetup &&
+      body.missing.length === 1 &&
+      body.missing[0]?.includes("MODEL");
+    if (onlyModelMissing) {
+      modelDropdown.classList.remove("hidden");
+      sessionDropdown.classList.add("hidden");
+      focusModelSearchInput();
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to connect OpenAI-compatible provider";
+    setOpenAiCompatibleConnectStatus(message, "error");
+  } finally {
+    openAiCompatibleConnectContinueBtn.disabled = false;
+  }
+}
+
+async function disconnectOpenAiCompatible(): Promise<void> {
+  disconnectOpenAiCompatibleBtn.disabled = true;
+  clearSettingsBanner();
+
+  try {
+    const res = await fetch("/api/openai-compatible/disconnect", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+    const body = await res.json() as OpenAiCompatibleDisconnectResponse | { error: string };
+    if (!res.ok) {
+      throw new Error("error" in body ? body.error : `Failed to disconnect OpenAI-compatible provider (${res.status})`);
+    }
+
+    activeBaseUrl = body.baseUrl;
+    addMessage(body.message, "thinking");
+    setSettingsBanner(body.message, body.disconnected ? "success" : "info");
+    clearConfigConnectStatus();
+    await fetchStatus();
+    await refreshModelList();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to disconnect OpenAI-compatible provider";
+    setSettingsBanner(message, "error");
+  } finally {
+    disconnectOpenAiCompatibleBtn.disabled = false;
+  }
+}
+
 async function fetchStatus(): Promise<void> {
   try {
     const res = await fetch("/api/status");
@@ -398,7 +606,8 @@ async function fetchStatus(): Promise<void> {
     activeModel = data.model;
     activeBaseUrl = data.baseUrl ?? "";
     sessionOpenRouterConnected = data.sessionOpenRouterConnected ?? false;
-    renderOpenRouterSessionControls();
+    sessionOpenAiCompatibleConnected = data.sessionOpenAiCompatibleConnected ?? false;
+    renderSessionProviderControls();
 
     if (data.needsSetup) {
       configOverlay.classList.remove("hidden");
@@ -409,11 +618,18 @@ async function fetchStatus(): Promise<void> {
       if (missingEl && data.missing && data.missing.length > 0) {
         const isOnlyModelMissing = data.missing.length === 1 && data.missing[0]!.includes("MODEL");
         const hasPersistedOpenRouter = isOnlyModelMissing && (data.baseUrl ?? "").includes("openrouter");
+        const hasPersistedOpenAiCompatible =
+          isOnlyModelMissing &&
+          !!(data.baseUrl ?? "").trim() &&
+          !(data.baseUrl ?? "").includes("openrouter");
         if (configOverlayIntro) {
           configOverlayIntro.textContent = hasPersistedOpenRouter
             ? "OpenRouter is already configured. Select a model to continue:"
-            : "minicode needs a model provider to run. Configure one of the following:";
+            : hasPersistedOpenAiCompatible
+              ? "An OpenAI-compatible provider is already configured. Select a model to continue:"
+              : "minicode needs a model provider to run. Configure one of the following:";
         }
+        configOverlayQuickConnects?.classList.toggle("hidden", hasPersistedOpenRouter || hasPersistedOpenAiCompatible);
         configOverlaySpotlight?.classList.toggle("hidden", hasPersistedOpenRouter);
         const hint = isOnlyModelMissing
           ? ` — select one from the <strong>model dropdown</strong> above, or set it in config`
@@ -433,6 +649,7 @@ async function fetchStatus(): Promise<void> {
       if (configOverlayIntro) {
         configOverlayIntro.textContent = "minicode needs a model provider to run. Configure one of the following:";
       }
+      configOverlayQuickConnects?.classList.remove("hidden");
       configOverlaySpotlight?.classList.remove("hidden");
     }
   } catch {
@@ -740,19 +957,37 @@ function clearSettingsBanner(): void {
   settingsBanner.className = "settings-banner hidden";
 }
 
-function renderOpenRouterSessionControls(): void {
+function renderSessionProviderControls(): void {
   if (sessionOpenRouterConnected) {
     settingsOpenRouterSession.classList.remove("hidden");
     settingsOpenRouterSessionMeta.textContent = activeBaseUrl
       ? `Endpoint: ${activeBaseUrl}. This session-only connection overrides your original provider settings until you disconnect or restart serve.`
       : "This session-only connection overrides your original provider settings until you disconnect or restart serve.";
+    settingsOpenAiCompatibleSession.classList.add("hidden");
+    settingsOpenAiCompatibleSessionMeta.textContent = "";
     disconnectOpenRouterBtn.disabled = false;
+    disconnectOpenAiCompatibleBtn.disabled = false;
+    return;
+  }
+
+  if (sessionOpenAiCompatibleConnected) {
+    settingsOpenAiCompatibleSession.classList.remove("hidden");
+    settingsOpenAiCompatibleSessionMeta.textContent = activeBaseUrl
+      ? `Endpoint: ${activeBaseUrl}. This session-only connection overrides your original provider settings until you disconnect or restart serve.`
+      : "This session-only connection overrides your original provider settings until you disconnect or restart serve.";
+    settingsOpenRouterSession.classList.add("hidden");
+    settingsOpenRouterSessionMeta.textContent = "";
+    disconnectOpenRouterBtn.disabled = false;
+    disconnectOpenAiCompatibleBtn.disabled = false;
     return;
   }
 
   settingsOpenRouterSession.classList.add("hidden");
   settingsOpenRouterSessionMeta.textContent = "";
+  settingsOpenAiCompatibleSession.classList.add("hidden");
+  settingsOpenAiCompatibleSessionMeta.textContent = "";
   disconnectOpenRouterBtn.disabled = false;
+  disconnectOpenAiCompatibleBtn.disabled = false;
 }
 
 function createSettingsControl(entry: SettingsEntry, inputId: string): HTMLElement {
@@ -1001,6 +1236,31 @@ function openOpenRouterConnectModal(): void {
 function closeOpenRouterConnectModal(): void {
   closeModal(openRouterConnectModal);
   openRouterConnectContinueBtn.disabled = false;
+}
+
+function openOpenAiCompatibleConnectModal(): void {
+  closeHeaderMenus();
+  openModal(openAiCompatibleConnectModal);
+  const preset = inferOpenAiCompatiblePreset(activeBaseUrl);
+  openAiCompatiblePresetSelect.value = preset;
+  openAiCompatibleBaseUrlInput.value = preset === "custom"
+    ? activeBaseUrl
+    : OPENAI_COMPATIBLE_PRESETS[preset].baseUrl;
+  openAiCompatibleApiKeyInput.value = "";
+  openAiCompatiblePersistCheckbox.checked = false;
+  openAiCompatibleConnectContinueBtn.disabled = false;
+  applyOpenAiCompatiblePreset(preset, { preserveCustomValue: preset === "custom" });
+  clearOpenAiCompatibleConnectStatus();
+  requestAnimationFrame(() => {
+    openAiCompatibleBaseUrlInput.focus();
+    openAiCompatibleBaseUrlInput.select();
+  });
+}
+
+function closeOpenAiCompatibleConnectModal(): void {
+  closeModal(openAiCompatibleConnectModal);
+  openAiCompatibleConnectContinueBtn.disabled = false;
+  clearOpenAiCompatibleConnectStatus();
 }
 
 // Form handling
@@ -1375,10 +1635,22 @@ openRouterConnectCancelBtn.addEventListener("click", () => {
   closeOpenRouterConnectModal();
 });
 
+openAiCompatibleConnectBackdrop.addEventListener("click", () => {
+  closeOpenAiCompatibleConnectModal();
+});
+
+openAiCompatibleConnectCloseBtn.addEventListener("click", () => {
+  closeOpenAiCompatibleConnectModal();
+});
+
+openAiCompatibleConnectCancelBtn.addEventListener("click", () => {
+  closeOpenAiCompatibleConnectModal();
+});
+
 settingsResetBtn.addEventListener("click", () => {
   clearSettingsBanner();
   renderSettings();
-  renderOpenRouterSessionControls();
+  renderSessionProviderControls();
 });
 
 settingsSaveBtn.addEventListener("click", async () => {
@@ -1440,12 +1712,20 @@ disconnectOpenRouterBtn.addEventListener("click", () => {
   void disconnectOpenRouter();
 });
 
+disconnectOpenAiCompatibleBtn.addEventListener("click", () => {
+  void disconnectOpenAiCompatible();
+});
+
 document.addEventListener("keydown", (event: KeyboardEvent) => {
   if (event.key !== "Escape") {
     return;
   }
   if (isOpenRouterConnectModalOpen()) {
     closeOpenRouterConnectModal();
+    return;
+  }
+  if (isOpenAiCompatibleConnectModalOpen()) {
+    closeOpenAiCompatibleConnectModal();
     return;
   }
   if (isSettingsModalOpen()) {
@@ -1459,10 +1739,33 @@ for (const button of connectOpenRouterButtons) {
   });
 }
 
+for (const button of connectOpenAiCompatibleButtons) {
+  button.addEventListener("click", () => {
+    openOpenAiCompatibleConnectModal();
+  });
+}
+
+openAiCompatiblePresetSelect.addEventListener("change", () => {
+  applyOpenAiCompatiblePreset(openAiCompatiblePresetSelect.value as OpenAiCompatiblePreset);
+  clearOpenAiCompatibleConnectStatus();
+});
+
+openAiCompatibleBaseUrlInput.addEventListener("input", () => {
+  clearOpenAiCompatibleConnectStatus();
+});
+
+openAiCompatibleApiKeyInput.addEventListener("input", () => {
+  clearOpenAiCompatibleConnectStatus();
+});
+
 openRouterConnectContinueBtn.addEventListener("click", () => {
   openRouterConnectContinueBtn.disabled = true;
   closeOpenRouterConnectModal();
   void startOpenRouterConnect(openRouterPersistCheckbox.checked);
+});
+
+openAiCompatibleConnectContinueBtn.addEventListener("click", () => {
+  void connectOpenAiCompatible();
 });
 
 // -- Resizable pane divider --

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -20,6 +20,7 @@ interface StatusResponse {
   model: string;
   provider: string;
   baseUrl?: string;
+  configuredProvider?: "anthropic" | "openrouter" | "openai-compatible" | null;
   sessionOpenRouterConnected?: boolean;
   sessionOpenAiCompatibleConnected?: boolean;
   needsSetup?: boolean;
@@ -617,21 +618,25 @@ async function fetchStatus(): Promise<void> {
       const missingEl = document.getElementById("config-missing");
       if (missingEl && data.missing && data.missing.length > 0) {
         const isOnlyModelMissing = data.missing.length === 1 && data.missing[0]!.includes("MODEL");
-        const hasPersistedOpenRouter = isOnlyModelMissing && (data.baseUrl ?? "").includes("openrouter");
+        const configuredProvider = data.configuredProvider ?? null;
+        const hasConfiguredProvider = isOnlyModelMissing && configuredProvider !== null;
+        const hasPersistedOpenRouter = isOnlyModelMissing && configuredProvider === "openrouter";
         const hasPersistedOpenAiCompatible =
           isOnlyModelMissing &&
-          !!(data.baseUrl ?? "").trim() &&
-          !(data.baseUrl ?? "").includes("openrouter");
+          configuredProvider === "openai-compatible";
+        const hasPersistedAnthropic = isOnlyModelMissing && configuredProvider === "anthropic";
         if (configOverlayIntro) {
           configOverlayIntro.textContent = hasPersistedOpenRouter
             ? "OpenRouter is already configured. Select a model to continue:"
             : hasPersistedOpenAiCompatible
               ? "An OpenAI-compatible provider is already configured. Select a model to continue:"
+              : hasPersistedAnthropic
+                ? "Anthropic is already configured. Select a model to continue:"
               : "minicode needs a model provider to run. Configure one of the following:";
         }
-        configOverlayQuickConnects?.classList.toggle("hidden", hasPersistedOpenRouter || hasPersistedOpenAiCompatible);
+        configOverlayQuickConnects?.classList.toggle("hidden", hasConfiguredProvider);
         configOverlaySpotlight?.classList.toggle("hidden", hasPersistedOpenRouter);
-        const hint = isOnlyModelMissing
+        const hint = hasConfiguredProvider
           ? ` — select one from the <strong>model dropdown</strong> above, or set it in config`
           : "";
         missingEl.innerHTML = `<strong>Missing:</strong> ${data.missing.map(escapeHtml).join(", ")}${hint}`;

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -2,6 +2,7 @@ import { initGraph, highlightAgentActivity, resizeGraph } from './graph.ts';
 import { closeModal, openModal } from './modal-state.ts';
 import { filterModelsByQuery, getModelDisplayName } from '../model-utils.ts';
 import { createLatestRequestTracker } from './request-tracker.ts';
+import { DEFAULT_SETUP_INTRO, deriveSetupOverlayState } from './setup-overlay-state.ts';
 import { escapeHtml, renderMarkdownInto } from './utils.ts';
 
 interface ServerMessage {
@@ -616,31 +617,27 @@ async function fetchStatus(): Promise<void> {
       sendBtn.disabled = true;
       // Show specific missing items
       const missingEl = document.getElementById("config-missing");
-      if (missingEl && data.missing && data.missing.length > 0) {
-        const isOnlyModelMissing = data.missing.length === 1 && data.missing[0]!.includes("MODEL");
-        const configuredProvider = data.configuredProvider ?? null;
-        const hasConfiguredProvider = isOnlyModelMissing && configuredProvider !== null;
-        const hasPersistedOpenRouter = isOnlyModelMissing && configuredProvider === "openrouter";
-        const hasPersistedOpenAiCompatible =
-          isOnlyModelMissing &&
-          configuredProvider === "openai-compatible";
-        const hasPersistedAnthropic = isOnlyModelMissing && configuredProvider === "anthropic";
-        if (configOverlayIntro) {
-          configOverlayIntro.textContent = hasPersistedOpenRouter
-            ? "OpenRouter is already configured. Select a model to continue:"
-            : hasPersistedOpenAiCompatible
-              ? "An OpenAI-compatible provider is already configured. Select a model to continue:"
-              : hasPersistedAnthropic
-                ? "Anthropic is already configured. Select a model to continue:"
-              : "minicode needs a model provider to run. Configure one of the following:";
+      const overlayState = deriveSetupOverlayState({
+        configuredProvider: data.configuredProvider ?? null,
+        missing: data.missing ?? [],
+      });
+      if (configOverlayIntro) {
+        configOverlayIntro.textContent = overlayState.introText;
+      }
+      configOverlayQuickConnects?.classList.toggle("hidden", overlayState.hideQuickConnects);
+      configOverlaySpotlight?.classList.toggle("hidden", overlayState.hideOpenRouterSpotlight);
+      if (missingEl) {
+        if (overlayState.missingItems.length > 0) {
+          const hint = overlayState.showModelSelectionHint
+            ? ` — select one from the <strong>model dropdown</strong> above, or set it in config`
+            : "";
+          missingEl.innerHTML =
+            `<strong>Missing:</strong> ${overlayState.missingItems.map(escapeHtml).join(", ")}${hint}`;
+          missingEl.classList.remove("hidden");
+        } else {
+          missingEl.classList.add("hidden");
+          missingEl.innerHTML = "";
         }
-        configOverlayQuickConnects?.classList.toggle("hidden", hasConfiguredProvider);
-        configOverlaySpotlight?.classList.toggle("hidden", hasPersistedOpenRouter);
-        const hint = hasConfiguredProvider
-          ? ` — select one from the <strong>model dropdown</strong> above, or set it in config`
-          : "";
-        missingEl.innerHTML = `<strong>Missing:</strong> ${data.missing.map(escapeHtml).join(", ")}${hint}`;
-        missingEl.classList.remove("hidden");
       }
     } else {
       configOverlay.classList.add("hidden");
@@ -652,7 +649,7 @@ async function fetchStatus(): Promise<void> {
         missingEl.innerHTML = "";
       }
       if (configOverlayIntro) {
-        configOverlayIntro.textContent = "minicode needs a model provider to run. Configure one of the following:";
+        configOverlayIntro.textContent = DEFAULT_SETUP_INTRO;
       }
       configOverlayQuickConnects?.classList.remove("hidden");
       configOverlaySpotlight?.classList.remove("hidden");

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -631,8 +631,11 @@ async function fetchStatus(): Promise<void> {
           const hint = overlayState.showModelSelectionHint
             ? ` — select one from the <strong>model dropdown</strong> above, or set it in config`
             : "";
+          const note = overlayState.modelSelectionNote
+            ? ` ${escapeHtml(overlayState.modelSelectionNote)}`
+            : "";
           missingEl.innerHTML =
-            `<strong>Missing:</strong> ${overlayState.missingItems.map(escapeHtml).join(", ")}${hint}`;
+            `<strong>Missing:</strong> ${overlayState.missingItems.map(escapeHtml).join(", ")}${hint}${note}`;
           missingEl.classList.remove("hidden");
         } else {
           missingEl.classList.add("hidden");

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -65,15 +65,29 @@
           <div class="config-overlay-content">
             <h2>Agent not connected</h2>
             <p id="config-missing" class="config-missing hidden"></p>
-            <div id="config-overlay-spotlight" class="config-overlay-spotlight">
-              <div class="config-overlay-spotlight-copy">
-                <span class="config-overlay-spotlight-badge">Fastest way to start</span>
-                <strong>Try minicode for free with OpenRouter</strong>
-                <p>Create a free OpenRouter account, connect it to this <code>minicode serve</code> session, and use free models without editing config files first.</p>
+            <div id="config-overlay-quick-connects" class="config-overlay-shortcuts">
+              <div id="config-overlay-spotlight" class="config-overlay-spotlight">
+                <div class="config-overlay-spotlight-copy">
+                  <span class="config-overlay-spotlight-badge">Fastest way to start</span>
+                  <strong>Try minicode for free with OpenRouter</strong>
+                  <p>Create a free OpenRouter account, connect it to this <code>minicode serve</code> session, and use free models without editing config files first.</p>
+                </div>
+                <div class="config-overlay-actions config-overlay-spotlight-actions">
+                  <button id="connect-openrouter-btn" class="dropdown-action" type="button" data-openrouter-connect="true">Connect OpenRouter</button>
+                  <span class="config-overlay-action-note">Session-only. Nothing is written to disk.</span>
+                </div>
               </div>
-              <div class="config-overlay-actions config-overlay-spotlight-actions">
-                <button id="connect-openrouter-btn" class="dropdown-action" type="button" data-openrouter-connect="true">Connect OpenRouter</button>
-                <span class="config-overlay-action-note">Session-only. Nothing is written to disk.</span>
+
+              <div id="config-overlay-openai-compatible" class="config-overlay-spotlight config-overlay-spotlight-secondary">
+                <div class="config-overlay-spotlight-copy">
+                  <span class="config-overlay-spotlight-badge">Local quick connect</span>
+                  <strong>Connect OpenAI-compatible</strong>
+                  <p>Choose a preset like LM Studio, OpenAI, Ollama, or Custom, then adjust the endpoint if needed before connecting this <code>minicode serve</code> session.</p>
+                </div>
+                <div class="config-overlay-actions config-overlay-spotlight-actions">
+                  <button id="connect-openai-compatible-btn" class="dropdown-action" type="button" data-openai-compatible-connect="true">Connect OpenAI-compatible</button>
+                  <span class="config-overlay-action-note">Starts with common presets, but the endpoint stays editable.</span>
+                </div>
               </div>
             </div>
             <p id="config-overlay-intro">minicode needs a model provider to run. Configure one of the following:</p>
@@ -180,6 +194,23 @@ MODEL=your-model-name</pre>
         </div>
         <button id="disconnect-openrouter-btn" class="header-btn" type="button">Disconnect OpenRouter</button>
       </div>
+      <div id="settings-openai-compatible-session" class="settings-session-banner hidden" role="status" aria-live="polite">
+        <div class="settings-session-copy">
+          <div class="settings-session-title">OpenAI-compatible provider is connected for this serve session</div>
+          <div id="settings-openai-compatible-session-meta" class="settings-session-meta"></div>
+        </div>
+        <button id="disconnect-openai-compatible-btn" class="header-btn" type="button">Disconnect OpenAI-compatible</button>
+      </div>
+      <div class="settings-provider-shortcuts">
+        <div class="settings-provider-shortcuts-copy">
+          <div class="settings-session-title">Quick connect</div>
+          <div class="settings-session-meta">Temporarily connect a provider for this serve session, or optionally save it to <code>~/.minicode/.env</code>.</div>
+        </div>
+        <div class="settings-provider-shortcuts-actions">
+          <button class="header-btn" type="button" data-openrouter-connect="true">Connect OpenRouter</button>
+          <button class="header-btn" type="button" data-openai-compatible-connect="true">Connect OpenAI-compatible</button>
+        </div>
+      </div>
       <div id="settings-list" class="settings-list">
         <div class="dropdown-empty">Loading settings...</div>
       </div>
@@ -234,6 +265,75 @@ MODEL=your-model-name</pre>
         <div class="settings-actions">
           <button id="openrouter-connect-cancel" class="header-btn" type="button">Cancel</button>
           <button id="openrouter-connect-continue" class="dropdown-action" type="button">Continue</button>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <div id="openai-compatible-connect-modal" class="modal hidden" aria-hidden="true">
+    <div id="openai-compatible-connect-backdrop" class="modal-backdrop"></div>
+    <section class="modal-panel modal-panel-compact" role="dialog" aria-modal="true" aria-labelledby="openai-compatible-connect-title">
+      <div class="modal-header">
+        <div>
+          <h2 id="openai-compatible-connect-title">Connect OpenAI-compatible</h2>
+          <p class="modal-subtitle">Configure an OpenAI-compatible endpoint for this <code>minicode serve</code> session and optionally save it for future runs.</p>
+        </div>
+        <button id="openai-compatible-connect-close" class="header-btn" type="button">Close</button>
+      </div>
+
+      <div class="openrouter-connect-body">
+        <p class="openrouter-connect-lead">
+          Pick a preset to prefill a common endpoint, then adjust it if needed. minicode will point this serve session at the OpenAI-compatible API endpoint you provide.
+        </p>
+
+        <div class="openrouter-connect-note">
+          <strong>Connection details</strong>
+          <p>Local runtimes like LM Studio or Ollama usually work without an API key, while hosted providers like OpenAI typically require one. The endpoint stays editable no matter which preset you choose.</p>
+        </div>
+
+        <label class="provider-input-group" for="openai-compatible-preset">
+          <span class="provider-input-label">Preset</span>
+          <select id="openai-compatible-preset" class="provider-input">
+            <option value="lmstudio">LM Studio</option>
+            <option value="openai">OpenAI</option>
+            <option value="ollama">Ollama</option>
+            <option value="custom">Custom</option>
+          </select>
+        </label>
+
+        <p id="openai-compatible-preset-help" class="openrouter-connect-help">
+          LM Studio pre-fills the default local server endpoint at <code>http://localhost:1234/v1</code>.
+        </p>
+
+        <label class="provider-input-group" for="openai-compatible-base-url">
+          <span class="provider-input-label">Endpoint</span>
+          <input id="openai-compatible-base-url" class="provider-input" type="text" value="http://localhost:1234/v1" spellcheck="false" autocomplete="off" />
+        </label>
+
+        <label class="provider-input-group" for="openai-compatible-api-key">
+          <span class="provider-input-label">API key (optional)</span>
+          <input id="openai-compatible-api-key" class="provider-input" type="password" placeholder="Leave blank for local providers that do not require auth" spellcheck="false" autocomplete="off" />
+        </label>
+
+        <label class="openrouter-persist-toggle" for="openai-compatible-persist-checkbox">
+          <input id="openai-compatible-persist-checkbox" type="checkbox" />
+          <span>Save the OpenAI-compatible provider defaults to <code>~/.minicode/.env</code> after connecting.</span>
+        </label>
+
+        <p class="openrouter-connect-help">
+          When enabled, minicode will update <code>MODEL_PROVIDER</code> and <code>OPENAI_BASE_URL</code>, and it will also write <code>OPENAI_API_KEY</code> if you provide one. Nothing is written unless you check the box.
+        </p>
+
+        <p id="openai-compatible-connect-status" class="config-connect-status hidden"></p>
+      </div>
+
+      <div class="modal-footer">
+        <p class="settings-footnote">
+          This uses the same OpenAI-compatible runtime path minicode already uses for local and hosted providers.
+        </p>
+        <div class="settings-actions">
+          <button id="openai-compatible-connect-cancel" class="header-btn" type="button">Cancel</button>
+          <button id="openai-compatible-connect-continue" class="dropdown-action" type="button">Continue</button>
         </div>
       </div>
     </section>

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -74,7 +74,6 @@
                 </div>
                 <div class="config-overlay-actions config-overlay-spotlight-actions">
                   <button id="connect-openrouter-btn" class="dropdown-action" type="button" data-openrouter-connect="true">Connect OpenRouter</button>
-                  <span class="config-overlay-action-note">Session-only. Nothing is written to disk.</span>
                 </div>
               </div>
 

--- a/src/web/setup-overlay-state.ts
+++ b/src/web/setup-overlay-state.ts
@@ -11,6 +11,7 @@ export interface SetupOverlayState {
   hideOpenRouterSpotlight: boolean;
   missingItems: string[];
   showModelSelectionHint: boolean;
+  modelSelectionNote: string | null;
 }
 
 export const DEFAULT_SETUP_INTRO =
@@ -43,5 +44,8 @@ export function deriveSetupOverlayState(input: SetupOverlayStateInput): SetupOve
     hideOpenRouterSpotlight: configuredProvider === "openrouter" && isOnlyModelMissing,
     missingItems: filteredMissingItems,
     showModelSelectionHint: hasConfiguredProvider,
+    modelSelectionNote: configuredProvider === "openrouter" && isOnlyModelMissing
+      ? 'If you are on the OpenRouter free tier, search "free" in the model dropdown to find supported free models.'
+      : null,
   };
 }

--- a/src/web/setup-overlay-state.ts
+++ b/src/web/setup-overlay-state.ts
@@ -1,0 +1,47 @@
+export type ConfiguredProvider = "anthropic" | "openrouter" | "openai-compatible" | null;
+
+export interface SetupOverlayStateInput {
+  configuredProvider?: ConfiguredProvider;
+  missing?: string[];
+}
+
+export interface SetupOverlayState {
+  introText: string;
+  hideQuickConnects: boolean;
+  hideOpenRouterSpotlight: boolean;
+  missingItems: string[];
+  showModelSelectionHint: boolean;
+}
+
+export const DEFAULT_SETUP_INTRO =
+  "minicode needs a model provider to run. Configure one of the following:";
+
+export function deriveSetupOverlayState(input: SetupOverlayStateInput): SetupOverlayState {
+  const missingItems = input.missing ?? [];
+  const configuredProvider = input.configuredProvider ?? null;
+  const isOnlyModelMissing =
+    missingItems.length === 1 &&
+    typeof missingItems[0] === "string" &&
+    missingItems[0].includes("MODEL");
+  const hasConfiguredProvider = isOnlyModelMissing && configuredProvider !== null;
+
+  const filteredMissingItems = hasConfiguredProvider
+    ? missingItems
+    : missingItems.filter((item) => !item.includes("MODEL"));
+
+  const introText = configuredProvider === "openrouter" && isOnlyModelMissing
+    ? "OpenRouter is already configured. Select a model to continue:"
+    : configuredProvider === "openai-compatible" && isOnlyModelMissing
+      ? "An OpenAI-compatible provider is already configured. Select a model to continue:"
+      : configuredProvider === "anthropic" && isOnlyModelMissing
+        ? "Anthropic is already configured. Select a model to continue:"
+        : DEFAULT_SETUP_INTRO;
+
+  return {
+    introText,
+    hideQuickConnects: hasConfiguredProvider,
+    hideOpenRouterSpotlight: configuredProvider === "openrouter" && isOnlyModelMissing,
+    missingItems: filteredMissingItems,
+    showModelSelectionHint: hasConfiguredProvider,
+  };
+}

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -422,11 +422,17 @@ h1 {
   margin-bottom: 16px;
 }
 
-.config-overlay-spotlight {
+.config-overlay-shortcuts {
   display: flex;
   flex-direction: column;
   gap: 12px;
   margin-bottom: 16px;
+}
+
+.config-overlay-spotlight {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
   padding: 14px 16px;
   border-radius: 8px;
   border: 1px solid rgba(122, 162, 247, 0.35);
@@ -434,6 +440,13 @@ h1 {
     linear-gradient(135deg, rgba(122, 162, 247, 0.18), rgba(158, 206, 106, 0.08)),
     var(--bg-surface);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+.config-overlay-spotlight-secondary {
+  border-color: rgba(158, 206, 106, 0.24);
+  background:
+    linear-gradient(135deg, rgba(158, 206, 106, 0.14), rgba(122, 162, 247, 0.06)),
+    var(--bg-surface);
 }
 
 .config-overlay-spotlight-copy {
@@ -1247,6 +1260,31 @@ footer {
   flex-shrink: 0;
 }
 
+.settings-provider-shortcuts {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+  padding: 14px 16px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: rgba(26, 27, 38, 0.72);
+}
+
+.settings-provider-shortcuts-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.settings-provider-shortcuts-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 .openrouter-connect-body {
   padding: 20px;
   display: flex;
@@ -1299,10 +1337,47 @@ footer {
   color: var(--text);
 }
 
+.provider-input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.provider-input-label {
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.provider-input {
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 9px 10px;
+}
+
+.provider-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
 @media (max-width: 760px) {
   .settings-session-banner {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .settings-provider-shortcuts {
+    flex-direction: column;
+  }
+
+  .settings-provider-shortcuts-actions {
+    width: 100%;
+    justify-content: flex-start;
   }
 }
 

--- a/tests/config-integration.test.ts
+++ b/tests/config-integration.test.ts
@@ -17,6 +17,7 @@ import {
   loadAgentConfig,
   resolveConfigEnv,
   getConfigSetupMessage,
+  getConfiguredProvider,
   getConfigMissing,
 } from "../src/agent/config.js";
 import { buildStructuredConfigPayload } from "../src/agent/editable-config.js";
@@ -750,6 +751,52 @@ describe("/api/status needsSetup", () => {
     assert.equal(body.model, "my-test-model");
     assert.equal(body.provider, "openai-compatible");
   });
+
+  test("status endpoint reports no configured provider for a fresh install using defaults", async () => {
+    const baseDir = await mkdtemp(path.join(os.tmpdir(), "minicode-integ-"));
+    tempDirs.push(baseDir);
+    const minicodeHome = path.join(baseDir, "new-home");
+    const config = {
+      ...createTestAgentConfig("/tmp"),
+      modelProvider: "openai-compatible" as const,
+      model: "",
+      openAiBaseUrl: "http://localhost:1234/v1",
+    };
+    const bridge = new ConfigurableBridge(config);
+    const base = await startServer(bridge, { minicodeHome });
+
+    const res = await fetch(`${base}/api/status`);
+    const body = await res.json() as {
+      configuredProvider: "anthropic" | "openrouter" | "openai-compatible" | null;
+      needsSetup: boolean;
+      missing: string[];
+    };
+    assert.equal(body.configuredProvider, null);
+    assert.equal(body.needsSetup, true);
+    assert.ok(body.missing.some((m: string) => m.includes("MODEL")));
+  });
+
+  test("status endpoint reports openai-compatible when localhost is explicitly configured", async () => {
+    const minicodeHome = await createTestHome({
+      config: {
+        modelProvider: "openai-compatible",
+        openAiBaseUrl: "http://localhost:1234/v1",
+      },
+    });
+    const config = await loadAgentConfig("/tmp", { minicodeHome });
+    const bridge = new ConfigurableBridge(config);
+    const base = await startServer(bridge, { minicodeHome });
+
+    const res = await fetch(`${base}/api/status`);
+    const body = await res.json() as {
+      configuredProvider: "anthropic" | "openrouter" | "openai-compatible" | null;
+      needsSetup: boolean;
+      missing: string[];
+    };
+    assert.equal(body.configuredProvider, "openai-compatible");
+    assert.equal(body.needsSetup, true);
+    assert.ok(body.missing.some((m: string) => m.includes("MODEL")));
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════
@@ -965,6 +1012,68 @@ describe("realistic user scenarios", () => {
       assert.equal(config.model, "");
       const missing = getConfigMissing(config);
       assert.ok(missing.length > 0);
+    });
+  });
+});
+
+describe("getConfiguredProvider", () => {
+  test("returns null for a fresh install using only fallback localhost defaults", async () => {
+    const base = await mkdtemp(path.join(os.tmpdir(), "minicode-integ-"));
+    tempDirs.push(base);
+    const minicodeHome = path.join(base, "new-home");
+
+    await withEnv({
+      MODEL: undefined,
+      MODEL_PROVIDER: undefined,
+      OPENAI_BASE_URL: undefined,
+      OPENAI_API_KEY: undefined,
+      OPENROUTER_API_KEY: undefined,
+      ANTHROPIC_API_KEY: undefined,
+    }, async () => {
+      const config = await loadAgentConfig("/tmp", { minicodeHome });
+      const resolvedEnv = await resolveConfigEnv({ minicodeHome });
+      assert.equal(getConfiguredProvider(config, resolvedEnv.values), null);
+    });
+  });
+
+  test("returns openrouter when OpenRouter is explicitly configured", async () => {
+    const home = await createTestHome({
+      config: {
+        modelProvider: "openai-compatible",
+        openAiBaseUrl: "https://openrouter.ai/api/v1",
+      },
+      dotenv: "OPENROUTER_API_KEY=sk-or-test-key\n",
+    });
+
+    await withEnv({
+      MODEL_PROVIDER: undefined,
+      OPENAI_BASE_URL: undefined,
+      OPENAI_API_KEY: undefined,
+      OPENROUTER_API_KEY: undefined,
+    }, async () => {
+      const config = await loadAgentConfig("/tmp", { minicodeHome: home });
+      const resolvedEnv = await resolveConfigEnv({ minicodeHome: home });
+      assert.equal(getConfiguredProvider(config, resolvedEnv.values), "openrouter");
+    });
+  });
+
+  test("returns openai-compatible when a local endpoint is explicitly configured", async () => {
+    const home = await createTestHome({
+      config: {
+        modelProvider: "openai-compatible",
+        openAiBaseUrl: "http://localhost:1234/v1",
+      },
+    });
+
+    await withEnv({
+      MODEL_PROVIDER: undefined,
+      OPENAI_BASE_URL: undefined,
+      OPENAI_API_KEY: undefined,
+      OPENROUTER_API_KEY: undefined,
+    }, async () => {
+      const config = await loadAgentConfig("/tmp", { minicodeHome: home });
+      const resolvedEnv = await resolveConfigEnv({ minicodeHome: home });
+      assert.equal(getConfiguredProvider(config, resolvedEnv.values), "openai-compatible");
     });
   });
 });

--- a/tests/serve.integration.test.ts
+++ b/tests/serve.integration.test.ts
@@ -25,6 +25,8 @@ class MockBridge extends AgentBridge {
   turnHistory: string[] = [];
   openRouterKey: string | undefined;
   openRouterSessionActive = false;
+  openAiCompatibleApiKey: string | undefined;
+  openAiCompatibleSessionActive = false;
 
   constructor() {
     super(() => {}, false);
@@ -104,9 +106,25 @@ class MockBridge extends AgentBridge {
   override connectOpenRouter(apiKey: string): void {
     this.openRouterKey = apiKey;
     this.openRouterSessionActive = true;
+    this.openAiCompatibleApiKey = undefined;
+    this.openAiCompatibleSessionActive = false;
     this._config.modelProvider = "openai-compatible";
     this._config.openAiBaseUrl = "https://openrouter.ai/api/v1";
     this._config.openAiApiKey = apiKey;
+  }
+
+  override connectOpenAiCompatible(baseUrl: string, apiKey?: string): void {
+    this.openAiCompatibleSessionActive = true;
+    this.openRouterKey = undefined;
+    this.openRouterSessionActive = false;
+    this.openAiCompatibleApiKey = apiKey?.trim() || undefined;
+    this._config.modelProvider = "openai-compatible";
+    this._config.openAiBaseUrl = baseUrl.trim().replace(/\/+$/, "");
+    if (this.openAiCompatibleApiKey) {
+      this._config.openAiApiKey = this.openAiCompatibleApiKey;
+    } else {
+      delete this._config.openAiApiKey;
+    }
   }
 
   override disconnectOpenRouter(): boolean {
@@ -125,6 +143,24 @@ class MockBridge extends AgentBridge {
 
   override isOpenRouterSessionConnected(): boolean {
     return this.openRouterSessionActive;
+  }
+
+  override disconnectOpenAiCompatible(): boolean {
+    if (!this.openAiCompatibleSessionActive) {
+      return false;
+    }
+
+    this.openAiCompatibleSessionActive = false;
+    this.openAiCompatibleApiKey = undefined;
+    this._config.modelProvider = this._baseConfig.modelProvider;
+    this._config.model = this._baseConfig.model;
+    this._config.openAiBaseUrl = this._baseConfig.openAiBaseUrl;
+    delete this._config.openAiApiKey;
+    return true;
+  }
+
+  override isOpenAiCompatibleSessionConnected(): boolean {
+    return this.openAiCompatibleSessionActive;
   }
 
   override switchModel(modelId: string): void {
@@ -819,6 +855,131 @@ test("GET /api/status exposes OpenRouter session state and base URL", async () =
   assert.equal(body.sessionOpenRouterConnected, true);
 });
 
+test("POST /api/openai-compatible/connect stores a session-only endpoint", async () => {
+  const bridge = new MockBridge();
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/openai-compatible/connect`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ baseUrl: "http://localhost:1234/v1/", apiKey: "local-key" }),
+  });
+  assert.equal(res.status, 200);
+
+  const body = await res.json() as {
+    ok: boolean;
+    sessionOnly: boolean;
+    persistedToEnv: boolean;
+    persistedEnvPath: string | null;
+    persistWarning: string | null;
+    baseUrl: string;
+    needsSetup: boolean;
+    missing: string[];
+    message: string;
+  };
+  assert.equal(body.ok, true);
+  assert.equal(body.sessionOnly, true);
+  assert.equal(body.persistedToEnv, false);
+  assert.equal(body.persistedEnvPath, null);
+  assert.equal(body.persistWarning, null);
+  assert.equal(body.baseUrl, "http://localhost:1234/v1");
+  assert.equal(body.needsSetup, false);
+  assert.deepEqual(body.missing, []);
+  assert.equal(body.message, "The OpenAI-compatible provider connected for this serve session.");
+  assert.equal(bridge.getConfig().modelProvider, "openai-compatible");
+  assert.equal(bridge.getConfig().openAiBaseUrl, "http://localhost:1234/v1");
+  assert.equal(bridge.getConfig().openAiApiKey, "local-key");
+  assert.equal(bridge.isOpenAiCompatibleSessionConnected(), true);
+});
+
+test("POST /api/openai-compatible/connect can persist the endpoint to ~/.minicode/.env", async () => {
+  const bridge = new MockBridge();
+  const minicodeHome = mkdtempSync(path.join(os.tmpdir(), "minicode-openai-compatible-home-"));
+  const base = await startTestServer(bridge, { minicodeHome });
+
+  try {
+    const res = await fetch(`${base}/api/openai-compatible/connect`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        baseUrl: "http://127.0.0.1:1234/v1",
+        apiKey: "",
+        persistToEnv: true,
+      }),
+    });
+    assert.equal(res.status, 200);
+
+    const body = await res.json() as {
+      persistedToEnv: boolean;
+      persistedEnvPath: string | null;
+      persistWarning: string | null;
+      message: string;
+    };
+    assert.equal(body.persistedToEnv, true);
+    assert.equal(body.persistWarning, null);
+    assert.equal(body.persistedEnvPath, path.join(minicodeHome, ".env"));
+    assert.match(body.message, /saved to ~\/\.minicode\/\.env/);
+
+    const envContents = readFileSync(path.join(minicodeHome, ".env"), "utf8");
+    assert.match(envContents, /^MODEL_PROVIDER=openai-compatible$/m);
+    assert.match(envContents, /^OPENAI_BASE_URL=http:\/\/127\.0\.0\.1:1234\/v1$/m);
+    assert.doesNotMatch(envContents, /^OPENAI_API_KEY=/m);
+  } finally {
+    rmSync(minicodeHome, { recursive: true, force: true });
+  }
+});
+
+test("POST /api/openai-compatible/disconnect removes the session-only endpoint", async () => {
+  const bridge = new MockBridge();
+  bridge.connectOpenAiCompatible("http://localhost:1234/v1", "local-key");
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/openai-compatible/disconnect`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
+  assert.equal(res.status, 200);
+
+  const body = await res.json() as {
+    ok: boolean;
+    disconnected: boolean;
+    sessionOnly: boolean;
+    baseUrl: string;
+    provider: string;
+    message: string;
+  };
+  assert.equal(body.ok, true);
+  assert.equal(body.disconnected, true);
+  assert.equal(body.sessionOnly, true);
+  assert.equal(body.provider, "anthropic");
+  assert.equal(body.baseUrl, "http://localhost:1234/v1");
+  assert.equal(
+    body.message,
+    "Removed the session-only OpenAI-compatible connection and restored your original provider settings.",
+  );
+  assert.equal(bridge.isOpenAiCompatibleSessionConnected(), false);
+  assert.equal(bridge.getConfig().modelProvider, "anthropic");
+  assert.equal(bridge.getConfig().openAiApiKey, undefined);
+});
+
+test("GET /api/status exposes OpenAI-compatible session state and base URL", async () => {
+  const bridge = new MockBridge();
+  bridge.connectOpenAiCompatible("http://localhost:1234/v1");
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/status`);
+  assert.equal(res.status, 200);
+
+  const body = await res.json() as {
+    baseUrl: string;
+    sessionOpenAiCompatibleConnected: boolean;
+    provider: string;
+  };
+  assert.equal(body.provider, "openai-compatible");
+  assert.equal(body.baseUrl, "http://localhost:1234/v1");
+  assert.equal(body.sessionOpenAiCompatibleConnected, true);
+});
+
 test("POST /api/openrouter/connect returns 400 when code is missing", async () => {
   const bridge = new MockBridge();
   const base = await startTestServer(bridge);
@@ -856,6 +1017,20 @@ test("POST /api/openrouter/connect surfaces exchange failures", async () => {
   } finally {
     globalThis.fetch = originalFetch;
   }
+});
+
+test("POST /api/openai-compatible/connect rejects an invalid endpoint", async () => {
+  const bridge = new MockBridge();
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/openai-compatible/connect`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ baseUrl: "localhost:1234/v1" }),
+  });
+  assert.equal(res.status, 400);
+  const body = await res.json() as { error: string };
+  assert.match(body.error, /valid absolute http\(s\) URL/);
 });
 
 // ── OpenAI-compatible API tests ──

--- a/tests/settings-ui.test.ts
+++ b/tests/settings-ui.test.ts
@@ -10,11 +10,27 @@ test("built HTML contains settings entry point and modal shell", () => {
   assert.ok(html.includes('id="settings-btn"'), "HTML should contain the settings button");
   assert.ok(html.includes('id="settings-modal"'), "HTML should contain the settings modal");
   assert.ok(html.includes('id="connect-openrouter-btn"'), "HTML should contain the OpenRouter connect button");
+  assert.ok(
+    html.includes('id="connect-openai-compatible-btn"'),
+    "HTML should contain the OpenAI-compatible connect button",
+  );
   assert.ok(html.includes('id="config-overlay-intro"'), "HTML should contain the setup overlay intro copy");
   assert.ok(html.includes("Try minicode for free with OpenRouter"), "HTML should promote the free OpenRouter quick start");
   assert.ok(html.includes('id="openrouter-connect-modal"'), "HTML should contain the OpenRouter consent modal");
+  assert.ok(
+    html.includes('id="openai-compatible-connect-modal"'),
+    "HTML should contain the OpenAI-compatible connect modal",
+  );
+  assert.ok(
+    html.includes('id="openai-compatible-preset"'),
+    "HTML should contain the OpenAI-compatible preset selector",
+  );
   assert.ok(html.includes('id="openrouter-persist-checkbox"'), "HTML should contain the OpenRouter persistence checkbox");
   assert.ok(html.includes('id="disconnect-openrouter-btn"'), "HTML should contain the OpenRouter disconnect button");
+  assert.ok(
+    html.includes('id="disconnect-openai-compatible-btn"'),
+    "HTML should contain the OpenAI-compatible disconnect button",
+  );
   assert.ok(!html.includes('id="settings-scope"'), "HTML should no longer contain the settings scope selector");
   assert.ok(html.includes('id="settings-save"'), "HTML should contain the settings save action");
 });
@@ -27,9 +43,12 @@ test("built CSS contains modal and settings layout styles", () => {
   assert.ok(css.includes(".settings-help-warning"), "CSS should contain warning styling for env overrides");
   assert.ok(css.includes("align-items: flex-start;"), "CSS should top-align scrollable setup overlay content");
   assert.ok(css.includes(".config-overlay-spotlight"), "CSS should style the OpenRouter quick-start spotlight");
+  assert.ok(css.includes(".config-overlay-shortcuts"), "CSS should lay out the setup quick-connect cards");
   assert.ok(css.includes(".openrouter-connect-body"), "CSS should style the OpenRouter consent modal body");
+  assert.ok(css.includes(".provider-input"), "CSS should style provider connection form inputs");
   assert.ok(css.includes(".config-connect-status.success"), "CSS should style OpenRouter connect success state");
   assert.ok(css.includes(".settings-session-banner"), "CSS should style the OpenRouter session banner");
+  assert.ok(css.includes(".settings-provider-shortcuts"), "CSS should style provider shortcuts inside settings");
   assert.ok(css.includes("body.modal-open"), "CSS should lock scroll while the settings modal is open");
 });
 
@@ -38,11 +57,24 @@ test("built JS contains config loading and saving logic for settings", () => {
   assert.ok(js.includes("/api/config"), "JS should fetch the config API");
   assert.ok(js.includes("/api/openrouter/connect"), "JS should call the OpenRouter connect API");
   assert.ok(js.includes("/api/openrouter/disconnect"), "JS should call the OpenRouter disconnect API");
+  assert.ok(
+    js.includes("/api/openai-compatible/connect"),
+    "JS should call the OpenAI-compatible connect API",
+  );
+  assert.ok(
+    js.includes("/api/openai-compatible/disconnect"),
+    "JS should call the OpenAI-compatible disconnect API",
+  );
   assert.ok(js.includes("persistToHomeEnv"), "JS should support persisting the selected model after OpenRouter setup");
   assert.ok(js.includes("code_challenge_method"), "JS should generate an OpenRouter PKCE auth request");
   assert.ok(js.includes("sessionStorage"), "JS should persist the PKCE verifier for the OAuth callback");
   assert.ok(js.includes("minicode:openrouter:persist-to-env"), "JS should persist the optional OpenRouter env-write choice across OAuth");
   assert.ok(js.includes("sessionOpenRouterConnected"), "JS should track session-only OpenRouter state");
+  assert.ok(
+    js.includes("sessionOpenAiCompatibleConnected"),
+    "JS should track session-only OpenAI-compatible state",
+  );
+  assert.ok(js.includes("OPENAI_COMPATIBLE_PRESETS"), "JS should include OpenAI-compatible endpoint presets");
   assert.ok(js.includes("Save settings"), "JS should contain the settings save action text");
   assert.ok(js.includes("settingsPayload"), "JS should track settings payload state");
   assert.ok(js.includes("persistedValue"), "JS should wire persisted settings behavior");

--- a/tests/setup-overlay-state.test.ts
+++ b/tests/setup-overlay-state.test.ts
@@ -14,6 +14,7 @@ test("fresh install hides MODEL missing copy until a provider is configured", ()
   assert.equal(state.hideOpenRouterSpotlight, false);
   assert.deepEqual(state.missingItems, []);
   assert.equal(state.showModelSelectionHint, false);
+  assert.equal(state.modelSelectionNote, null);
 });
 
 test("configured OpenAI-compatible provider keeps model guidance visible", () => {
@@ -30,6 +31,7 @@ test("configured OpenAI-compatible provider keeps model guidance visible", () =>
   assert.equal(state.hideOpenRouterSpotlight, false);
   assert.deepEqual(state.missingItems, ["MODEL is not set"]);
   assert.equal(state.showModelSelectionHint, true);
+  assert.equal(state.modelSelectionNote, null);
 });
 
 test("configured OpenRouter provider keeps model guidance and hides spotlight", () => {
@@ -46,6 +48,10 @@ test("configured OpenRouter provider keeps model guidance and hides spotlight", 
   assert.equal(state.hideOpenRouterSpotlight, true);
   assert.deepEqual(state.missingItems, ["MODEL is not set"]);
   assert.equal(state.showModelSelectionHint, true);
+  assert.equal(
+    state.modelSelectionNote,
+    'If you are on the OpenRouter free tier, search "free" in the model dropdown to find supported free models.',
+  );
 });
 
 test("non-model missing items still surface before provider selection", () => {
@@ -57,4 +63,5 @@ test("non-model missing items still surface before provider selection", () => {
   assert.equal(state.introText, DEFAULT_SETUP_INTRO);
   assert.deepEqual(state.missingItems, ["SOME_OTHER_SETTING is not set"]);
   assert.equal(state.showModelSelectionHint, false);
+  assert.equal(state.modelSelectionNote, null);
 });

--- a/tests/setup-overlay-state.test.ts
+++ b/tests/setup-overlay-state.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { DEFAULT_SETUP_INTRO, deriveSetupOverlayState } from "../src/web/setup-overlay-state.js";
+
+test("fresh install hides MODEL missing copy until a provider is configured", () => {
+  const state = deriveSetupOverlayState({
+    configuredProvider: null,
+    missing: ["MODEL is not set"],
+  });
+
+  assert.equal(state.introText, DEFAULT_SETUP_INTRO);
+  assert.equal(state.hideQuickConnects, false);
+  assert.equal(state.hideOpenRouterSpotlight, false);
+  assert.deepEqual(state.missingItems, []);
+  assert.equal(state.showModelSelectionHint, false);
+});
+
+test("configured OpenAI-compatible provider keeps model guidance visible", () => {
+  const state = deriveSetupOverlayState({
+    configuredProvider: "openai-compatible",
+    missing: ["MODEL is not set"],
+  });
+
+  assert.equal(
+    state.introText,
+    "An OpenAI-compatible provider is already configured. Select a model to continue:",
+  );
+  assert.equal(state.hideQuickConnects, true);
+  assert.equal(state.hideOpenRouterSpotlight, false);
+  assert.deepEqual(state.missingItems, ["MODEL is not set"]);
+  assert.equal(state.showModelSelectionHint, true);
+});
+
+test("configured OpenRouter provider keeps model guidance and hides spotlight", () => {
+  const state = deriveSetupOverlayState({
+    configuredProvider: "openrouter",
+    missing: ["MODEL is not set"],
+  });
+
+  assert.equal(
+    state.introText,
+    "OpenRouter is already configured. Select a model to continue:",
+  );
+  assert.equal(state.hideQuickConnects, true);
+  assert.equal(state.hideOpenRouterSpotlight, true);
+  assert.deepEqual(state.missingItems, ["MODEL is not set"]);
+  assert.equal(state.showModelSelectionHint, true);
+});
+
+test("non-model missing items still surface before provider selection", () => {
+  const state = deriveSetupOverlayState({
+    configuredProvider: null,
+    missing: ["SOME_OTHER_SETTING is not set"],
+  });
+
+  assert.equal(state.introText, DEFAULT_SETUP_INTRO);
+  assert.deepEqual(state.missingItems, ["SOME_OTHER_SETTING is not set"]);
+  assert.equal(state.showModelSelectionHint, false);
+});


### PR DESCRIPTION
## Summary
- Generalizes the quick-connect flow from LM Studio-specific setup to OpenAI-compatible endpoints with presets for LM Studio, OpenAI, Ollama, and custom URLs.
- Adds session-only connect/disconnect support for generic OpenAI-compatible providers, including optional persistence to `~/.minicode/.env`.
- Refines first-run onboarding so fallback localhost defaults are not treated as a configured provider, hides premature model-missing copy, and guides OpenRouter free-tier users to search for `free` models.

## Why
The onboarding flow was misleading fresh installs by implying a provider was already configured and asking users to choose a model before any usable provider connection existed. This keeps provider setup first, then model selection once a real provider is configured.

## Validation
- `npm run build`
- `node --test --import tsx tests/config-integration.test.ts`
- `node --test --import tsx tests/serve.integration.test.ts tests/settings-ui.test.ts`
- `node --test --import tsx tests/setup-overlay-state.test.ts`
- `npm test`