### PR TITLE
Add benchmark runtime surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ minicode --oneshot --json "Summarize recent changes"
 minicode --oneshot --out result.txt "Generate release notes"
 ```
 
+Run the benchmark-friendly non-interactive entrypoint for external eval harnesses:
+
+```bash
+minicode benchmark run --prompt-file prompt.txt --out result.json
+```
+
+See [docs/BENCHMARKING.md](docs/BENCHMARKING.md) for the reproducible benchmark config/env flow.
+
 **Requirements:** Node.js 22+, LM Studio (or any OpenAI-compatible local server), `rg` in PATH (recommended). Set `MODEL` to match the model name in LM Studio.
 
 ### Install from source

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -1,0 +1,93 @@
+# Benchmarking
+
+`minicode benchmark run` is the stable non-interactive entrypoint for external benchmark harnesses.
+
+Unlike the normal CLI and web UI flows, benchmark mode does **not** read `~/.minicode/.env` by default. This keeps runs reproducible and avoids leaking a developer's local interactive config into benchmark jobs.
+
+## Command
+
+```bash
+minicode benchmark run [options] "prompt text"
+```
+
+Or, for long benchmark instructions:
+
+```bash
+minicode benchmark run [options] --prompt-file prompt.txt
+```
+
+## Supported options
+
+- `--config <path>`: Optional benchmark JSON config file. If omitted, minicode will use `./benchmarks/benchmark.config.json` when that file exists under the current working directory.
+- `--env-file <path>`: Optional dotenv file. Pass multiple times if needed.
+- `--provider <value>`: Explicit model provider override.
+- `--model <value>`: Explicit model override.
+- `--base-url <value>`: Explicit OpenAI-compatible base URL override.
+- `--workspace-root <path>`: Explicit workspace root override.
+- `--diff-out <path>`: Write the final git patch to a file.
+- `--out <path>`: Write the structured JSON result to a file instead of stdout.
+- `--verbose`: Enable verbose agent logging during the run.
+
+## Precedence
+
+Benchmark config is resolved in this order:
+
+1. Hardcoded runtime defaults
+2. Benchmark JSON config (`--config` or `./benchmarks/benchmark.config.json`)
+3. `--env-file` dotenv files, in the order provided
+4. Shell environment variables
+5. Explicit CLI overrides (`--provider`, `--model`, `--base-url`, `--workspace-root`)
+
+`~/.minicode/.env` is excluded from this resolution path unless you explicitly pass it through `--env-file ~/.minicode/.env`.
+
+## Benchmark config file
+
+The benchmark config file uses the same runtime concepts as the main CLI, but in JSON form:
+
+```json
+{
+  "modelProvider": "openai-compatible",
+  "model": "google/gemini-3-flash-preview",
+  "openAiBaseUrl": "https://openrouter.ai/api/v1",
+  "maxSteps": 50,
+  "maxContextTokens": 32000,
+  "commandTimeoutMs": 30000
+}
+```
+
+The repository's own benchmark defaults live in [`benchmarks/benchmark.config.json`](../benchmarks/benchmark.config.json).
+
+## Credentials
+
+Recommended patterns:
+
+- Put benchmark-specific secrets in a repo-local or job-local dotenv file and pass it with `--env-file`.
+- Or inject secrets through the runner environment (`OPENAI_API_KEY`, `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, etc.).
+
+Avoid relying on `~/.minicode/.env` for benchmark jobs unless you deliberately pass it in.
+
+## Output
+
+Benchmark mode emits structured JSON with:
+
+- final agent text
+- token usage, when available
+- elapsed time
+- resolved workspace root
+- resolved provider/model/base URL
+- changed files detected from git status
+- whether the workspace is a git repo
+- optional diff artifact path
+
+Example:
+
+```bash
+minicode benchmark run \
+  --config benchmarks/benchmark.config.json \
+  --env-file benchmarks/benchmark.env \
+  --prompt-file prompt.txt \
+  --diff-out artifacts/result.patch \
+  --out artifacts/result.json
+```
+
+This is the recommended surface for integrating minicode with `ts-bench`, Harbor-based benchmarks like CCBench, and future patch-based evaluators.

--- a/src/benchmark/config.ts
+++ b/src/benchmark/config.ts
@@ -1,0 +1,323 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import dotenv from "dotenv";
+
+import type { AgentConfig, ReasoningEffort } from "@minicode/agent-sdk";
+
+const DEFAULT_COMMAND_DENYLIST: RegExp[] = [
+  /\brm\s+-rf\s+\//i,
+  /\bmkfs\b/i,
+  /\bdd\s+if=/i,
+  /:\(\)\s*\{\s*:\|:&\s*\};:/,
+  /\bshutdown\b/i,
+  /\breboot\b/i,
+  /\bpoweroff\b/i,
+  /\binit\s+0\b/i,
+  /\bchmod\s+-R\s+777\s+\//i,
+];
+
+const VALID_REASONING_EFFORTS = new Set<ReasoningEffort>([
+  "xhigh",
+  "high",
+  "medium",
+  "low",
+  "minimal",
+  "none",
+]);
+
+export interface BenchmarkConfigFile {
+  modelProvider?: "anthropic" | "openai-compatible";
+  model?: string;
+  openAiBaseUrl?: string;
+  workspaceRoot?: string;
+  maxSteps?: number;
+  maxTokens?: number;
+  modelTimeoutSeconds?: number;
+  maxContextTokens?: number;
+  commandTimeoutMs?: number;
+  maxFileSizeBytes?: number;
+  keepRecentMessages?: number;
+  loopDetectionWindow?: number;
+  maxToolOutputChars?: number;
+  confirmDestructive?: boolean;
+  enableFileReadDedup?: boolean;
+  enableAdaptiveKeepRecent?: boolean;
+  enableToolOutputTruncation?: boolean;
+  compactionThreshold?: number;
+  compactionModel?: string;
+  reasoningEffort?: ReasoningEffort;
+  enableDynamicPrompt?: boolean;
+}
+
+export interface BenchmarkAgentConfigOverrides {
+  provider?: string;
+  model?: string;
+  baseUrl?: string;
+  workspaceRoot?: string;
+}
+
+export interface BenchmarkConfigOptions {
+  cwd?: string;
+  configPath?: string;
+  envFiles?: string[];
+  env?: NodeJS.ProcessEnv;
+  overrides?: BenchmarkAgentConfigOverrides;
+}
+
+export interface ResolvedBenchmarkEnv {
+  values: Record<string, string>;
+  configPath: string;
+  envFiles: string[];
+}
+
+function parseNumber(value: string | number | undefined, fallback: number): number {
+  if (value === undefined || value === "") {
+    return fallback;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function parseBoolean(value: string | boolean | undefined, fallback: boolean): boolean {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (typeof value === "boolean") {
+    return value;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(normalized)) {
+    return false;
+  }
+  return fallback;
+}
+
+function parseReasoningEffort(value: string | ReasoningEffort | undefined): ReasoningEffort | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const normalized = value.trim().toLowerCase() as ReasoningEffort;
+  return VALID_REASONING_EFFORTS.has(normalized) ? normalized : undefined;
+}
+
+function parseModelProvider(value: string | undefined): "anthropic" | "openai-compatible" {
+  const normalized = value?.trim().toLowerCase();
+  if (
+    normalized === "openai-compatible" ||
+    normalized === "openai" ||
+    normalized === "lmstudio" ||
+    normalized === "lm-studio"
+  ) {
+    return "openai-compatible";
+  }
+  return "anthropic";
+}
+
+function parseCommandDenylistEnv(value: string | undefined): RegExp[] {
+  if (!value?.trim()) {
+    return [];
+  }
+
+  const trimmed = value.trim();
+  const toRegexps = (patterns: string[]): RegExp[] => patterns.flatMap((pattern) => {
+    try {
+      return [new RegExp(pattern, "i")];
+    } catch {
+      return [];
+    }
+  });
+
+  if (trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (Array.isArray(parsed) && parsed.every((entry) => typeof entry === "string")) {
+        return toRegexps(parsed);
+      }
+    } catch {
+      return [];
+    }
+  }
+
+  return toRegexps(
+    trimmed.split(",").map((pattern) => pattern.trim()).filter(Boolean),
+  );
+}
+
+async function readOptionalFile(filePath: string): Promise<string | undefined> {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+export function getDefaultBenchmarkConfigPath(cwd = process.cwd()): string {
+  return path.resolve(cwd, "benchmarks", "benchmark.config.json");
+}
+
+async function loadBenchmarkConfigFile(configPath: string): Promise<Partial<BenchmarkConfigFile>> {
+  const file = await readOptionalFile(configPath);
+  if (!file) {
+    return {};
+  }
+  return JSON.parse(file) as Partial<BenchmarkConfigFile>;
+}
+
+export async function resolveBenchmarkEnv(
+  options: BenchmarkConfigOptions = {},
+): Promise<ResolvedBenchmarkEnv> {
+  const cwd = path.resolve(options.cwd ?? process.cwd());
+  const configPath = options.configPath
+    ? path.resolve(cwd, options.configPath)
+    : getDefaultBenchmarkConfigPath(cwd);
+  const envFiles = (options.envFiles ?? []).map((filePath) => path.resolve(cwd, filePath));
+  const values: Record<string, string> = {};
+
+  for (const envFile of envFiles) {
+    const file = await readFile(envFile, "utf8");
+    Object.assign(values, dotenv.parse(file));
+  }
+
+  for (const [key, value] of Object.entries(options.env ?? process.env)) {
+    if (value !== undefined) {
+      values[key] = value;
+    }
+  }
+
+  return {
+    values,
+    configPath,
+    envFiles,
+  };
+}
+
+export async function buildBenchmarkAgentConfig(
+  options: BenchmarkConfigOptions = {},
+): Promise<AgentConfig> {
+  const cwd = path.resolve(options.cwd ?? process.cwd());
+  const resolvedEnv = await resolveBenchmarkEnv(options);
+  const fileConfig = await loadBenchmarkConfigFile(resolvedEnv.configPath);
+  const overrides = options.overrides ?? {};
+
+  const provider = parseModelProvider(
+    overrides.provider ??
+    resolvedEnv.values.MODEL_PROVIDER ??
+    fileConfig.modelProvider ??
+    "openai-compatible",
+  );
+  const openAiBaseUrl =
+    overrides.baseUrl ??
+    resolvedEnv.values.OPENAI_BASE_URL ??
+    fileConfig.openAiBaseUrl ??
+    "http://localhost:1234/v1";
+  const model =
+    overrides.model ??
+    resolvedEnv.values.MODEL ??
+    fileConfig.model ??
+    "";
+  const rawWorkspaceRoot =
+    overrides.workspaceRoot ??
+    resolvedEnv.values.WORKSPACE_ROOT ??
+    fileConfig.workspaceRoot ??
+    cwd;
+  const workspaceRoot = path.resolve(cwd, rawWorkspaceRoot);
+  const isOpenRouter =
+    provider === "openai-compatible" &&
+    openAiBaseUrl.toLowerCase().includes("openrouter");
+  const openAiApiKey = provider === "openai-compatible"
+    ? (isOpenRouter
+        ? (resolvedEnv.values.OPENROUTER_API_KEY ?? resolvedEnv.values.OPENAI_API_KEY)
+        : resolvedEnv.values.OPENAI_API_KEY)
+    : undefined;
+
+  return {
+    modelProvider: provider,
+    model,
+    maxSteps: parseNumber(
+      resolvedEnv.values.MAX_STEPS ?? fileConfig.maxSteps,
+      50,
+    ),
+    maxTokens: parseNumber(
+      resolvedEnv.values.MAX_TOKENS ?? fileConfig.maxTokens,
+      4096,
+    ),
+    modelTimeoutSeconds: parseNumber(
+      resolvedEnv.values.MODEL_TIMEOUT_SECONDS ?? fileConfig.modelTimeoutSeconds,
+      60,
+    ),
+    maxContextTokens: parseNumber(
+      resolvedEnv.values.MAX_CONTEXT_TOKENS ?? fileConfig.maxContextTokens,
+      32_000,
+    ),
+    workspaceRoot,
+    commandTimeoutMs: parseNumber(
+      resolvedEnv.values.COMMAND_TIMEOUT_MS ?? fileConfig.commandTimeoutMs,
+      30_000,
+    ),
+    maxFileSizeBytes: parseNumber(
+      resolvedEnv.values.MAX_FILE_SIZE_BYTES ?? fileConfig.maxFileSizeBytes,
+      1_000_000,
+    ),
+    commandDenylist: [
+      ...DEFAULT_COMMAND_DENYLIST,
+      ...parseCommandDenylistEnv(resolvedEnv.values.COMMAND_DENYLIST),
+    ],
+    confirmDestructive: parseBoolean(
+      resolvedEnv.values.CONFIRM_DESTRUCTIVE ?? fileConfig.confirmDestructive,
+      false,
+    ),
+    keepRecentMessages: parseNumber(
+      resolvedEnv.values.KEEP_RECENT_MESSAGES ?? fileConfig.keepRecentMessages,
+      12,
+    ),
+    loopDetectionWindow: parseNumber(
+      resolvedEnv.values.LOOP_DETECTION_WINDOW ?? fileConfig.loopDetectionWindow,
+      6,
+    ),
+    maxToolOutputChars: parseNumber(
+      resolvedEnv.values.MAX_TOOL_OUTPUT_CHARS ?? fileConfig.maxToolOutputChars,
+      8_000,
+    ),
+    openAiBaseUrl,
+    ...(openAiApiKey !== undefined ? { openAiApiKey } : {}),
+    enableFileReadDedup: parseBoolean(
+      resolvedEnv.values.ENABLE_FILE_READ_DEDUP ?? fileConfig.enableFileReadDedup,
+      true,
+    ),
+    enableAdaptiveKeepRecent: parseBoolean(
+      resolvedEnv.values.ENABLE_ADAPTIVE_KEEP_RECENT ?? fileConfig.enableAdaptiveKeepRecent,
+      true,
+    ),
+    enableToolOutputTruncation: parseBoolean(
+      resolvedEnv.values.ENABLE_TOOL_OUTPUT_TRUNCATION ?? fileConfig.enableToolOutputTruncation,
+      true,
+    ),
+    compactionThreshold: parseNumber(
+      resolvedEnv.values.COMPACTION_THRESHOLD ?? fileConfig.compactionThreshold,
+      0.8,
+    ),
+    ...(resolvedEnv.values.COMPACTION_MODEL ?? fileConfig.compactionModel
+      ? {
+          compactionModel:
+            resolvedEnv.values.COMPACTION_MODEL ?? fileConfig.compactionModel ?? "",
+        }
+      : {}),
+    ...(() => {
+      const effort = parseReasoningEffort(
+        resolvedEnv.values.REASONING_EFFORT ?? fileConfig.reasoningEffort,
+      );
+      return effort ? { reasoningEffort: effort } : {};
+    })(),
+    enableDynamicPrompt: parseBoolean(
+      resolvedEnv.values.ENABLE_DYNAMIC_PROMPT ?? fileConfig.enableDynamicPrompt,
+      false,
+    ),
+  };
+}

--- a/src/benchmark/index.ts
+++ b/src/benchmark/index.ts
@@ -20,6 +20,21 @@ export {
   type RunnerOptions,
 } from "./runner.js";
 export {
+  buildBenchmarkAgentConfig,
+  getDefaultBenchmarkConfigPath,
+  resolveBenchmarkEnv,
+  type BenchmarkAgentConfigOverrides,
+  type BenchmarkConfigFile,
+  type BenchmarkConfigOptions,
+  type ResolvedBenchmarkEnv,
+} from "./config.js";
+export {
+  collectWorkspaceChanges,
+  writeWorkspaceDiff,
+  type WorkspaceChanges,
+  type WorkspaceStatusEntry,
+} from "./workspace-changes.js";
+export {
   buildReport,
   buildReportFromEvaluations,
   formatReport,

--- a/src/benchmark/workspace-changes.ts
+++ b/src/benchmark/workspace-changes.ts
@@ -1,0 +1,141 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export interface WorkspaceStatusEntry {
+  status: string;
+  path: string;
+  previousPath?: string;
+}
+
+export interface WorkspaceChanges {
+  isGitRepo: boolean;
+  entries: WorkspaceStatusEntry[];
+  changedFiles: string[];
+}
+
+async function runGit(
+  workspaceRoot: string,
+  args: string[],
+  allowFailure = false,
+): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", workspaceRoot, ...args], {
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return stdout;
+  } catch (error) {
+    if (allowFailure) {
+      const stdout = (error as { stdout?: string }).stdout;
+      if (typeof stdout === "string") {
+        return stdout;
+      }
+      return "";
+    }
+    throw error;
+  }
+}
+
+function parseStatusLine(line: string): WorkspaceStatusEntry | undefined {
+  if (line.length < 4) {
+    return undefined;
+  }
+  const status = line.slice(0, 2);
+  const rawPath = line.slice(3).trim();
+  if (!rawPath) {
+    return undefined;
+  }
+  if (rawPath.includes(" -> ")) {
+    const [previousPath, nextPath] = rawPath.split(" -> ");
+    if (!nextPath || !previousPath) {
+      return undefined;
+    }
+    return {
+      status,
+      path: nextPath,
+      previousPath,
+    };
+  }
+  return {
+    status,
+    path: rawPath,
+  };
+}
+
+async function isGitRepository(workspaceRoot: string): Promise<boolean> {
+  try {
+    const output = await runGit(workspaceRoot, ["rev-parse", "--is-inside-work-tree"], true);
+    return output.trim() === "true";
+  } catch {
+    return false;
+  }
+}
+
+export async function collectWorkspaceChanges(workspaceRoot: string): Promise<WorkspaceChanges> {
+  const isGitRepo = await isGitRepository(workspaceRoot);
+  if (!isGitRepo) {
+    return {
+      isGitRepo: false,
+      entries: [],
+      changedFiles: [],
+    };
+  }
+
+  const statusOutput = await runGit(
+    workspaceRoot,
+    ["status", "--porcelain=v1", "--untracked-files=all"],
+    true,
+  );
+  const entries = statusOutput
+    .split(/\r?\n/)
+    .map((line) => parseStatusLine(line))
+    .filter((entry): entry is WorkspaceStatusEntry => entry !== undefined);
+
+  const changedFiles = [...new Set(entries.map((entry) => entry.path))];
+  return {
+    isGitRepo: true,
+    entries,
+    changedFiles,
+  };
+}
+
+export async function writeWorkspaceDiff(
+  workspaceRoot: string,
+  outPath: string,
+): Promise<boolean> {
+  const changes = await collectWorkspaceChanges(workspaceRoot);
+  if (!changes.isGitRepo) {
+    return false;
+  }
+
+  const trackedDiff = await runGit(
+    workspaceRoot,
+    ["diff", "--binary", "--no-ext-diff", "--relative", "--"],
+    true,
+  );
+
+  const untrackedDiffs: string[] = [];
+  for (const entry of changes.entries) {
+    if (entry.status === "??") {
+      const diff = await runGit(
+        workspaceRoot,
+        ["diff", "--binary", "--no-ext-diff", "--no-index", "--", "/dev/null", entry.path],
+        true,
+      );
+      if (diff.trim().length > 0) {
+        untrackedDiffs.push(diff);
+      }
+    }
+  }
+
+  const combinedDiff = [trackedDiff, ...untrackedDiffs]
+    .filter((section) => section.trim().length > 0)
+    .join("\n");
+
+  await mkdir(path.dirname(outPath), { recursive: true });
+  await writeFile(outPath, combinedDiff, "utf8");
+  return true;
+}

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -7,6 +7,8 @@ export interface CliArgs {
   port: number;
   task: string;
   pluginInstall?: boolean;
+  benchmarkRun?: boolean;
+  benchmarkArgv?: string[];
 }
 
 export class CliUsageError extends Error {
@@ -18,6 +20,20 @@ export class CliUsageError extends Error {
 
 export function parseCliArgs(argv: string[]): CliArgs {
   const args = argv.slice(2);
+  if (args[0] === "benchmark" && args[1] === "run") {
+    return {
+      verbose: false,
+      oneshot: false,
+      json: false,
+      serve: false,
+      port: 4567,
+      task: "",
+      pluginInstall: false,
+      benchmarkRun: true,
+      benchmarkArgv: args.slice(2),
+    };
+  }
+
   let verbose = false;
   let oneshot = false;
   let json = false;

--- a/src/cli/benchmark-run.ts
+++ b/src/cli/benchmark-run.ts
@@ -1,0 +1,310 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+import { CodingAgent, createModelClient } from "@minicode/agent-sdk";
+
+import { getConfigSetupMessage } from "../agent/config.js";
+import {
+  buildBenchmarkAgentConfig,
+  resolveBenchmarkEnv,
+} from "../benchmark/config.js";
+import {
+  collectWorkspaceChanges,
+  writeWorkspaceDiff,
+} from "../benchmark/workspace-changes.js";
+import { buildProjectIndex } from "../indexer/project-index.js";
+import { createToolRegistry } from "../tools/registry.js";
+import { CliUsageError } from "./args.js";
+
+export interface BenchmarkRunArgs {
+  prompt: string;
+  promptFile?: string;
+  configPath?: string;
+  envFiles: string[];
+  provider?: string;
+  model?: string;
+  baseUrl?: string;
+  workspaceRoot?: string;
+  diffOut?: string;
+  outFile?: string;
+  verbose: boolean;
+}
+
+export interface BenchmarkRunResult {
+  text: string;
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+  } | null;
+  durationMs: number;
+  startedAt: string;
+  completedAt: string;
+  workspaceRoot: string;
+  provider: "anthropic" | "openai-compatible";
+  model: string;
+  openAiBaseUrl: string;
+  isGitRepo: boolean;
+  changedFiles: string[];
+  diffOut?: string;
+}
+
+function readFlagValue(
+  args: string[],
+  index: number,
+  flagName: string,
+): { value: string; nextIndex: number } {
+  const next = args[index + 1];
+  if (!next || next.startsWith("-")) {
+    throw new CliUsageError(`${flagName} requires a value.`);
+  }
+  return { value: next, nextIndex: index + 1 };
+}
+
+export function parseBenchmarkRunArgs(argv: string[]): BenchmarkRunArgs {
+  const envFiles: string[] = [];
+  const promptParts: string[] = [];
+  let promptFile: string | undefined;
+  let configPath: string | undefined;
+  let provider: string | undefined;
+  let model: string | undefined;
+  let baseUrl: string | undefined;
+  let workspaceRoot: string | undefined;
+  let diffOut: string | undefined;
+  let outFile: string | undefined;
+  let verbose = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === undefined) {
+      continue;
+    }
+
+    if (arg === "--verbose" || arg === "-v") {
+      verbose = true;
+      continue;
+    }
+    if (arg === "--config") {
+      const parsed = readFlagValue(argv, i, "--config");
+      configPath = parsed.value;
+      i = parsed.nextIndex;
+      continue;
+    }
+    if (arg.startsWith("--config=")) {
+      configPath = arg.slice("--config=".length).trim();
+      continue;
+    }
+    if (arg === "--env-file") {
+      const parsed = readFlagValue(argv, i, "--env-file");
+      envFiles.push(parsed.value);
+      i = parsed.nextIndex;
+      continue;
+    }
+    if (arg.startsWith("--env-file=")) {
+      envFiles.push(arg.slice("--env-file=".length).trim());
+      continue;
+    }
+    if (arg === "--provider") {
+      const parsed = readFlagValue(argv, i, "--provider");
+      provider = parsed.value;
+      i = parsed.nextIndex;
+      continue;
+    }
+    if (arg.startsWith("--provider=")) {
+      provider = arg.slice("--provider=".length).trim();
+      continue;
+    }
+    if (arg === "--model") {
+      const parsed = readFlagValue(argv, i, "--model");
+      model = parsed.value;
+      i = parsed.nextIndex;
+      continue;
+    }
+    if (arg.startsWith("--model=")) {
+      model = arg.slice("--model=".length).trim();
+      continue;
+    }
+    if (arg === "--base-url") {
+      const parsed = readFlagValue(argv, i, "--base-url");
+      baseUrl = parsed.value;
+      i = parsed.nextIndex;
+      continue;
+    }
+    if (arg.startsWith("--base-url=")) {
+      baseUrl = arg.slice("--base-url=".length).trim();
+      continue;
+    }
+    if (arg === "--workspace-root") {
+      const parsed = readFlagValue(argv, i, "--workspace-root");
+      workspaceRoot = parsed.value;
+      i = parsed.nextIndex;
+      continue;
+    }
+    if (arg.startsWith("--workspace-root=")) {
+      workspaceRoot = arg.slice("--workspace-root=".length).trim();
+      continue;
+    }
+    if (arg === "--diff-out") {
+      const parsed = readFlagValue(argv, i, "--diff-out");
+      diffOut = parsed.value;
+      i = parsed.nextIndex;
+      continue;
+    }
+    if (arg.startsWith("--diff-out=")) {
+      diffOut = arg.slice("--diff-out=".length).trim();
+      continue;
+    }
+    if (arg === "--out") {
+      const parsed = readFlagValue(argv, i, "--out");
+      outFile = parsed.value;
+      i = parsed.nextIndex;
+      continue;
+    }
+    if (arg.startsWith("--out=")) {
+      outFile = arg.slice("--out=".length).trim();
+      continue;
+    }
+    if (arg === "--prompt-file") {
+      const parsed = readFlagValue(argv, i, "--prompt-file");
+      promptFile = parsed.value;
+      i = parsed.nextIndex;
+      continue;
+    }
+    if (arg.startsWith("--prompt-file=")) {
+      promptFile = arg.slice("--prompt-file=".length).trim();
+      continue;
+    }
+
+    promptParts.push(arg);
+  }
+
+  if (promptFile && promptParts.length > 0) {
+    throw new CliUsageError("Provide either prompt text or --prompt-file, not both.");
+  }
+
+  return {
+    prompt: promptParts.join(" ").trim(),
+    ...(promptFile ? { promptFile } : {}),
+    ...(configPath ? { configPath } : {}),
+    envFiles,
+    ...(provider ? { provider } : {}),
+    ...(model ? { model } : {}),
+    ...(baseUrl ? { baseUrl } : {}),
+    ...(workspaceRoot ? { workspaceRoot } : {}),
+    ...(diffOut ? { diffOut } : {}),
+    ...(outFile ? { outFile } : {}),
+    verbose,
+  };
+}
+
+async function resolvePrompt(args: BenchmarkRunArgs, cwd: string): Promise<string> {
+  if (args.promptFile) {
+    const promptFilePath = path.resolve(cwd, args.promptFile);
+    return (await readFile(promptFilePath, "utf8")).trim();
+  }
+  return args.prompt;
+}
+
+export async function runBenchmarkCommand(argv: string[]): Promise<void> {
+  const cwd = process.cwd();
+  const args = parseBenchmarkRunArgs(argv);
+  const prompt = await resolvePrompt(args, cwd);
+  if (prompt.length === 0) {
+    throw new CliUsageError(
+      "benchmark run requires prompt text or --prompt-file. Example: minicode benchmark run --prompt-file prompt.txt",
+    );
+  }
+
+  const benchmarkOptions = {
+    cwd,
+    envFiles: args.envFiles,
+    env: process.env,
+    ...(args.configPath ? { configPath: args.configPath } : {}),
+  };
+  const resolvedEnv = await resolveBenchmarkEnv(benchmarkOptions);
+  const config = await buildBenchmarkAgentConfig({
+    ...benchmarkOptions,
+    overrides: {
+      ...(args.provider ? { provider: args.provider } : {}),
+      ...(args.model ? { model: args.model } : {}),
+      ...(args.baseUrl ? { baseUrl: args.baseUrl } : {}),
+      ...(args.workspaceRoot ? { workspaceRoot: args.workspaceRoot } : {}),
+    },
+  });
+
+  const previousAnthropicApiKey = process.env.ANTHROPIC_API_KEY;
+  if (resolvedEnv.values.ANTHROPIC_API_KEY !== undefined) {
+    process.env.ANTHROPIC_API_KEY = resolvedEnv.values.ANTHROPIC_API_KEY;
+  }
+
+  try {
+    const setupMessage = getConfigSetupMessage(config);
+    if (setupMessage) {
+      throw new CliUsageError(
+        `${setupMessage}\n\nBenchmark mode does not read ~/.minicode/.env unless you pass it explicitly with --env-file.`,
+      );
+    }
+
+    const modelClient = createModelClient(config);
+    let projectIndex: Awaited<ReturnType<typeof buildProjectIndex>> | undefined;
+    try {
+      projectIndex = await buildProjectIndex(config.workspaceRoot);
+    } catch {
+      projectIndex = undefined;
+    }
+
+    const toolRegistry = createToolRegistry(config, projectIndex);
+    const agent = new CodingAgent({
+      config,
+      modelClient,
+      toolRegistry,
+      verbose: args.verbose,
+      ...(projectIndex !== undefined
+        ? { getCodeMap: (focusSymbols?: Set<string>) => projectIndex.getCodeMap(undefined, focusSymbols) }
+        : {}),
+    });
+
+    const startedAt = new Date().toISOString();
+    const started = performance.now();
+    const { text, usage } = await agent.runTurn(prompt);
+    const durationMs = performance.now() - started;
+    const completedAt = new Date().toISOString();
+
+    const changes = await collectWorkspaceChanges(config.workspaceRoot);
+    let diffOutPath: string | undefined;
+    if (args.diffOut) {
+      diffOutPath = path.resolve(cwd, args.diffOut);
+      await writeWorkspaceDiff(config.workspaceRoot, diffOutPath);
+    }
+
+    const result: BenchmarkRunResult = {
+      text,
+      usage: usage ?? null,
+      durationMs,
+      startedAt,
+      completedAt,
+      workspaceRoot: config.workspaceRoot,
+      provider: config.modelProvider,
+      model: config.model,
+      openAiBaseUrl: config.openAiBaseUrl,
+      isGitRepo: changes.isGitRepo,
+      changedFiles: changes.changedFiles,
+      ...(diffOutPath ? { diffOut: diffOutPath } : {}),
+    };
+    const payload = JSON.stringify(result, null, 2);
+
+    if (args.outFile) {
+      const outPath = path.resolve(cwd, args.outFile);
+      await mkdir(path.dirname(outPath), { recursive: true });
+      await writeFile(outPath, payload + "\n", "utf8");
+    } else {
+      console.log(payload);
+    }
+  } finally {
+    if (previousAnthropicApiKey === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = previousAnthropicApiKey;
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -346,6 +346,13 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (cliArgs.benchmarkRun) {
+    const { runBenchmarkCommand } = await import("./cli/benchmark-run.js");
+    await runBenchmarkCommand(cliArgs.benchmarkArgv ?? []);
+    process.exitCode = EXIT_CODE_SUCCESS;
+    return;
+  }
+
   if (cliArgs.serve) {
     const { runServe } = await import("./serve/server.js");
     await runServe(cliArgs.verbose, cliArgs.port);

--- a/tests/benchmark-config.test.ts
+++ b/tests/benchmark-config.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, test } from "node:test";
+
+import {
+  buildBenchmarkAgentConfig,
+  getDefaultBenchmarkConfigPath,
+} from "../src/benchmark/config.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+test("getDefaultBenchmarkConfigPath resolves under benchmarks/", () => {
+  const repoRoot = "/tmp/minicode-repo";
+  assert.equal(
+    getDefaultBenchmarkConfigPath(repoRoot),
+    path.join(repoRoot, "benchmarks", "benchmark.config.json"),
+  );
+});
+
+test("buildBenchmarkAgentConfig uses config, env files, shell env, and CLI overrides in precedence order", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "minicode-benchmark-config-"));
+  tempDirs.push(repoRoot);
+
+  const configPath = path.join(repoRoot, "benchmarks", "benchmark.config.json");
+  const envFilePath = path.join(repoRoot, "benchmarks", "benchmark.env");
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      modelProvider: "openai-compatible",
+      model: "config-model",
+      openAiBaseUrl: "https://config.example/v1",
+      workspaceRoot: "./config-workspace",
+      maxSteps: 11,
+      maxContextTokens: 12000,
+      commandTimeoutMs: 4000,
+      enableDynamicPrompt: true,
+    }),
+    "utf8",
+  );
+  await writeFile(
+    envFilePath,
+    [
+      "MODEL=env-file-model",
+      "OPENAI_BASE_URL=https://env-file.example/v1",
+      "OPENAI_API_KEY=env-file-key",
+      "MAX_STEPS=22",
+      "ENABLE_DYNAMIC_PROMPT=true",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const config = await buildBenchmarkAgentConfig({
+    cwd: repoRoot,
+    configPath: path.relative(repoRoot, configPath),
+    envFiles: [path.relative(repoRoot, envFilePath)],
+    env: {
+      MODEL: "shell-model",
+      MAX_STEPS: "33",
+      MAX_CONTEXT_TOKENS: "24000",
+      OPENAI_API_KEY: "shell-key",
+    },
+    overrides: {
+      model: "override-model",
+      baseUrl: "https://override.example/v1",
+      workspaceRoot: "./override-workspace",
+    },
+  });
+
+  assert.equal(config.modelProvider, "openai-compatible");
+  assert.equal(config.model, "override-model");
+  assert.equal(config.openAiBaseUrl, "https://override.example/v1");
+  assert.equal(config.workspaceRoot, path.join(repoRoot, "override-workspace"));
+  assert.equal(config.maxSteps, 33);
+  assert.equal(config.maxContextTokens, 24000);
+  assert.equal(config.commandTimeoutMs, 4000);
+  assert.equal(config.openAiApiKey, "shell-key");
+  assert.equal(config.enableDynamicPrompt, true);
+});
+
+test("buildBenchmarkAgentConfig does not require a default config file", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "minicode-benchmark-config-"));
+  tempDirs.push(repoRoot);
+
+  const config = await buildBenchmarkAgentConfig({
+    cwd: repoRoot,
+    env: {
+      MODEL_PROVIDER: "openai-compatible",
+      MODEL: "standalone-model",
+      OPENAI_BASE_URL: "http://localhost:1234/v1",
+    },
+  });
+
+  assert.equal(config.modelProvider, "openai-compatible");
+  assert.equal(config.model, "standalone-model");
+  assert.equal(config.openAiBaseUrl, "http://localhost:1234/v1");
+  assert.equal(config.maxSteps, 50);
+  assert.equal(config.enableDynamicPrompt, false);
+});

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -54,6 +54,30 @@ test("parseCliArgs supports --json and --out path", () => {
   assert.equal(parsed.task, "summarize todos");
 });
 
+test("parseCliArgs detects benchmark run and preserves subcommand argv", () => {
+  const parsed = parseCliArgs([
+    "node",
+    "src/index.ts",
+    "benchmark",
+    "run",
+    "--config",
+    "benchmarks/custom.json",
+    "--model",
+    "test-model",
+    "solve task",
+  ]);
+
+  assert.equal(parsed.benchmarkRun, true);
+  assert.deepEqual(parsed.benchmarkArgv, [
+    "--config",
+    "benchmarks/custom.json",
+    "--model",
+    "test-model",
+    "solve task",
+  ]);
+  assert.equal(parsed.task, "");
+});
+
 test("parseCliArgs supports --out=<file>", () => {
   const parsed = parseCliArgs([
     "node",

--- a/tests/cli-oneshot.integration.test.ts
+++ b/tests/cli-oneshot.integration.test.ts
@@ -28,3 +28,9 @@ test("oneshot mode exits with usage code when --out has no value", () => {
   assert.equal(result.status, 2);
   assert.match(result.stderr, /--out requires a file path/);
 });
+
+test("benchmark run exits with usage code when prompt is missing", () => {
+  const result = runCli(["benchmark", "run"]);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /benchmark run requires prompt text or --prompt-file/);
+});

--- a/tests/workspace-changes.test.ts
+++ b/tests/workspace-changes.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, test } from "node:test";
+
+import {
+  collectWorkspaceChanges,
+  writeWorkspaceDiff,
+} from "../src/benchmark/workspace-changes.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createGitWorkspace(): Promise<string> {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "minicode-workspace-changes-"));
+  tempDirs.push(workspaceRoot);
+
+  execFileSync("git", ["init"], { cwd: workspaceRoot, stdio: "ignore" });
+  execFileSync("git", ["config", "user.name", "Codex"], { cwd: workspaceRoot, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "codex@example.com"], { cwd: workspaceRoot, stdio: "ignore" });
+
+  await mkdir(path.join(workspaceRoot, "src"), { recursive: true });
+  await writeFile(path.join(workspaceRoot, "src", "app.ts"), "export const value = 1;\n", "utf8");
+  execFileSync("git", ["add", "."], { cwd: workspaceRoot, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: workspaceRoot, stdio: "ignore" });
+
+  return workspaceRoot;
+}
+
+test("collectWorkspaceChanges returns changed files for tracked and untracked edits", async () => {
+  const workspaceRoot = await createGitWorkspace();
+  await writeFile(path.join(workspaceRoot, "src", "app.ts"), "export const value = 2;\n", "utf8");
+  await writeFile(path.join(workspaceRoot, "README.md"), "# test\n", "utf8");
+
+  const changes = await collectWorkspaceChanges(workspaceRoot);
+
+  assert.equal(changes.isGitRepo, true);
+  assert.deepEqual(changes.changedFiles.sort(), ["README.md", "src/app.ts"]);
+});
+
+test("writeWorkspaceDiff writes a patch artifact for tracked and untracked changes", async () => {
+  const workspaceRoot = await createGitWorkspace();
+  await writeFile(path.join(workspaceRoot, "src", "app.ts"), "export const value = 2;\n", "utf8");
+  await writeFile(path.join(workspaceRoot, "README.md"), "# test\n", "utf8");
+
+  const diffPath = path.join(workspaceRoot, "artifacts", "result.patch");
+  const wrote = await writeWorkspaceDiff(workspaceRoot, diffPath);
+  const diff = await readFile(diffPath, "utf8");
+
+  assert.equal(wrote, true);
+  assert.match(diff, /diff --git a\/src\/app\.ts b\/src\/app\.ts/);
+  assert.match(diff, /diff --git a\/README\.md b\/README\.md/);
+});


### PR DESCRIPTION
## Summary
- add a dedicated `minicode benchmark run` CLI entrypoint for external eval harnesses
- add benchmark-only config and workspace diff helpers that avoid `~/.minicode/.env` by default
- document the benchmark runtime flow and add regression coverage for config precedence, CLI usage, and patch capture

## Testing
- npm run build
- npm run lint
- TMPDIR=/tmp TEMP=/tmp TMP=/tmp npm test
