### PR TITLE
[codex] Fix session saves and command/tool-call edge cases

### DIFF
--- a/packages/agent-sdk/src/agent/agent.ts
+++ b/packages/agent-sdk/src/agent/agent.ts
@@ -470,7 +470,8 @@ export class CodingAgent {
         toolCalls: response.toolCalls,
       });
 
-      for (const toolCall of response.toolCalls) {
+      for (let toolCallIndex = 0; toolCallIndex < response.toolCalls.length; toolCallIndex += 1) {
+        const toolCall = response.toolCalls[toolCallIndex]!;
         const fingerprint = signatureForToolCall(toolCall);
         recentToolCallFingerprints.push(fingerprint);
         if (
@@ -486,6 +487,14 @@ export class CodingAgent {
         if (repeatedCalls >= 3) {
           const loopMessage =
             "Stopped due to repeated identical tool calls. Please refine the prompt or provide additional constraints.";
+          for (const skippedToolCall of response.toolCalls.slice(toolCallIndex)) {
+            this.session.addMessage({
+              role: "tool",
+              toolCallId: skippedToolCall.id,
+              toolName: skippedToolCall.name,
+              content: `Tool skipped: ${loopMessage}`,
+            });
+          }
           this.session.addMessage({
             role: "assistant",
             content: loopMessage,

--- a/packages/agent-sdk/src/model/client.ts
+++ b/packages/agent-sdk/src/model/client.ts
@@ -303,6 +303,9 @@ type OpenAICompatibleMessage =
       content: string;
     };
 
+const MISSING_TOOL_RESULT_CONTENT =
+  "Tool result unavailable because the previous minicode run ended before recording output.";
+
 function toOpenAICompatibleMessages(
   system: string,
   messages: SessionMessage[],
@@ -313,9 +316,22 @@ function toOpenAICompatibleMessages(
       content: system,
     },
   ];
+  let pendingToolCalls: ToolCall[] = [];
+
+  const flushMissingToolResults = () => {
+    for (const toolCall of pendingToolCalls) {
+      converted.push({
+        role: "tool",
+        tool_call_id: toolCall.id,
+        content: MISSING_TOOL_RESULT_CONTENT,
+      });
+    }
+    pendingToolCalls = [];
+  };
 
   for (const message of messages) {
     if (message.role === "user") {
+      flushMissingToolResults();
       converted.push({
         role: "user",
         content: message.content,
@@ -324,6 +340,7 @@ function toOpenAICompatibleMessages(
     }
 
     if (message.role === "assistant") {
+      flushMissingToolResults();
       const toolCalls = message.toolCalls?.map((toolCall) => ({
         id: toolCall.id,
         type: "function" as const,
@@ -338,6 +355,14 @@ function toOpenAICompatibleMessages(
         content: message.content.length > 0 ? message.content : null,
         ...(toolCalls ? { tool_calls: toolCalls } : {}),
       });
+      pendingToolCalls = [...(message.toolCalls ?? [])];
+      continue;
+    }
+
+    const pendingToolCallIndex = pendingToolCalls.findIndex(
+      (toolCall) => toolCall.id === message.toolCallId,
+    );
+    if (pendingToolCallIndex === -1) {
       continue;
     }
 
@@ -346,7 +371,10 @@ function toOpenAICompatibleMessages(
       tool_call_id: message.toolCallId,
       content: message.content,
     });
+    pendingToolCalls.splice(pendingToolCallIndex, 1);
   }
+
+  flushMissingToolResults();
 
   return converted;
 }

--- a/packages/agent-sdk/src/tools/run-command.ts
+++ b/packages/agent-sdk/src/tools/run-command.ts
@@ -14,6 +14,8 @@ interface CommandExecutionResult {
   timedOut: boolean;
 }
 
+const COMMAND_KILL_GRACE_MS = 1_000;
+
 export interface RunCommandHooks {
   afterCommand?: ((command: string, result: CommandExecutionResult) => Promise<void> | void) | undefined;
 }
@@ -24,15 +26,67 @@ function executeBashCommand(
   timeoutMs: number,
 ): Promise<CommandExecutionResult> {
   return new Promise<CommandExecutionResult>((resolve, reject) => {
-    const child = spawn("bash", ["-lc", command], { cwd });
+    const useProcessGroup = process.platform !== "win32";
+    const child = spawn("bash", ["-lc", command], {
+      cwd,
+      detached: useProcessGroup,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
 
     let stdout = "";
     let stderr = "";
     let timedOut = false;
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let forceKillTimeout: ReturnType<typeof setTimeout> | undefined;
+    let forceResolveTimeout: ReturnType<typeof setTimeout> | undefined;
 
-    const timeout = setTimeout(() => {
+    const cleanup = () => {
+      if (timeout) clearTimeout(timeout);
+      if (forceKillTimeout) clearTimeout(forceKillTimeout);
+      if (forceResolveTimeout) clearTimeout(forceResolveTimeout);
+    };
+
+    const settle = (result: CommandExecutionResult) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(result);
+    };
+
+    const terminate = (signal: NodeJS.Signals) => {
+      if (child.pid && useProcessGroup) {
+        try {
+          process.kill(-child.pid, signal);
+          return;
+        } catch {
+          // Fall through to killing the shell process directly.
+        }
+      }
+
+      try {
+        child.kill(signal);
+      } catch {
+        // The process may have already exited.
+      }
+    };
+
+    timeout = setTimeout(() => {
       timedOut = true;
-      child.kill("SIGTERM");
+      terminate("SIGTERM");
+      forceKillTimeout = setTimeout(() => {
+        terminate("SIGKILL");
+        forceResolveTimeout = setTimeout(() => {
+          child.stdout.destroy();
+          child.stderr.destroy();
+          settle({
+            stdout: stdout.trimEnd(),
+            stderr: stderr.trimEnd(),
+            exitCode: null,
+            timedOut,
+          });
+        }, COMMAND_KILL_GRACE_MS);
+      }, COMMAND_KILL_GRACE_MS);
     }, timeoutMs);
 
     child.stdout.on("data", (chunk: Buffer | string) => {
@@ -42,12 +96,11 @@ function executeBashCommand(
       stderr += chunk.toString();
     });
     child.on("error", (error) => {
-      clearTimeout(timeout);
+      cleanup();
       reject(error);
     });
     child.on("close", (code) => {
-      clearTimeout(timeout);
-      resolve({
+      settle({
         stdout: stdout.trimEnd(),
         stderr: stderr.trimEnd(),
         exitCode: code,

--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -17,6 +17,7 @@ import type { ServerMessage } from "./types.js";
 import type { WebSocketServer } from "ws";
 import { handleMcpRequest } from "./mcp-server.js";
 import { buildSessionPreview } from "../session/session-preview.js";
+import { DuplicateSessionLabelError } from "../session/session-store.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -563,8 +564,15 @@ export function createRequestHandler(
 
       if (pathname === "/api/sessions/save" && method === "POST") {
         const body = JSON.parse(await readBody(req)) as { label?: string };
-        const meta = await bridge.saveSess(body.label);
-        sendJson(res, 200, meta);
+        try {
+          const meta = await bridge.saveSess(body.label);
+          sendJson(res, 200, meta);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Failed to save session";
+          sendJson(res, error instanceof DuplicateSessionLabelError ? 409 : 500, {
+            error: message,
+          });
+        }
         return;
       }
 

--- a/src/session/session-store.ts
+++ b/src/session/session-store.ts
@@ -21,9 +21,23 @@ interface SavedSessionFile {
 
 let sessionsDir = path.join(os.homedir(), ".minicode", "sessions");
 
+export class DuplicateSessionLabelError extends Error {
+  constructor(
+    readonly label: string,
+    readonly existingSessionId: string,
+  ) {
+    super(`A saved session named "${label}" already exists. Choose a different name or load that session to update it.`);
+    this.name = "DuplicateSessionLabelError";
+  }
+}
+
 /** Override sessions directory (for testing). */
 export function setSessionsDir(dir: string): void {
   sessionsDir = dir;
+}
+
+function normalizeSessionLabel(label: string): string {
+  return label.trim().toLowerCase();
 }
 
 export async function saveSession(
@@ -39,6 +53,15 @@ export async function saveSession(
     label && label.trim().length > 0
       ? label.trim()
       : new Date().toLocaleString();
+
+  const duplicate = (await listSessions()).find(
+    (savedSession) =>
+      savedSession.id !== snapshot.id &&
+      normalizeSessionLabel(savedSession.label) === normalizeSessionLabel(resolvedLabel),
+  );
+  if (duplicate) {
+    throw new DuplicateSessionLabelError(resolvedLabel, duplicate.id);
+  }
 
   const data: SavedSessionFile = {
     label: resolvedLabel,

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1485,17 +1485,21 @@ saveBtn.addEventListener("click", async () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ label }),
     });
-    if (res.ok) {
-      const data = await res.json() as SessionMeta;
-      saveLabelInput.value = "";
-      addMessage(
-        `${isUpdatingCurrentSession ? "Session updated" : "Session saved"}: "${data.label}"`,
-        "thinking",
-      );
-      await refreshSessionList();
+    const body = await res.json() as SessionMeta | { error: string };
+    if (!res.ok) {
+      throw new Error("error" in body ? body.error : `Failed to save session (${res.status})`);
     }
-  } catch {
-    // ignore
+
+    const data = body as SessionMeta;
+    saveLabelInput.value = "";
+    addMessage(
+      `${isUpdatingCurrentSession ? "Session updated" : "Session saved"}: "${data.label}"`,
+      "thinking",
+    );
+    await refreshSessionList();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to save session";
+    addMessage(message, "error");
   } finally {
     saveBtn.removeAttribute("disabled");
   }
@@ -1589,13 +1593,17 @@ sessionUpdateBtn.addEventListener("click", async () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ label: activeSavedSession.label }),
     });
-    if (res.ok) {
-      const data = await res.json() as SessionMeta;
-      addMessage(`Session updated: "${data.label}"`, "thinking");
-      await refreshSessionList();
+    const body = await res.json() as SessionMeta | { error: string };
+    if (!res.ok) {
+      throw new Error("error" in body ? body.error : `Failed to update session (${res.status})`);
     }
-  } catch {
-    // ignore
+
+    const data = body as SessionMeta;
+    addMessage(`Session updated: "${data.label}"`, "thinking");
+    await refreshSessionList();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to update session";
+    addMessage(message, "error");
   } finally {
     sessionUpdateBtn.disabled = false;
   }

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -97,6 +97,23 @@ function createEchoTool(): ToolDefinition {
   };
 }
 
+function assertToolCallTranscriptIsComplete(messages: SessionMessage[]): void {
+  for (let i = 0; i < messages.length; i += 1) {
+    const message = messages[i];
+    if (message?.role !== "assistant" || !message.toolCalls?.length) {
+      continue;
+    }
+
+    const toolCalls = message.toolCalls;
+    for (let offset = 0; offset < toolCalls.length; offset += 1) {
+      const toolCall = toolCalls[offset]!;
+      const toolResult = messages[i + offset + 1];
+      assert.equal(toolResult?.role, "tool");
+      assert.equal(toolResult?.role === "tool" ? toolResult.toolCallId : undefined, toolCall.id);
+    }
+  }
+}
+
 test("agent executes tool calls and returns final assistant text", async () => {
   const responses: ModelResponse[] = [
     {
@@ -139,6 +156,7 @@ test("agent stops on repeated identical tool calls", async () => {
 
   const { text } = await agent.runTurn("Do something");
   assert.match(text, /repeated identical tool calls/);
+  assertToolCallTranscriptIsComplete(agent.getSession().getMessages());
 });
 
 test("agent tells the user how to continue when the turn call limit is reached", async () => {

--- a/tests/file-tools.test.ts
+++ b/tests/file-tools.test.ts
@@ -137,6 +137,24 @@ test("run_command refresh removes deleted files from the index", async () => {
   assert.equal(index.getSymbol("add"), undefined, "deleted file should be removed from the index");
 });
 
+test("run_command times out commands that ignore SIGTERM", async () => {
+  const workspaceRoot = await createTempWorkspace();
+  const config = createTestAgentConfig(workspaceRoot);
+  config.commandTimeoutMs = 100;
+  const runTool = createRunCommandTool(config);
+  const start = Date.now();
+
+  const output = await runTool.execute({
+    command: `node -e 'process.on("SIGTERM", () => {}); setInterval(() => {}, 1000)'`,
+  });
+
+  assert.match(output, /timed_out: true/);
+  assert.ok(
+    Date.now() - start < 5_000,
+    "run_command should return after the timeout and kill grace period",
+  );
+});
+
 test("read_file supports negative offset and line limits", async () => {
   const workspaceRoot = await createTempWorkspace();
   const filePath = path.join(workspaceRoot, "lines.txt");

--- a/tests/model-client-openai.test.ts
+++ b/tests/model-client-openai.test.ts
@@ -130,6 +130,55 @@ test("openai-compatible client sends correct app URL in HTTP-Referer header", as
   assert.equal(capturedHeaders["X-Title"], "minicode");
 });
 
+test("openai-compatible client repairs missing tool results before sending", async () => {
+  let capturedBody = "";
+
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    capturedBody = String(init?.body ?? "");
+    return new Response(
+      JSON.stringify({
+        choices: [
+          {
+            finish_reason: "stop",
+            message: { content: "ok", tool_calls: [] },
+          },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 3 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+
+  await client.chat({
+    model: "test-model",
+    system: "sys",
+    messages: [
+      { role: "user", content: "start" },
+      {
+        role: "assistant",
+        content: "checking",
+        toolCalls: [{ id: "call-missing", name: "read_file", input: { path: "src/index.ts" } }],
+      },
+      { role: "user", content: "continue" },
+    ],
+    tools: [],
+    maxTokens: 64,
+  });
+
+  const parsedBody = JSON.parse(capturedBody) as Record<string, unknown>;
+  const messages = parsedBody.messages as Array<Record<string, unknown>>;
+  assert.equal(messages[2]?.role, "assistant");
+  assert.equal(messages[3]?.role, "tool");
+  assert.equal(messages[3]?.tool_call_id, "call-missing");
+  assert.match(String(messages[3]?.content), /Tool result unavailable/);
+  assert.equal(messages[4]?.role, "user");
+});
+
 test("createModelClient returns openai-compatible client", () => {
   const config: AgentConfig = {
     ...createTestAgentConfig("/tmp"),

--- a/tests/serve.integration.test.ts
+++ b/tests/serve.integration.test.ts
@@ -11,6 +11,7 @@ import { AgentBridge } from "../src/serve/agent-bridge.js";
 import { Session, type UiUpdate } from "@minicode/agent-sdk";
 import type { IndexedSymbol } from "../src/indexer/types.js";
 import type { ServerMessage } from "../src/serve/types.js";
+import { DuplicateSessionLabelError } from "../src/session/session-store.js";
 import { createTestAgentConfig } from "./test-utils.js";
 
 /**
@@ -431,6 +432,18 @@ class EmptySessionsBridge extends MockBridge {
   }
 }
 
+class DuplicateSessionLabelBridge extends MockBridge {
+  override async saveSess(): Promise<{
+    id: string;
+    label: string;
+    createdAt: string;
+    savedAt: string;
+    messageCount: number;
+  }> {
+    throw new DuplicateSessionLabelError("test-session", "sess-1");
+  }
+}
+
 // ── Test harness ──
 
 let activeServer: Server | undefined;
@@ -547,6 +560,21 @@ test("POST /api/sessions/save saves a session", async () => {
 
   const body = (await res.json()) as { label: string };
   assert.equal(body.label, "my-save");
+});
+
+test("POST /api/sessions/save rejects duplicate session labels", async () => {
+  const bridge = new DuplicateSessionLabelBridge();
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/sessions/save`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ label: "test-session" }),
+  });
+  assert.equal(res.status, 409);
+
+  const body = (await res.json()) as { error: string };
+  assert.match(body.error, /already exists/);
 });
 
 test("session APIs support the first save when no sessions exist yet", async () => {

--- a/tests/session-store.test.ts
+++ b/tests/session-store.test.ts
@@ -7,6 +7,7 @@ import os from "node:os";
 import { Session } from "@minicode/agent-sdk";
 
 import {
+  DuplicateSessionLabelError,
   listSessions,
   loadSession,
   loadSessionByLabel,
@@ -123,6 +124,28 @@ test("loadSessionByLabel returns undefined for no match", async () => {
   await withTmpDir(async () => {
     const result = await loadSessionByLabel("nope");
     assert.equal(result, undefined);
+  });
+});
+
+test("saveSession rejects duplicate labels for different sessions", async () => {
+  await withTmpDir(async (dir) => {
+    const firstSession = new Session("first-id");
+    firstSession.addMessage({ role: "user", content: "first" });
+    await saveSession(firstSession, "My Label");
+
+    const secondSession = new Session("second-id");
+    secondSession.addMessage({ role: "user", content: "second" });
+
+    await assert.rejects(
+      () => saveSession(secondSession, " my label "),
+      (error) =>
+        error instanceof DuplicateSessionLabelError &&
+        error.label === "my label" &&
+        error.existingSessionId === "first-id",
+    );
+
+    const files = await readdir(dir);
+    assert.deepEqual(files, ["first-id.json"]);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes three bug-squashing issues:

- Blocks saving a new session with the same label as an existing saved session, while still allowing updates to the currently saved session.
- Keeps tool-call transcripts valid when loop detection stops repeated tool calls, and defensively repairs missing OpenAI-compatible tool results before sending provider requests.
- Makes `run_command` timeouts actually terminate stubborn long-running commands by killing the process group and escalating from `SIGTERM` to `SIGKILL`.

## Validation

- `npm run lint`
- `npm run build`
- `TMPDIR=/tmp npm test`

Closes #104.
Closes #127.
Closes #128.