### PR TITLE
Support async plugin methods for language servers and WASM parsers

### DIFF
--- a/docs/PLUGIN_SPEC.md
+++ b/docs/PLUGIN_SPEC.md
@@ -158,6 +158,30 @@ interface DependencyEdge {
 
 ---
 
+## Choosing an approach
+
+`indexFile` and `resolveDependencies` are unconstrained — implement them with an AST parser, a language server, regex, or anything else. The right tool depends on what each method actually needs to do:
+
+- `indexFile` is single-file and structural ("extract symbols, signatures, and line ranges from this string"). An in-process parser — the language's own compiler API or a grammar-based parser — maps directly onto this shape and stays sync.
+- `resolveDependencies` is whole-project and semantic. Heuristic AST analysis works well for statically-typed languages; precise cross-file resolution or dynamic-language accuracy is where an external semantic source (e.g. a language server) starts to pay off.
+
+A reasonable default for a new plugin: in-process AST for both, accepting that `resolveDependencies` will be heuristic. Reach for an external/async source when heuristics produce too many false matches, when you need cross-file type information you can't get from a single file, or when an authoritative source (one your users already run) is available.
+
+Properties to weigh:
+
+| Dimension | In-process AST | External (async) source |
+|-----------|----------------|-------------------------|
+| Startup time | Negligible | Seconds, sometimes much longer |
+| Memory | Bounded by file size | Often substantial |
+| Dependencies | A library | A server or binary the user must install |
+| Sync/async | Naturally sync | Inherently async |
+| Cross-file accuracy | Heuristic | Authoritative |
+| Failure mode | Bad parse → no symbols | Process crash, retries, version drift |
+
+Both options satisfy the contract; pick whichever fits your language and constraints.
+
+---
+
 ## Step-by-Step: Creating a Plugin
 
 ### 1. Set up the project

--- a/docs/PLUGIN_SPEC.md
+++ b/docs/PLUGIN_SPEC.md
@@ -32,16 +32,21 @@ interface LanguagePlugin {
   /** Return true if this plugin can index the given file path */
   canIndex(filePath: string): boolean;
 
-  /** Parse file content and return extracted symbols */
-  indexFile(filePath: string, content: string): IndexedSymbol[];
+  /** Parse file content and return extracted symbols. May be sync or async. */
+  indexFile(
+    filePath: string,
+    content: string,
+  ): IndexedSymbol[] | Promise<IndexedSymbol[]>;
 
-  /** Optional: resolve dependency edges between symbols (for find_references, get_dependencies) */
+  /** Optional: resolve dependency edges between symbols (for find_references, get_dependencies). May be sync or async. */
   resolveDependencies?(
     symbols: IndexedSymbol[],
     projectFiles: Map<string, string>,
-  ): DependencyEdge[];
+  ): DependencyEdge[] | Promise<DependencyEdge[]>;
 }
 ```
+
+Both `indexFile` and `resolveDependencies` may return either a value or a `Promise`. The host always awaits the result, so plugins backed by async sources — language servers (LSP), network calls, or parsers with async initialization (e.g. tree-sitter WASM) — can return promises without changing how they're consumed. Sync plugins continue to return arrays directly.
 
 ### `canIndex(filePath: string): boolean`
 

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -203,13 +203,13 @@ When integrating with a project indexer, use `CoreToolHooks` to get notified aft
 import { ToolRegistry } from "@minicode/agent-sdk";
 
 const toolRegistry = ToolRegistry.createDefault(config, {
-  afterWrite: (relativePath, content) => {
+  afterWrite: async (relativePath, content) => {
     // Re-index the file after it's written
-    projectIndex.reindexFile(relativePath, content);
+    await projectIndex.reindexFile(relativePath, content);
   },
-  afterEdit: (relativePath, content) => {
+  afterEdit: async (relativePath, content) => {
     // Re-index the file after it's edited
-    projectIndex.reindexFile(relativePath, content);
+    await projectIndex.reindexFile(relativePath, content);
   },
 });
 ```

--- a/packages/agent-sdk/src/indexer/types.ts
+++ b/packages/agent-sdk/src/indexer/types.ts
@@ -50,16 +50,24 @@ export interface DependencyEdge {
 
 /**
  * Contract for language-specific indexer plugins.
+ *
+ * `indexFile` and `resolveDependencies` may return either a value or a Promise;
+ * the host awaits the result, so plugins backed by async sources (LSP, network,
+ * WASM parsers with async init) can return promises while sync plugins continue
+ * to return arrays directly.
  */
 export interface LanguagePlugin {
   name: string;
   extensions: string[];
   canIndex(filePath: string): boolean;
-  indexFile(filePath: string, content: string): IndexedSymbol[];
+  indexFile(
+    filePath: string,
+    content: string,
+  ): IndexedSymbol[] | Promise<IndexedSymbol[]>;
   resolveDependencies?(
     symbols: IndexedSymbol[],
     projectFiles: Map<string, string>,
-  ): DependencyEdge[];
+  ): DependencyEdge[] | Promise<DependencyEdge[]>;
 }
 
 /**
@@ -95,7 +103,7 @@ export interface ProjectIndex {
   findPathToEntryPoint(symbolName: string, maxDepth?: number): IndexedSymbol[][];
 
   /** Re-index a file after it has been modified. Updates symbols and dependency edges. */
-  reindexFile(filePath: string, content: string): void;
+  reindexFile(filePath: string, content: string): Promise<void>;
 
   /** Re-scan the workspace from disk and rebuild indexed files, symbols, and dependency edges in place. */
   refreshFromWorkspace(): Promise<void>;

--- a/packages/agent-sdk/src/tools/edit-file.ts
+++ b/packages/agent-sdk/src/tools/edit-file.ts
@@ -31,7 +31,9 @@ function countOccurrences(haystack: string, needle: string): number {
 }
 
 export interface EditFileHooks {
-  afterEdit?: ((filePath: string, content: string) => void) | undefined;
+  afterEdit?:
+    | ((filePath: string, content: string) => void | Promise<void>)
+    | undefined;
 }
 
 export function createEditFileTool(
@@ -85,7 +87,7 @@ export function createEditFileTool(
       await writeFile(filePath, updated, "utf8");
 
       if (hooks?.afterEdit) {
-        hooks.afterEdit(filePath, updated);
+        await hooks.afterEdit(filePath, updated);
       }
 
       return `Updated "${requestedPath}" successfully.`;

--- a/packages/agent-sdk/src/tools/write-file.ts
+++ b/packages/agent-sdk/src/tools/write-file.ts
@@ -14,7 +14,9 @@ function expectString(input: Record<string, unknown>, key: string): string {
 }
 
 export interface WriteFileHooks {
-  afterWrite?: ((filePath: string, content: string) => void) | undefined;
+  afterWrite?:
+    | ((filePath: string, content: string) => void | Promise<void>)
+    | undefined;
 }
 
 export function createWriteFileTool(
@@ -49,7 +51,7 @@ export function createWriteFileTool(
       await writeFile(filePath, content, "utf8");
 
       if (hooks?.afterWrite) {
-        hooks.afterWrite(filePath, content);
+        await hooks.afterWrite(filePath, content);
       }
 
       return `Wrote ${content.length} characters to "${requestedPath}".`;

--- a/src/indexer/plugins/typescript.ts
+++ b/src/indexer/plugins/typescript.ts
@@ -74,7 +74,7 @@ function extractJSDoc(node: ts.Node, sourceFile: ts.SourceFile): string | undefi
   return cleaned.length > 0 ? cleaned : undefined;
 }
 
-function createPlugin(): LanguagePlugin {
+function createPlugin() {
   const astCache = new Map<string, ts.SourceFile>();
 
   return {
@@ -495,4 +495,4 @@ function createPlugin(): LanguagePlugin {
   };
 }
 
-export const typescriptPlugin: LanguagePlugin = createPlugin();
+export const typescriptPlugin = createPlugin() satisfies LanguagePlugin;

--- a/src/indexer/project-index.ts
+++ b/src/indexer/project-index.ts
@@ -116,11 +116,11 @@ export function createProjectIndex(
     }
   }
 
-  function rebuildDependencyEdges(): void {
+  async function rebuildDependencyEdges(): Promise<void> {
     for (const p of plugins) {
       if (p.resolveDependencies) {
         const allSymbols = [...symbols.values()];
-        const edges = p.resolveDependencies(allSymbols, projectFiles);
+        const edges = await p.resolveDependencies(allSymbols, projectFiles);
         dependencyEdges.splice(0, dependencyEdges.length, ...edges);
         adjacencyFrom = buildAdjacencyFrom(dependencyEdges);
         break;
@@ -149,12 +149,12 @@ export function createProjectIndex(
       }
 
       projectFiles.set(relPath, content);
-      const extracted = plugin.indexFile(relPath, content);
+      const extracted = await plugin.indexFile(relPath, content);
       files.set(relPath, extracted);
     }
 
     rebuildSymbolsMap();
-    rebuildDependencyEdges();
+    await rebuildDependencyEdges();
   }
 
   return {
@@ -323,7 +323,7 @@ export function createProjectIndex(
       return generateCodeMap(files, tokenBudget, dependencyEdges, focusSymbols);
     },
 
-    reindexFile(filePath: string, content: string): void {
+    async reindexFile(filePath: string, content: string): Promise<void> {
       const relPath = path.isAbsolute(filePath)
         ? path.relative(workspaceRoot, filePath)
         : path.normalize(filePath);
@@ -334,10 +334,10 @@ export function createProjectIndex(
       files.delete(relPath);
 
       projectFiles.set(relPath, content);
-      const extracted = plugin.indexFile(relPath, content);
+      const extracted = await plugin.indexFile(relPath, content);
       files.set(relPath, extracted);
       rebuildSymbolsMap();
-      rebuildDependencyEdges();
+      await rebuildDependencyEdges();
     },
 
     refreshFromWorkspace,
@@ -374,7 +374,7 @@ export async function buildProjectIndex(
     }
 
     projectFiles.set(relPath, content);
-    const extracted = plugin.indexFile(relPath, content);
+    const extracted = await plugin.indexFile(relPath, content);
     files.set(relPath, extracted);
   }
 
@@ -388,7 +388,7 @@ export async function buildProjectIndex(
   for (const plugin of plugins) {
     if (plugin.resolveDependencies) {
       const allSymbols = [...symbols.values()];
-      const edges = plugin.resolveDependencies(allSymbols, projectFiles);
+      const edges = await plugin.resolveDependencies(allSymbols, projectFiles);
       dependencyEdges = edges;
       break;
     }

--- a/src/serve/agent-bridge.ts
+++ b/src/serve/agent-bridge.ts
@@ -225,7 +225,7 @@ export class AgentBridge {
     const absPath = path.resolve(this.config.workspaceRoot, relPath);
     try {
       const content = await readFile(absPath, "utf-8");
-      this.projectIndex.reindexFile(relPath, content);
+      await this.projectIndex.reindexFile(relPath, content);
       if (this.verbose) {
         console.error(`[watch] Reindexed: ${relPath}`);
       }

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -17,6 +17,18 @@ import { createSearchCodeMapTool } from "./search-code-map.js";
 
 export { ToolRegistry };
 
+async function reindexBestEffort(
+  projectIndex: ProjectIndex,
+  relPath: string,
+  content: string,
+): Promise<void> {
+  try {
+    await projectIndex.reindexFile(relPath, content);
+  } catch {
+    // Best effort only: the file mutation already succeeded.
+  }
+}
+
 /**
  * Create a ToolRegistry with the SDK's core tools plus indexer-specific tools
  * when a ProjectIndex is available.
@@ -28,9 +40,9 @@ export function createToolRegistry(
   const hooks = projectIndex
     ? {
         afterWrite: (relPath: string, content: string) =>
-          projectIndex.reindexFile(relPath, content),
+          reindexBestEffort(projectIndex, relPath, content),
         afterEdit: (relPath: string, content: string) =>
-          projectIndex.reindexFile(relPath, content),
+          reindexBestEffort(projectIndex, relPath, content),
         afterCommand: async () => {
           await projectIndex.refreshFromWorkspace();
         },

--- a/tests/file-tools.test.ts
+++ b/tests/file-tools.test.ts
@@ -6,6 +6,7 @@ import { test } from "node:test";
 
 import { createEditFileTool, createReadFileTool, createRunCommandTool, createWriteFileTool } from "@minicode/agent-sdk";
 import { buildProjectIndex } from "../src/indexer/project-index.js";
+import { createToolRegistry } from "../src/tools/registry.js";
 import { createTestAgentConfig } from "./test-utils.js";
 
 async function createTempWorkspace(): Promise<string> {
@@ -94,6 +95,54 @@ test("write_file triggers reindex when projectIndex provided", async () => {
 
   const added = index.getSymbol("add");
   assert.ok(added?.signature.includes("a: number, b: number"), "index should reflect newly written file");
+});
+
+test("write_file succeeds even when post-write reindex fails", async () => {
+  const workspaceRoot = await createTempWorkspace();
+  const index = await buildProjectIndex(workspaceRoot);
+  index.reindexFile = async () => {
+    throw new Error("reindex failed");
+  };
+
+  const registry = createToolRegistry(createTestAgentConfig(workspaceRoot), index);
+
+  const result = await registry.execute("write_file", {
+    path: "src/util.ts",
+    content: `export function add(a: number, b: number): number {\n  return a + b;\n}\n`,
+  });
+
+  assert.match(result, /Wrote \d+ characters to "src\/util\.ts"\./);
+  const written = await readFile(path.join(workspaceRoot, "src", "util.ts"), "utf8");
+  assert.match(written, /export function add/);
+});
+
+test("edit_file succeeds even when post-edit reindex fails", async () => {
+  const workspaceRoot = await createTempWorkspace();
+  const { mkdir } = await import("node:fs/promises");
+  const filePath = path.join(workspaceRoot, "src", "util.ts");
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(
+    filePath,
+    `export function add(a: number, b: number): number {\n  return a + b;\n}\n`,
+    "utf8",
+  );
+
+  const index = await buildProjectIndex(workspaceRoot);
+  index.reindexFile = async () => {
+    throw new Error("reindex failed");
+  };
+
+  const registry = createToolRegistry(createTestAgentConfig(workspaceRoot), index);
+
+  const result = await registry.execute("edit_file", {
+    path: "src/util.ts",
+    old_string: "return a + b;",
+    new_string: "return a + b + 1;",
+  });
+
+  assert.match(result, /Updated "src\/util\.ts" successfully\./);
+  const updated = await readFile(filePath, "utf8");
+  assert.match(updated, /return a \+ b \+ 1;/);
 });
 
 test("run_command refreshes index after shell-created file changes", async () => {

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -248,7 +248,7 @@ test("reindexFile updates symbols and code map after file change", async () => {
   return title ? \`Hello, \${title} \${name}\` : \`Hello, \${name}\`;
 }
 `;
-  index.reindexFile("sample.ts", updatedContent);
+  await index.reindexFile("sample.ts", updatedContent);
 
   const updatedSym = index.getSymbol("greet");
   assert.ok(updatedSym, "should still find greet");


### PR DESCRIPTION
## Summary
Enable language plugins to implement `indexFile` and `resolveDependencies` as async methods, allowing plugins to integrate with language servers (LSP), network-based semantic sources, and WASM parsers with async initialization. Sync plugins continue to work unchanged.

## Key Changes

- **Plugin interface updates**: Modified `LanguagePlugin.indexFile()` and `LanguagePlugin.resolveDependencies()` to return `T | Promise<T>`, allowing both sync and async implementations
- **Host awaiting**: Updated all call sites in `project-index.ts` and `buildProjectIndex()` to `await` plugin method results, making the host agnostic to whether plugins are sync or async
- **API surface changes**: 
  - `ProjectIndex.reindexFile()` is now async (`Promise<void>`)
  - `CoreToolHooks.afterWrite` and `afterEdit` callbacks now support async functions
- **Documentation**: Added comprehensive guidance in `PLUGIN_SPEC.md` explaining when to use in-process AST vs. external/async sources, with a comparison table of tradeoffs
- **Implementation updates**: Updated all call sites (`agent-bridge.ts`, `edit-file.ts`, `write-file.ts`, test files) to properly await async operations

## Notable Details

- The change is **backward compatible**: existing sync plugins continue to work without modification
- The host always awaits results, so plugins can transparently return either values or promises
- Added detailed documentation explaining the design choice and helping plugin authors decide between sync AST parsing and async external sources
- Type safety is maintained through union return types (`T | Promise<T>`)

https://claude.ai/code/session_012ajRQHucZRbcE39L9E75nw