### PR TITLE
[codex] Add session autosave and delete controls

### DIFF
--- a/src/serve/agent-bridge.ts
+++ b/src/serve/agent-bridge.ts
@@ -16,6 +16,7 @@ import type { ProjectIndex } from "../indexer/types.js";
 import { sortModelsAlphabetically } from "../model-utils.js";
 import { createToolRegistry } from "../tools/registry.js";
 import {
+  deleteSession,
   listSessions,
   loadSession,
   loadSessionByLabel,
@@ -429,6 +430,10 @@ export class AgentBridge {
 
   async listSess() {
     return listSessions();
+  }
+
+  async deleteSess(sessionId: string) {
+    return deleteSession(sessionId);
   }
 
   // ── Project index queries ──

--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -590,6 +590,23 @@ export function createRequestHandler(
         return;
       }
 
+      if (pathname.startsWith("/api/sessions/") && method === "DELETE") {
+        const sessionId = decodeURIComponent(pathname.slice("/api/sessions/".length));
+        if (!sessionId) {
+          sendJson(res, 400, { error: "Session id is required" });
+          return;
+        }
+
+        const deleted = await bridge.deleteSess(sessionId);
+        if (!deleted) {
+          sendJson(res, 404, { error: "Session not found" });
+          return;
+        }
+
+        sendJson(res, 200, { ok: true, deleted: true, id: sessionId });
+        return;
+      }
+
       // ── Graph / Index API ──
 
       if (pathname === "/api/symbols" && method === "GET") {

--- a/src/session/session-store.ts
+++ b/src/session/session-store.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -138,4 +138,14 @@ export async function loadSessionByLabel(
   );
   if (!match) return undefined;
   return loadSession(match.id);
+}
+
+export async function deleteSession(sessionId: string): Promise<boolean> {
+  const filePath = path.join(sessionsDir, `${sessionId}.json`);
+  try {
+    await unlink(filePath);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -73,6 +73,12 @@ interface SessionsResponse {
   currentSessionId: string;
 }
 
+interface DeleteSessionResponse {
+  ok: boolean;
+  deleted: boolean;
+  id: string;
+}
+
 type SettingsValue = string | number | boolean | null;
 type SettingsFieldType = "string" | "number" | "boolean" | "enum";
 
@@ -165,6 +171,7 @@ const sessionDropdown = document.getElementById("session-dropdown")!;
 const sessionList = document.getElementById("session-list")!;
 const sessionUpdateRow = document.getElementById("session-update-row")!;
 const sessionUpdateBtn = document.getElementById("session-update-btn") as HTMLButtonElement;
+const sessionAutoSaveToggle = document.getElementById("session-autosave-toggle") as HTMLInputElement;
 const saveBtn = document.getElementById("save-btn")!;
 const saveLabelInput = document.getElementById("save-label") as HTMLInputElement;
 const contextFill = document.getElementById("context-fill")!;
@@ -227,6 +234,8 @@ const sessionRefreshTracker = createLatestRequestTracker();
 const TOOL_RESULT_MAX = 500;
 const OPENROUTER_PKCE_VERIFIER_KEY = "minicode:openrouter:pkce-verifier";
 const OPENROUTER_PERSIST_TO_ENV_KEY = "minicode:openrouter:persist-to-env";
+const SESSION_AUTOSAVE_KEY = "minicode:session:auto-save";
+const SESSION_AUTOSAVE_LABEL_PREFIX = "Autosave";
 type OpenAiCompatiblePreset = "lmstudio" | "openai" | "ollama" | "custom";
 
 const OPENAI_COMPATIBLE_PRESETS: Record<OpenAiCompatiblePreset, {
@@ -255,6 +264,13 @@ const OPENAI_COMPATIBLE_PRESETS: Record<OpenAiCompatiblePreset, {
     apiKeyPlaceholder: "Add an API key only if this endpoint requires auth",
   },
 };
+
+let sessionAutoSaveEnabled = loadSessionAutoSavePreference();
+let pendingAutoSaveLabel: string | null = null;
+let autoSaveInFlight: Promise<void> | null = null;
+let autoSaveQueued = false;
+
+sessionAutoSaveToggle.checked = sessionAutoSaveEnabled;
 
 function connect(): void {
   const protocol = location.protocol === "https:" ? "wss:" : "ws:";
@@ -722,6 +738,7 @@ function handleServerMessage(msg: ServerMessage): void {
       if (msg.usage) {
         addUsageInfo(msg.usage);
       }
+      queueSessionAutoSave();
       break;
 
     case "error":
@@ -905,7 +922,9 @@ function updateContextIndicator(contextTokens: number, maxContextTokens: number)
   }
   contextLabel.textContent = pct + "%";
   const indicator = document.getElementById("context-indicator")!;
-  indicator.title = `Context: ~${contextTokens.toLocaleString()} / ${maxContextTokens.toLocaleString()} tokens (${pct}%)`;
+  indicator.title =
+    `Context: ~${contextTokens.toLocaleString()} / ${maxContextTokens.toLocaleString()} tokens (${pct}%)\n` +
+    "Adjust context size in Settings if you want it larger or smaller.";
 }
 
 async function fetchContext(): Promise<void> {
@@ -1477,6 +1496,134 @@ document.addEventListener("click", (e: Event) => {
   }
 });
 
+function loadSessionAutoSavePreference(): boolean {
+  try {
+    return localStorage.getItem(SESSION_AUTOSAVE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function persistSessionAutoSavePreference(enabled: boolean): void {
+  try {
+    if (enabled) {
+      localStorage.setItem(SESSION_AUTOSAVE_KEY, "1");
+    } else {
+      localStorage.removeItem(SESSION_AUTOSAVE_KEY);
+    }
+  } catch {
+    // ignore
+  }
+}
+
+function buildAutoSaveLabel(): string {
+  return `${SESSION_AUTOSAVE_LABEL_PREFIX} ${new Date().toLocaleString()}`;
+}
+
+async function persistCurrentSession(label?: string): Promise<SessionMeta> {
+  const res = await fetch("/api/sessions/save", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ label }),
+  });
+  const body = await res.json() as SessionMeta | { error: string };
+  if (!res.ok) {
+    throw new Error("error" in body ? body.error : `Failed to save session (${res.status})`);
+  }
+  return body as SessionMeta;
+}
+
+async function deleteSavedSession(session: SessionMeta): Promise<void> {
+  const isCurrentSavedSession = activeSavedSession?.id === session.id;
+  const confirmed = window.confirm(`Delete saved session "${session.label}"?`);
+  if (!confirmed) {
+    return;
+  }
+
+  try {
+    const res = await fetch(`/api/sessions/${encodeURIComponent(session.id)}`, {
+      method: "DELETE",
+    });
+    const body = await res.json() as DeleteSessionResponse | { error: string };
+    if (!res.ok) {
+      throw new Error("error" in body ? body.error : `Failed to delete session (${res.status})`);
+    }
+
+    if (isCurrentSavedSession) {
+      activeSavedSession = null;
+    }
+    if (pendingAutoSaveLabel === session.label) {
+      pendingAutoSaveLabel = null;
+    }
+
+    addMessage(
+      isCurrentSavedSession
+        ? `Deleted saved session "${session.label}". The current chat stays open until you load another session or refresh.`
+        : `Session deleted: "${session.label}"`,
+      "thinking",
+    );
+    await refreshSessionList();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to delete session";
+    addMessage(message, "error");
+  }
+}
+
+async function maybeAutoSaveSession(): Promise<void> {
+  if (!sessionAutoSaveEnabled) {
+    return;
+  }
+
+  const label = activeSavedSession?.label ?? pendingAutoSaveLabel ?? buildAutoSaveLabel();
+  try {
+    const data = await persistCurrentSession(label);
+    pendingAutoSaveLabel = data.label;
+    await refreshSessionList();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to auto-save session";
+    addMessage(message, "error");
+  }
+}
+
+function queueSessionAutoSave(): void {
+  if (!sessionAutoSaveEnabled) {
+    return;
+  }
+
+  if (autoSaveInFlight) {
+    autoSaveQueued = true;
+    return;
+  }
+
+  autoSaveInFlight = (async () => {
+    await maybeAutoSaveSession();
+  })();
+
+  void autoSaveInFlight.finally(() => {
+    autoSaveInFlight = null;
+    if (autoSaveQueued) {
+      autoSaveQueued = false;
+      queueSessionAutoSave();
+    }
+  });
+}
+
+sessionAutoSaveToggle.addEventListener("change", () => {
+  sessionAutoSaveEnabled = sessionAutoSaveToggle.checked;
+  persistSessionAutoSavePreference(sessionAutoSaveEnabled);
+
+  if (sessionAutoSaveEnabled) {
+    addMessage(
+      activeSavedSession
+        ? `Auto-save enabled. minicode will update "${activeSavedSession.label}" after each completed turn.`
+        : "Auto-save enabled. minicode will save this chat after the next completed turn.",
+      "thinking",
+    );
+  } else {
+    addMessage("Auto-save disabled.", "thinking");
+  }
+});
+
 saveBtn.addEventListener("click", async () => {
   const requestedLabel = saveLabelInput.value.trim();
   const label = requestedLabel || activeSavedSession?.label || undefined;
@@ -1484,18 +1631,9 @@ saveBtn.addEventListener("click", async () => {
     !!activeSavedSession && (requestedLabel.length === 0 || requestedLabel === activeSavedSession.label);
   try {
     saveBtn.setAttribute("disabled", "true");
-    const res = await fetch("/api/sessions/save", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ label }),
-    });
-    const body = await res.json() as SessionMeta | { error: string };
-    if (!res.ok) {
-      throw new Error("error" in body ? body.error : `Failed to save session (${res.status})`);
-    }
-
-    const data = body as SessionMeta;
+    const data = await persistCurrentSession(label);
     saveLabelInput.value = "";
+    pendingAutoSaveLabel = data.label;
     addMessage(
       `${isUpdatingCurrentSession ? "Session updated" : "Session saved"}: "${data.label}"`,
       "thinking",
@@ -1529,6 +1667,7 @@ async function refreshSessionList(): Promise<void> {
       sessions.find((session) => session.id === data.currentSessionId) ?? null;
 
     if (activeSavedSession) {
+      pendingAutoSaveLabel = activeSavedSession.label;
       sessionUpdateRow.classList.remove("hidden");
       sessionUpdateBtn.textContent = `Update "${activeSavedSession.label}"`;
       sessionUpdateBtn.title = `Save changes back to "${activeSavedSession.label}"`;
@@ -1548,10 +1687,26 @@ async function refreshSessionList(): Promise<void> {
       const el = document.createElement("div");
       const isActive = activeSavedSession?.id === s.id;
       el.className = "session-item" + (isActive ? " active" : "");
-      el.innerHTML =
+      const loadBtn = document.createElement("button");
+      loadBtn.type = "button";
+      loadBtn.className = "session-load-btn";
+      loadBtn.innerHTML =
         `<span class="session-label">${escapeHtml(s.label)}</span>` +
         `<span class="session-meta">${s.messageCount} msgs${isActive ? ' <span class="session-active-badge">• active</span>' : ""}</span>`;
-      el.addEventListener("click", () => loadSession(s.label));
+      loadBtn.addEventListener("click", () => loadSession(s.label));
+
+      const deleteBtn = document.createElement("button");
+      deleteBtn.type = "button";
+      deleteBtn.className = "session-delete-btn";
+      deleteBtn.textContent = "Delete";
+      deleteBtn.title = `Delete "${s.label}"`;
+      deleteBtn.addEventListener("click", (event: Event) => {
+        event.stopPropagation();
+        void deleteSavedSession(s);
+      });
+
+      el.appendChild(loadBtn);
+      el.appendChild(deleteBtn);
       sessionList.appendChild(el);
     }
   } catch {
@@ -1574,6 +1729,7 @@ async function loadSession(label: string): Promise<void> {
     if (res.ok) {
       const body = await res.json() as LoadSessionResponse;
       sessionDropdown.classList.add("hidden");
+      pendingAutoSaveLabel = body.label;
       renderLoadedSessionMessages(body.messages);
       if (body.messages.length === 0) {
         addMessage(`Session "${body.label}" restored`, "thinking");
@@ -1592,17 +1748,8 @@ sessionUpdateBtn.addEventListener("click", async () => {
 
   try {
     sessionUpdateBtn.disabled = true;
-    const res = await fetch("/api/sessions/save", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ label: activeSavedSession.label }),
-    });
-    const body = await res.json() as SessionMeta | { error: string };
-    if (!res.ok) {
-      throw new Error("error" in body ? body.error : `Failed to update session (${res.status})`);
-    }
-
-    const data = body as SessionMeta;
+    const data = await persistCurrentSession(activeSavedSession.label);
+    pendingAutoSaveLabel = data.label;
     addMessage(`Session updated: "${data.label}"`, "thinking");
     await refreshSessionList();
   } catch (error) {

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -16,7 +16,7 @@
       <div class="header-left">
         <h1>minicode</h1>
         <span id="status-badge" class="badge ready">ready</span>
-        <div id="context-indicator" title="Context window usage">
+        <div id="context-indicator" title="Context window usage. Adjust context size in Settings if you want it larger or smaller.">
           <div id="context-bar">
             <div id="context-fill"></div>
           </div>
@@ -45,6 +45,10 @@
               <div id="session-update-row" class="session-update-row hidden">
                 <button id="session-update-btn" class="dropdown-action" type="button">Update current saved session</button>
               </div>
+              <label id="session-autosave-row" class="session-autosave-row" title="Automatically save or update this chat after each completed turn.">
+                <input id="session-autosave-toggle" type="checkbox" />
+                <span>Auto-save after each turn</span>
+              </label>
               <div class="dropdown-row">
                 <input id="save-label" type="text" placeholder="Label (optional)" />
                 <button id="save-btn" class="dropdown-action">Save</button>

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -222,6 +222,20 @@ h1 {
   margin-bottom: 8px;
 }
 
+.session-autosave-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: 12px;
+  color: var(--text-dim);
+  cursor: pointer;
+}
+
+.session-autosave-row input {
+  accent-color: var(--accent);
+}
+
 .dropdown-divider {
   height: 1px;
   background: var(--border);
@@ -275,10 +289,8 @@ h1 {
 .session-item {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 6px 8px;
+  gap: 8px;
   border-radius: 4px;
-  cursor: pointer;
   font-size: 12px;
   transition: background 0.15s;
 }
@@ -290,6 +302,28 @@ h1 {
 .session-item.active {
   background: rgba(122, 162, 247, 0.12);
   outline: 1px solid rgba(122, 162, 247, 0.35);
+}
+
+.session-load-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.session-load-btn:focus-visible,
+.session-delete-btn:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
 }
 
 .session-label {
@@ -308,6 +342,26 @@ h1 {
 
 .session-active-badge {
   color: var(--accent);
+}
+
+.session-delete-btn {
+  flex-shrink: 0;
+  margin: 4px 6px 4px 0;
+  padding: 4px 8px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.session-delete-btn:hover {
+  color: var(--red);
+  border-color: rgba(247, 118, 142, 0.55);
+  background: rgba(247, 118, 142, 0.08);
 }
 
 .badge {

--- a/tests/context-indicator.test.ts
+++ b/tests/context-indicator.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { test, afterEach } from "node:test";
 import type { Server } from "node:http";
 import { createServer } from "node:http";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { createRequestHandler } from "../src/serve/server.js";
 import { AgentBridge } from "../src/serve/agent-bridge.js";
 import type { UiUpdate } from "@minicode/agent-sdk";
@@ -18,6 +20,8 @@ import type {
 } from "@minicode/agent-sdk";
 import { UiStore } from "../src/ui/state/ui-store.js";
 import { createTestAgentConfig } from "./test-utils.js";
+
+const distWeb = join(import.meta.dirname, "..", "dist", "src", "web");
 
 // ── Mock model client ──
 
@@ -152,6 +156,20 @@ test("GET /api/context reflects updated context state", async () => {
   const body = (await res.json()) as { contextTokens: number; maxContextTokens: number };
   assert.equal(body.contextTokens, 8000);
   assert.equal(body.maxContextTokens, 16000);
+});
+
+test("built web UI explains that context size can be adjusted in Settings", () => {
+  const html = readFileSync(join(distWeb, "index.html"), "utf8");
+  const js = readFileSync(join(distWeb, "app.js"), "utf8");
+
+  assert.ok(
+    html.includes("Context window usage. Adjust context size in Settings"),
+    "HTML should provide a helpful default tooltip for the context indicator",
+  );
+  assert.ok(
+    js.includes("Adjust context size in Settings if you want it larger or smaller."),
+    "JS should include guidance about adjusting context size in Settings",
+  );
 });
 
 // ── Agent emits context_status UiUpdate ──

--- a/tests/serve.integration.test.ts
+++ b/tests/serve.integration.test.ts
@@ -29,6 +29,7 @@ class MockBridge extends AgentBridge {
   openAiCompatibleApiKey: string | undefined;
   openAiCompatibleSessionActive = false;
   refreshIndexCount = 0;
+  deletedSessionIds: string[] = [];
 
   constructor() {
     super(() => {}, false);
@@ -99,6 +100,14 @@ class MockBridge extends AgentBridge {
       });
     }
     return { session, label };
+  }
+
+  override async deleteSess(sessionId: string) {
+    if (sessionId !== "sess-1") {
+      return false;
+    }
+    this.deletedSessionIds.push(sessionId);
+    return true;
   }
 
   override getCurrentSessionId(): string {
@@ -642,6 +651,35 @@ test("POST /api/sessions/load returns success for known session", async () => {
   assert.ok(
     body.messages.every((message) => !message.content.startsWith("[Conversation Summary")),
   );
+});
+
+test("DELETE /api/sessions/:id deletes a saved session", async () => {
+  const bridge = new MockBridge();
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/sessions/sess-1`, {
+    method: "DELETE",
+  });
+  assert.equal(res.status, 200);
+
+  const body = (await res.json()) as { ok: boolean; deleted: boolean; id: string };
+  assert.equal(body.ok, true);
+  assert.equal(body.deleted, true);
+  assert.equal(body.id, "sess-1");
+  assert.deepEqual(bridge.deletedSessionIds, ["sess-1"]);
+});
+
+test("DELETE /api/sessions/:id returns 404 for unknown session", async () => {
+  const bridge = new MockBridge();
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/sessions/missing`, {
+    method: "DELETE",
+  });
+  assert.equal(res.status, 404);
+
+  const body = (await res.json()) as { error: string };
+  assert.match(body.error, /Session not found/);
 });
 
 test("POST /api/chat returns agent response", async () => {

--- a/tests/session-store.test.ts
+++ b/tests/session-store.test.ts
@@ -7,6 +7,7 @@ import os from "node:os";
 import { Session } from "@minicode/agent-sdk";
 
 import {
+  deleteSession,
   DuplicateSessionLabelError,
   listSessions,
   loadSession,
@@ -165,5 +166,26 @@ test("saving same session twice overwrites the file", async () => {
     assert.ok(result);
     assert.equal(result.label, "v2");
     assert.equal(result.session.getMessages().length, 2);
+  });
+});
+
+test("deleteSession removes the saved session file", async () => {
+  await withTmpDir(async (dir) => {
+    const session = new Session("test-id");
+    session.addMessage({ role: "user", content: "hello" });
+    await saveSession(session, "delete me");
+
+    const deleted = await deleteSession("test-id");
+    assert.equal(deleted, true);
+
+    const files = await readdir(dir);
+    assert.equal(files.length, 0);
+  });
+});
+
+test("deleteSession returns false for a missing session", async () => {
+  await withTmpDir(async () => {
+    const deleted = await deleteSession("missing-session");
+    assert.equal(deleted, false);
   });
 });

--- a/tests/session-ui.test.ts
+++ b/tests/session-ui.test.ts
@@ -9,12 +9,15 @@ test("built HTML contains update action for the current saved session", () => {
   const html = readFileSync(join(distWeb, "index.html"), "utf8");
   assert.ok(html.includes('id="session-update-row"'), "HTML should contain the session update row");
   assert.ok(html.includes('id="session-update-btn"'), "HTML should contain the session update button");
+  assert.ok(html.includes('id="session-autosave-toggle"'), "HTML should contain the auto-save sessions toggle");
 });
 
 test("built CSS contains active-session styling", () => {
   const css = readFileSync(join(distWeb, "style.css"), "utf8");
   assert.ok(css.includes(".session-item.active"), "CSS should style the active saved session row");
   assert.ok(css.includes(".session-active-badge"), "CSS should style the active session badge");
+  assert.ok(css.includes(".session-delete-btn"), "CSS should style the session delete button");
+  assert.ok(css.includes(".session-autosave-row"), "CSS should style the auto-save toggle row");
 });
 
 test("built JS contains active saved session update logic", () => {
@@ -26,4 +29,7 @@ test("built JS contains active saved session update logic", () => {
   assert.ok(js.includes('saveBtn.setAttribute("disabled", "true")'), "JS should disable saving while the first save is in flight");
   assert.ok(js.includes("renderLoadedSessionMessages"), "JS should render session previews after load");
   assert.ok(js.includes("body.messages"), "JS should read preview messages from the load session response");
+  assert.ok(js.includes("SESSION_AUTOSAVE_KEY"), "JS should persist the auto-save preference");
+  assert.ok(js.includes("window.confirm"), "JS should confirm before deleting a saved session");
+  assert.ok(js.includes('method: "DELETE"'), "JS should call the delete session API");
 });


### PR DESCRIPTION
## Summary

Adds a few expected usability improvements to the serve UI around saved sessions and context visibility.

## What changed

- Added delete support for saved sessions in the session store, serve bridge, and `/api/sessions/:id` delete endpoint.
- Added session delete controls to the web Sessions menu.
- Added an auto-save toggle in the Sessions menu that saves or updates the current chat after each completed turn.
- Updated the context usage tooltip to show token usage and point users to Settings if they want a larger or smaller context window.
- Added integration and built-asset coverage for session deletion, session autosave UI wiring, and the updated context tooltip guidance.

## Validation

- `npm run lint`
- `npm run build`
- `npm test`