### PR TITLE
[codex] Refresh graph index from the web UI

### DIFF
--- a/src/serve/agent-bridge.ts
+++ b/src/serve/agent-bridge.ts
@@ -88,19 +88,10 @@ export class AgentBridge {
       projectIndex = undefined;
     }
 
-    const toolRegistry = createToolRegistry(config, projectIndex);
-
-    // Wrap tool registry execute to inject annotations into tool results
-    const originalExecute = toolRegistry.execute.bind(toolRegistry);
-    toolRegistry.execute = async (name: string, input: unknown) => {
-      const result = await originalExecute(name, input);
-      return this.appendAnnotationsToResult(name, input, result);
-    };
-
     this.config = config;
     this.baseConfig = AgentBridge.cloneConfig(config);
     this.projectIndex = projectIndex;
-    this.toolRegistry = toolRegistry;
+    this.installToolRegistry(projectIndex);
 
     if (this.modelClient) {
       this.agent = this.createAgent();
@@ -128,6 +119,19 @@ export class AgentBridge {
     }
 
     Object.assign(targetRecord, AgentBridge.cloneConfig(source));
+  }
+
+  private installToolRegistry(projectIndex: ProjectIndex | undefined): void {
+    const toolRegistry = createToolRegistry(this.config, projectIndex);
+
+    // Wrap tool registry execute to inject annotations into tool results.
+    const originalExecute = toolRegistry.execute.bind(toolRegistry);
+    toolRegistry.execute = async (name: string, input: unknown) => {
+      const result = await originalExecute(name, input);
+      return this.appendAnnotationsToResult(name, input, result);
+    };
+
+    this.toolRegistry = toolRegistry;
   }
 
   private createAgent(
@@ -225,7 +229,8 @@ export class AgentBridge {
         console.error(`[watch] Reindexed: ${relPath}`);
       }
     } catch {
-      // File may have been deleted — ignore
+      // File may have been deleted or renamed. A workspace refresh prunes stale symbols.
+      await this.refreshIndex();
     }
   }
 
@@ -430,6 +435,37 @@ export class AgentBridge {
 
   hasIndex(): boolean {
     return this.projectIndex !== undefined;
+  }
+
+  async refreshIndex(): Promise<boolean> {
+    try {
+      if (this.projectIndex) {
+        await this.projectIndex.refreshFromWorkspace();
+      } else {
+        this.projectIndex = await buildProjectIndex(this.config.workspaceRoot);
+        this.installToolRegistry(this.projectIndex);
+        if (this.modelClient) {
+          this.agent = this.createAgent(this.agent?.getSession());
+        }
+      }
+
+      const index = this.projectIndex;
+      if (!index) {
+        return false;
+      }
+
+      const cacheDir = getWorkspaceCacheDir(this.config.workspaceRoot);
+      const fileHashes = await computeFileHashes(this.config.workspaceRoot);
+      await saveIndex(index, cacheDir, fileHashes);
+      this.evictStaleAnnotations();
+      return true;
+    } catch (error) {
+      if (this.verbose) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`[index] Refresh failed: ${message}`);
+      }
+      return false;
+    }
   }
 
   getSymbols() {

--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -716,6 +716,22 @@ export function createRequestHandler(
         return;
       }
 
+      if (pathname === "/api/index/refresh" && method === "POST") {
+        const refreshed = await bridge.refreshIndex();
+        if (!refreshed) {
+          sendJson(res, 404, { error: "No project index available" });
+          return;
+        }
+
+        const graph = bridge.getGraph();
+        sendJson(res, 200, {
+          ok: true,
+          symbolCount: graph?.nodes.length ?? 0,
+          edgeCount: graph?.edges.length ?? 0,
+        });
+        return;
+      }
+
       if (pathname === "/api/analysis" && method === "GET") {
         const result = bridge.getStructuralAnalysis();
         if (!result) {

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,4 +1,4 @@
-import { initGraph, highlightAgentActivity, resizeGraph } from './graph.ts';
+import { initGraph, highlightAgentActivity, resizeGraph, scheduleGraphDataRefresh } from './graph.ts';
 import { closeModal, openModal } from './modal-state.ts';
 import { filterModelsByQuery, getModelDisplayName } from '../model-utils.ts';
 import { createLatestRequestTracker } from './request-tracker.ts';
@@ -207,6 +207,7 @@ const connectOpenRouterButtons = Array.from(
 const connectOpenAiCompatibleButtons = Array.from(
   document.querySelectorAll<HTMLButtonElement>("[data-openai-compatible-connect]"),
 );
+const GRAPH_REFRESH_TOOL_NAMES = new Set(["write_file", "edit_file", "run_command"]);
 const configOverlayQuickConnects = document.getElementById("config-overlay-quick-connects");
 const configOverlaySpotlight = document.getElementById("config-overlay-spotlight");
 const configOverlayIntro = document.getElementById("config-overlay-intro");
@@ -697,6 +698,9 @@ function handleServerMessage(msg: ServerMessage): void {
 
     case "tool_call_end":
       finalizeToolCall(msg.name || '', msg.result || '', msg.elapsedMs || 0);
+      if (GRAPH_REFRESH_TOOL_NAMES.has(msg.name || "")) {
+        scheduleGraphDataRefresh();
+      }
       break;
 
     case "turn_end":

--- a/src/web/graph.ts
+++ b/src/web/graph.ts
@@ -98,6 +98,21 @@ interface RawEdge {
   type?: string;
 }
 
+interface GraphResponse {
+  nodes?: GraphNode[];
+  edges?: RawEdge[];
+}
+
+interface FocusResponse {
+  pinned?: unknown[];
+}
+
+interface RefreshGraphDataOptions {
+  refreshIndex?: boolean;
+  preserveVisible?: boolean;
+  showFeedback?: boolean;
+}
+
 let cy: CyInstance | null = null;
 const graphNodes = new Map<string, GraphNode>();
 let graphEdges: GraphEdge[] = [];
@@ -113,6 +128,7 @@ let activeAnalysisFilter: AnalysisFindingFilter = 'all';
 const analysisExplanationCache = new Map<string, string>();
 let filePreviewModalInitialized = false;
 let latestFilePreviewRequestId = 0;
+let pendingGraphRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 
 const LAYOUT_OPTIONS: Record<string, unknown> = {
   name: 'cose',
@@ -138,50 +154,9 @@ export async function initGraph(): Promise<void> {
   const cyEl = document.getElementById('cy')!;
   const detailEl = document.getElementById('symbol-detail')!;
   setupFilePreviewModal();
+  cyEl.innerHTML = '';
 
   try {
-    const [graphRes, symbolsRes, focusRes] = await Promise.all([
-      fetch('/api/graph'),
-      fetch('/api/symbols'),
-      fetch('/api/focus'),
-    ]);
-
-    if (!graphRes.ok || !symbolsRes.ok) {
-      cyEl.innerHTML = '<div class="graph-empty">No index available. Run minicode with a project to generate the code graph.</div>';
-      return;
-    }
-
-    const graphData = await graphRes.json();
-    const focusData = focusRes.ok ? await focusRes.json() : { pinned: [] };
-
-    if (!graphData.nodes || graphData.nodes.length === 0) {
-      cyEl.innerHTML = '<div class="graph-empty">No index available. Run minicode with a project to generate the code graph.</div>';
-      return;
-    }
-
-    // Build lookup maps from full graph data
-    for (const node of graphData.nodes as GraphNode[]) {
-      const id = node.qualifiedName || node.id || node.name || '';
-      graphNodes.set(id, node);
-    }
-    graphEdges = ((graphData.edges || []) as RawEdge[]).map((e) => ({
-      source: e.source || e.from || '',
-      target: e.target || e.to || '',
-      kind: (e.kind || e.type || 'references').toLowerCase(),
-    }));
-    edgeIndex = buildGraphEdgeIndex(graphEdges);
-    fileToSymbolIds = buildGraphFileIndex(graphNodes);
-
-    allSymbolNames = Array.from(graphNodes.keys()).sort();
-
-    // Track pinned
-    const pinned: unknown[] = focusData.pinned || [];
-    for (const f of pinned) {
-      const name = typeof f === 'string' ? f : (f as Record<string, string>).name || (f as Record<string, string>).qualifiedName;
-      if (name) pinnedNames.add(name);
-    }
-
-    // Create empty cytoscape instance
     cy = cytoscape({
       container: cyEl,
       elements: [],
@@ -192,21 +167,72 @@ export async function initGraph(): Promise<void> {
     setupInteractions(cy, detailEl);
     setupToolbar();
 
-    // If there are pinned symbols, seed with those; otherwise show onboarding hint
-    if (pinnedNames.size > 0) {
-      for (const name of pinnedNames) {
-        addNodeNeighborhood(name, 1);
-      }
-      runLayout();
-    } else {
-      showOnboardingHint(cyEl);
+    const loaded = await loadGraphSnapshot(false);
+    if (!loaded) {
+      showOnboardingHint(cyEl, 'No project index is available yet. Refresh after files are available, or restart minicode serve.');
+      return;
     }
+
+    seedPinnedSymbolsOrOnboarding(
+      graphNodes.size === 0
+        ? 'No JavaScript or TypeScript symbols are indexed yet. Create a file, then refresh the graph.'
+        : undefined,
+    );
 
   } catch (err) {
     console.error('Graph init failed:', err);
     const msg = err instanceof Error ? err.message : String(err);
     cyEl.innerHTML = `<div class="graph-empty">Failed to load graph: ${msg}</div>`;
   }
+}
+
+export async function refreshGraphData(options: RefreshGraphDataOptions = {}): Promise<void> {
+  if (!initialized || !cy) return;
+
+  const {
+    refreshIndex = false,
+    preserveVisible = true,
+    showFeedback = false,
+  } = options;
+  const refreshBtn = document.getElementById('graph-refresh') as HTMLButtonElement | null;
+  const visibleIds = preserveVisible ? cy.nodes().map((node: CyElement) => node.id()) : [];
+
+  if (showFeedback && refreshBtn) {
+    refreshBtn.disabled = true;
+    refreshBtn.textContent = 'Refreshing...';
+  }
+
+  try {
+    const loaded = await loadGraphSnapshot(refreshIndex);
+    if (!loaded) {
+      throw new Error('No project index available');
+    }
+    renderGraphAfterDataRefresh(visibleIds, preserveVisible);
+  } catch (err) {
+    console.error('Graph refresh failed:', err);
+    if (showFeedback) {
+      const cyEl = document.getElementById('cy');
+      if (cyEl && graphNodes.size === 0) {
+        showOnboardingHint(cyEl, 'Could not refresh the project index. Check the minicode serve logs, then try again.');
+      }
+    }
+  } finally {
+    if (showFeedback && refreshBtn) {
+      refreshBtn.disabled = false;
+      refreshBtn.textContent = 'Refresh';
+    }
+  }
+}
+
+export function scheduleGraphDataRefresh(): void {
+  if (!initialized) return;
+  if (pendingGraphRefreshTimer) {
+    clearTimeout(pendingGraphRefreshTimer);
+  }
+  pendingGraphRefreshTimer = setTimeout(() => {
+    pendingGraphRefreshTimer = null;
+    void refreshGraphData({ preserveVisible: true });
+  }, 250);
 }
 
 export function highlightAgentActivity(symbolName: string): void {
@@ -227,14 +253,135 @@ export function resizeGraph(): void {
 
 // -- Graph building (incremental) --
 
-function showOnboardingHint(container: HTMLElement): void {
-  if (container.querySelector('.graph-onboarding')) return;
+async function loadGraphSnapshot(refreshIndex: boolean): Promise<boolean> {
+  if (refreshIndex) {
+    const refreshRes = await fetch('/api/index/refresh', { method: 'POST' });
+    if (!refreshRes.ok) {
+      return false;
+    }
+  }
+
+  const [graphRes, focusRes] = await Promise.all([
+    fetch('/api/graph'),
+    fetch('/api/focus'),
+  ]);
+
+  if (!graphRes.ok) {
+    return false;
+  }
+
+  const graphData = await graphRes.json() as GraphResponse;
+  const focusData = focusRes.ok ? await focusRes.json() as FocusResponse : { pinned: [] };
+  applyGraphSnapshot(graphData, focusData);
+  return true;
+}
+
+function applyGraphSnapshot(graphData: GraphResponse, focusData: FocusResponse): void {
+  graphNodes.clear();
+  for (const node of graphData.nodes || []) {
+    const id = node.qualifiedName || node.id || node.name || '';
+    if (id) {
+      graphNodes.set(id, node);
+    }
+  }
+
+  graphEdges = (graphData.edges || []).map((e) => ({
+    source: e.source || e.from || '',
+    target: e.target || e.to || '',
+    kind: (e.kind || e.type || 'references').toLowerCase(),
+  })).filter((edge) => edge.source && edge.target);
+  edgeIndex = buildGraphEdgeIndex(graphEdges);
+  fileToSymbolIds = buildGraphFileIndex(graphNodes);
+  allSymbolNames = Array.from(graphNodes.keys()).sort();
+
+  pinnedNames.clear();
+  for (const pinned of focusData.pinned || []) {
+    const name = typeof pinned === 'string'
+      ? pinned
+      : (pinned as Record<string, string>).name || (pinned as Record<string, string>).qualifiedName;
+    if (name) pinnedNames.add(name);
+  }
+
+  resetAnalysisForGraphRefresh();
+}
+
+function resetAnalysisForGraphRefresh(): void {
+  analysisReport = null;
+  activeAnalysisFindingId = null;
+  activeAnalysisFilter = 'all';
+  analysisExplanationCache.clear();
+  clearAnalysisGraphClasses();
+
+  const panel = document.getElementById('analysis-panel');
+  if (!panel || panel.classList.contains('hidden')) {
+    return;
+  }
+
+  const { summary, findings } = getAnalysisPanelEls();
+  summary.innerHTML = '';
+  findings.innerHTML = '<div class="analysis-empty">Graph refreshed. Re-run analysis to inspect the latest dependency graph.</div>';
+  setAnalysisStatus('Graph refreshed. Re-run analysis to inspect the latest snapshot.');
+}
+
+function renderGraphAfterDataRefresh(previousVisibleIds: string[], preserveVisible: boolean): void {
+  if (!cy) return;
+
+  cy.elements().remove();
+  document.getElementById('symbol-detail')?.classList.add('hidden');
+
+  const visibleIds = preserveVisible
+    ? [...new Set(previousVisibleIds)].filter((id) => graphNodes.has(id))
+    : [];
+
+  for (const id of visibleIds) {
+    addNodeToGraph(id);
+  }
+  connectExistingNodes();
+
+  if (cy.nodes().length > 0) {
+    refreshAnalysisGraphState();
+    runLayout();
+    return;
+  }
+
+  seedPinnedSymbolsOrOnboarding(
+    graphNodes.size === 0
+      ? 'No JavaScript or TypeScript symbols are indexed yet. Create a file, then refresh the graph.'
+      : undefined,
+  );
+}
+
+function seedPinnedSymbolsOrOnboarding(subtitle?: string): void {
+  if (!cy) return;
+  for (const name of pinnedNames) {
+    addNodeNeighborhood(name, 1);
+  }
+  connectExistingNodes();
+
+  if (cy.nodes().length > 0) {
+    refreshAnalysisGraphState();
+    runLayout();
+    return;
+  }
+
+  const cyEl = document.getElementById('cy');
+  if (cyEl) showOnboardingHint(cyEl, subtitle);
+  refreshAnalysisGraphState();
+}
+
+function showOnboardingHint(container: HTMLElement, subtitle = 'Search for a symbol or file above to start exploring.<br/>Nodes expand on click to reveal connections.'): void {
+  const existing = container.querySelector('.graph-onboarding');
+  if (existing) {
+    const subtitleEl = existing.querySelector('.graph-onboarding-subtitle');
+    if (subtitleEl) subtitleEl.innerHTML = subtitle;
+    return;
+  }
   const hint = document.createElement('div');
   hint.className = 'graph-onboarding';
   hint.innerHTML =
     '<div class="graph-onboarding-icon">&#9670; &#8212; &#9670;</div>' +
     '<div class="graph-onboarding-title">Code dependency graph</div>' +
-    '<div class="graph-onboarding-subtitle">Search for a symbol or file above to start exploring.<br/>Nodes expand on click to reveal connections.</div>';
+    `<div class="graph-onboarding-subtitle">${subtitle}</div>`;
   container.appendChild(hint);
 }
 
@@ -1309,6 +1456,7 @@ async function togglePin(name: string, node: CyCollection, btnEl: HTMLButtonElem
 function setupToolbar(): void {
   const searchInput = document.getElementById('graph-search') as HTMLInputElement;
   const analyzeBtn = document.getElementById('graph-analyze') as HTMLButtonElement;
+  const refreshBtn = document.getElementById('graph-refresh') as HTMLButtonElement;
   const fitBtn = document.getElementById('graph-fit') as HTMLButtonElement;
   const relayoutBtn = document.getElementById('graph-relayout') as HTMLButtonElement;
   const clearBtn = document.getElementById('graph-clear') as HTMLButtonElement;
@@ -1321,9 +1469,6 @@ function setupToolbar(): void {
   dropdown.className = 'search-dropdown hidden';
   (searchInput.parentNode as HTMLElement).style.position = 'relative';
   searchInput.parentNode!.appendChild(dropdown);
-
-  // Rank symbols: exported first, then alphabetical by short name
-  const rankedSymbols = allSymbolNames.slice().sort((a, b) => compareGraphNodeIds(a, b, graphNodes));
 
   function showDropdownResults(results: GraphSearchResult[]): void {
     if (results.length === 0) {
@@ -1369,6 +1514,8 @@ function setupToolbar(): void {
   }
 
   function updateDropdownResults(): void {
+    // Rank symbols from the latest graph snapshot so new files appear after refresh.
+    const rankedSymbols = allSymbolNames.slice().sort((a, b) => compareGraphNodeIds(a, b, graphNodes));
     const results = buildGraphSearchResults({
       query: searchInput.value,
       symbolIds: rankedSymbols,
@@ -1405,6 +1552,10 @@ function setupToolbar(): void {
     if (cy && cy.nodes().length > 0) {
       cy.fit(40);
     }
+  });
+
+  refreshBtn.addEventListener('click', () => {
+    void refreshGraphData({ refreshIndex: true, preserveVisible: true, showFeedback: true });
   });
 
   analyzeBtn.addEventListener('click', () => {

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -132,6 +132,7 @@ MODEL=your-model-name</pre>
         <div id="graph-toolbar">
           <input id="graph-search" type="text" placeholder="Search symbols or files..." autocomplete="off" />
           <button id="graph-analyze" class="header-btn">Analyze</button>
+          <button id="graph-refresh" class="header-btn" title="Refresh the dependency graph and symbol search">Refresh</button>
           <button id="graph-fit" class="header-btn">Fit</button>
           <button id="graph-relayout" class="header-btn">Re-layout</button>
           <button id="graph-clear" class="header-btn">Clear</button>

--- a/tests/graph-onboarding.test.ts
+++ b/tests/graph-onboarding.test.ts
@@ -28,6 +28,7 @@ test('built HTML contains #cy graph container', () => {
   assert.ok(html.includes('id="cy"'), 'HTML should contain the #cy graph container');
   assert.ok(html.includes('id="graph-pane"'), 'HTML should contain the #graph-pane wrapper');
   assert.ok(html.includes('Search symbols or files...'), 'HTML should expose mixed symbol/file search');
+  assert.ok(html.includes('id="graph-refresh"'), 'HTML should expose a graph refresh button');
   assert.ok(html.includes('id="file-preview-modal"'), 'HTML should contain the file preview modal shell');
   assert.ok(html.includes('id="file-preview-code"'), 'HTML should contain the file preview code surface');
 });
@@ -126,6 +127,26 @@ test('built JS supports file search results and file-centered neighborhood rende
   assert.ok(
     js.includes('detail-file-link'),
     'JS should wire the symbol detail filename into the preview modal',
+  );
+});
+
+test('built JS refreshes graph data manually and after mutating tool calls', () => {
+  const js = readFileSync(join(distWeb, 'app.js'), 'utf-8');
+  assert.ok(
+    js.includes('/api/index/refresh'),
+    'manual graph refresh should call the backend index refresh endpoint',
+  );
+  assert.ok(
+    js.includes('refreshGraphData'),
+    'JS should define a graph data refresh helper',
+  );
+  assert.ok(
+    js.includes('scheduleGraphDataRefresh'),
+    'JS should debounce automatic graph refreshes after tool calls',
+  );
+  assert.ok(
+    js.includes('"write_file"') && js.includes('"edit_file"') && js.includes('"run_command"'),
+    'mutating tools should trigger a graph data refresh so new symbols appear in search',
   );
 });
 

--- a/tests/serve.integration.test.ts
+++ b/tests/serve.integration.test.ts
@@ -28,6 +28,7 @@ class MockBridge extends AgentBridge {
   openRouterSessionActive = false;
   openAiCompatibleApiKey: string | undefined;
   openAiCompatibleSessionActive = false;
+  refreshIndexCount = 0;
 
   constructor() {
     super(() => {}, false);
@@ -173,6 +174,11 @@ class MockBridge extends AgentBridge {
   }
 
   override hasIndex(): boolean {
+    return true;
+  }
+
+  override async refreshIndex(): Promise<boolean> {
+    this.refreshIndexCount += 1;
     return true;
   }
 
@@ -1384,6 +1390,20 @@ test("GET /api/graph returns nodes and edges", async () => {
   assert.equal(body.edges[0]!.from, "foo");
   assert.equal(body.edges[0]!.to, "Bar");
   assert.equal(body.edges[0]!.kind, "calls");
+});
+
+test("POST /api/index/refresh rebuilds the project index", async () => {
+  const bridge = new MockBridge();
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/index/refresh`, { method: "POST" });
+  assert.equal(res.status, 200);
+
+  const body = (await res.json()) as { ok: boolean; symbolCount: number; edgeCount: number };
+  assert.equal(body.ok, true);
+  assert.equal(body.symbolCount, 2);
+  assert.equal(body.edgeCount, 1);
+  assert.equal(bridge.refreshIndexCount, 1);
 });
 
 test("GET /api/analysis returns deterministic structural findings", async () => {


### PR DESCRIPTION
## Summary

Adds a graph refresh path so the web UI can rebuild the dependency graph and symbol/file search state without requiring a browser reload or serve restart.

## What changed

- Added `POST /api/index/refresh` to refresh the project index and return refreshed graph counts.
- Added a `Refresh` button to the graph toolbar that refreshes the backend index, reloads graph data, and preserves currently visible nodes when possible.
- Reloads the browser-side graph/search cache after mutating tool calls (`write_file`, `edit_file`, `run_command`) so newly created files and symbols appear in the dropdown.
- Updates the file watcher delete/rename path to run a full workspace refresh so stale symbols are pruned.
- Added integration and built-web tests for the refresh endpoint, refresh button, and automatic refresh trigger.

Closes #125.
Closes #126.

## Validation

- `npm run lint`
- `npm run build`
- `npm test`