### PR TITLE
Integrate minicode with ts-bench

### DIFF
--- a/benchmarks/ts-bench/README.md
+++ b/benchmarks/ts-bench/README.md
@@ -1,0 +1,116 @@
+# `ts-bench` Integration
+
+This directory documents how to run `minicode` against [`ts-bench`](https://github.com/laiso/ts-bench) without changing the product runtime.
+
+The integration has two moving parts:
+
+- [`scripts/ts-bench-adapter.ts`](../../scripts/ts-bench-adapter.ts) patches a local `ts-bench` checkout to register `minicode` as an agent.
+- [`scripts/run-ts-bench-smoke.ts`](../../scripts/run-ts-bench-smoke.ts) points that checkout at the current local `minicode` branch through a repo-local shim and runs a smoke exercise.
+
+## Clone `ts-bench`
+
+```bash
+git clone https://github.com/laiso/ts-bench.git /tmp/ts-bench
+```
+
+## Patch the checkout
+
+```bash
+source ~/.nvm/nvm.sh
+nvm use 22 >/dev/null
+node --import tsx scripts/ts-bench-adapter.ts --ts-bench-path /tmp/ts-bench
+```
+
+This patches the local `ts-bench` checkout in place:
+
+- `src/agents/registry.ts`
+- `scripts/agents.json`
+- `src/site/shared/format.ts`
+- `src/utils/version-detector.ts`
+- `src/utils/leaderboard-generator.ts`
+
+## Smoke run
+
+```bash
+source ~/.nvm/nvm.sh
+nvm use 22 >/dev/null
+node --import tsx scripts/run-ts-bench-smoke.ts \
+  --ts-bench-path /tmp/ts-bench \
+  --exercise acronym \
+  --provider openrouter \
+  --model google/gemini-3-flash-preview \
+  --env-file ~/.minicode/.env \
+  --install-deps
+```
+
+What this does:
+
+- builds the current `minicode` branch unless `--skip-build` is passed
+- patches the target `ts-bench` checkout
+- creates `/tmp/ts-bench/.minicode-local-bin/minicode` as a shim to the current local `dist/src/index.js`
+- sets `MINICODE_BENCHMARK_CONFIG` to [`benchmarks/benchmark.config.json`](../benchmark.config.json)
+- optionally forwards a dotenv file through `MINICODE_BENCHMARK_ENV_FILE`
+- runs:
+
+```bash
+bun src/index.ts \
+  --agent minicode \
+  --version local-dev \
+  --dataset v1 \
+  --exercise acronym \
+  --provider openrouter \
+  --model google/gemini-3-flash-preview \
+  --output-format json
+```
+
+## Supported providers
+
+The `minicode` adapter currently supports:
+
+- `openrouter`
+- `openai`
+- `anthropic`
+
+Provider mapping inside `ts-bench`:
+
+- `openrouter` -> `minicode benchmark run --provider openai-compatible --base-url https://openrouter.ai/api/v1`
+- `openai` -> `minicode benchmark run --provider openai-compatible --base-url https://api.openai.com/v1`
+- `anthropic` -> `minicode benchmark run --provider anthropic`
+
+## Benchmark env knobs
+
+The adapter passes through these optional env vars when you want to tune the run from the benchmark layer:
+
+- `MINICODE_BENCHMARK_CONFIG`
+- `MINICODE_BENCHMARK_ENV_FILE`
+- `MINICODE_OPENROUTER_BASE_URL`
+- `MINICODE_OPENAI_BASE_URL`
+- `MINICODE_BENCHMARK_MAX_STEPS`
+- `MINICODE_BENCHMARK_MAX_CONTEXT_TOKENS`
+- `MINICODE_BENCHMARK_COMMAND_TIMEOUT_MS`
+- `MINICODE_BENCHMARK_MODEL_TIMEOUT_SECONDS`
+- `MINICODE_BENCHMARK_MAX_TOOL_OUTPUT_CHARS`
+
+## Comparison lanes
+
+### `common-model`
+
+Use the same provider/model pairing across every agent that can support it. For the first pass we should prefer a broadly available OpenRouter model so the harness is testing the agent shell more than model differences.
+
+Example target:
+
+- provider: `openrouter`
+- model: `google/gemini-3-flash-preview`
+
+### `native-best`
+
+Run each agent with the provider/model combo that best matches how users are most likely to evaluate it in the wild.
+
+Examples:
+
+- `minicode`: OpenRouter + `google/gemini-3-flash-preview`
+- `Claude Code`: Anthropic + a current Claude model
+- `Codex CLI`: OpenAI + a current Codex model
+- `OpenCode`: its strongest supported default pairing
+
+Keep these results separate from `common-model` so we do not blur harness quality with provider/model differences.

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -91,3 +91,5 @@ minicode benchmark run \
 ```
 
 This is the recommended surface for integrating minicode with `ts-bench`, Harbor-based benchmarks like CCBench, and future patch-based evaluators.
+
+For the concrete `ts-bench` workflow, see [`benchmarks/ts-bench/README.md`](../benchmarks/ts-bench/README.md).

--- a/scripts/run-ts-bench-smoke.ts
+++ b/scripts/run-ts-bench-smoke.ts
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+
+import { chmod, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { parse as parseDotenv } from "dotenv";
+
+import { applyTsBenchMinicodeAdapter } from "./ts-bench-adapter.js";
+
+interface TsBenchSmokeArgs {
+  tsBenchPath: string;
+  exercise: string;
+  provider: "openrouter" | "openai" | "anthropic";
+  model: string;
+  envFile?: string;
+  skipBuild: boolean;
+  installDeps: boolean;
+  dryRun: boolean;
+}
+
+function readFlagValue(args: string[], index: number, flagName: string): { value: string; nextIndex: number } {
+  const next = args[index + 1];
+  if (!next || next.startsWith("-")) {
+    throw new Error(`${flagName} requires a value.`);
+  }
+  return { value: next, nextIndex: index + 1 };
+}
+
+export function parseTsBenchSmokeArgs(argv: string[]): TsBenchSmokeArgs {
+  let tsBenchPath: string | undefined;
+  let exercise = "acronym";
+  let provider: TsBenchSmokeArgs["provider"] = "openrouter";
+  let model: string | undefined;
+  let envFile: string | undefined;
+  let skipBuild = false;
+  let installDeps = false;
+  let dryRun = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === undefined) {
+      continue;
+    }
+
+    if (arg === "--skip-build") {
+      skipBuild = true;
+      continue;
+    }
+    if (arg === "--install-deps") {
+      installDeps = true;
+      continue;
+    }
+    if (arg === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (arg === "--ts-bench-path") {
+      const parsed = readFlagValue(argv, i, "--ts-bench-path");
+      tsBenchPath = parsed.value;
+      i = parsed.nextIndex;
+      continue;
+    }
+    if (arg.startsWith("--ts-bench-path=")) {
+      tsBenchPath = arg.slice("--ts-bench-path=".length).trim();
+      continue;
+    }
+    if (arg === "--exercise") {
+      const parsed = readFlagValue(argv, i, "--exercise");
+      exercise = parsed.value;
+      i = parsed.nextIndex;
+      continue;
+    }
+    if (arg.startsWith("--exercise=")) {
+      exercise = arg.slice("--exercise=".length).trim();
+      continue;
+    }
+    if (arg === "--provider") {
+      const parsed = readFlagValue(argv, i, "--provider");
+      const value = parsed.value as TsBenchSmokeArgs["provider"];
+      if (value !== "openrouter" && value !== "openai" && value !== "anthropic") {
+        throw new Error(`Unsupported --provider ${parsed.value}. Use openrouter, openai, or anthropic.`);
+      }
+      provider = value;
+      i = parsed.nextIndex;
+      continue;
+    }
+    if (arg.startsWith("--provider=")) {
+      const value = arg.slice("--provider=".length).trim() as TsBenchSmokeArgs["provider"];
+      if (value !== "openrouter" && value !== "openai" && value !== "anthropic") {
+        throw new Error(`Unsupported --provider ${value}. Use openrouter, openai, or anthropic.`);
+      }
+      provider = value;
+      continue;
+    }
+    if (arg === "--model") {
+      const parsed = readFlagValue(argv, i, "--model");
+      model = parsed.value;
+      i = parsed.nextIndex;
+      continue;
+    }
+    if (arg.startsWith("--model=")) {
+      model = arg.slice("--model=".length).trim();
+      continue;
+    }
+    if (arg === "--env-file") {
+      const parsed = readFlagValue(argv, i, "--env-file");
+      envFile = parsed.value;
+      i = parsed.nextIndex;
+      continue;
+    }
+    if (arg.startsWith("--env-file=")) {
+      envFile = arg.slice("--env-file=".length).trim();
+      continue;
+    }
+  }
+
+  if (!tsBenchPath) {
+    throw new Error("--ts-bench-path is required.");
+  }
+  if (!model) {
+    throw new Error("--model is required.");
+  }
+
+  return {
+    tsBenchPath,
+    exercise,
+    provider,
+    model,
+    ...(envFile ? { envFile } : {}),
+    skipBuild,
+    installDeps,
+    dryRun,
+  };
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    env?: NodeJS.ProcessEnv;
+  },
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: "inherit",
+    });
+
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} ${args.join(" ")} exited with code ${code ?? "unknown"}.`));
+      }
+    });
+  });
+}
+
+function buildStablePath(extraDirs: string[] = []): string {
+  const segments = (process.env.PATH ?? "")
+    .split(path.delimiter)
+    .filter((segment) => segment.length > 0 && !segment.startsWith("/mnt/"));
+  const ordered = [
+    ...extraDirs,
+    path.join(homedir(), ".bun", "bin"),
+    path.dirname(process.execPath),
+    ...segments,
+    "/usr/local/sbin",
+    "/usr/local/bin",
+    "/usr/sbin",
+    "/usr/bin",
+    "/sbin",
+    "/bin",
+  ];
+
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const segment of ordered) {
+    if (segment.length === 0 || seen.has(segment)) {
+      continue;
+    }
+    seen.add(segment);
+    deduped.push(segment);
+  }
+
+  return deduped.join(path.delimiter);
+}
+
+async function ensureFileExists(filePath: string, label: string): Promise<void> {
+  try {
+    const details = await stat(filePath);
+    if (!details.isFile()) {
+      throw new Error(`${label} is not a file: ${filePath}`);
+    }
+  } catch {
+    throw new Error(`${label} was not found at ${filePath}`);
+  }
+}
+
+export async function createLocalMinicodeShim(tsBenchRoot: string, repoRoot: string): Promise<string> {
+  const shimDir = path.join(tsBenchRoot, ".minicode-local-bin");
+  const shimPath = path.join(shimDir, "minicode");
+  const entryPath = path.join(repoRoot, "dist", "src", "index.js");
+  await ensureFileExists(entryPath, "Built minicode entrypoint");
+  await mkdir(shimDir, { recursive: true });
+  const script = [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    `exec "${process.execPath}" "${entryPath}" "$@"`,
+    "",
+  ].join("\n");
+  await writeFile(shimPath, script, "utf8");
+  await chmod(shimPath, 0o755);
+  return shimDir;
+}
+
+function buildSmokeCommand(args: TsBenchSmokeArgs): string[] {
+  return [
+    "src/index.ts",
+    "--agent",
+    "minicode",
+    "--version",
+    "local-dev",
+    "--dataset",
+    "v1",
+    "--exercise",
+    args.exercise,
+    "--provider",
+    args.provider,
+    "--model",
+    args.model,
+    "--output-format",
+    "json",
+  ];
+}
+
+async function main(): Promise<void> {
+  const args = parseTsBenchSmokeArgs(process.argv.slice(2));
+  const repoRoot = process.cwd();
+  const tsBenchRoot = path.resolve(repoRoot, args.tsBenchPath);
+  const benchmarkConfig = path.join(repoRoot, "benchmarks", "benchmark.config.json");
+  const home = homedir();
+  const baseEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: process.env.HOME ?? home,
+    USERPROFILE: home,
+    XDG_CACHE_HOME: process.env.XDG_CACHE_HOME ?? path.join(home, ".cache"),
+    COREPACK_HOME: process.env.COREPACK_HOME ?? path.join(home, ".cache", "node", "corepack"),
+    LOCALAPPDATA: path.join(home, ".local", "share"),
+    APPDATA: path.join(home, ".config"),
+    PATH: buildStablePath(),
+  };
+
+  if (!args.skipBuild) {
+    await runCommand("npm", ["run", "build"], { cwd: repoRoot, env: baseEnv });
+  }
+
+  await applyTsBenchMinicodeAdapter(tsBenchRoot);
+  const shimDir = await createLocalMinicodeShim(tsBenchRoot, repoRoot);
+
+  const env: NodeJS.ProcessEnv = {
+    ...baseEnv,
+    PATH: buildStablePath([shimDir]),
+    MINICODE_BENCHMARK_CONFIG: benchmarkConfig,
+  };
+
+  if (args.envFile) {
+    const envFilePath = path.resolve(repoRoot, args.envFile);
+    const parsed = parseDotenv(await readFile(envFilePath, "utf8"));
+    for (const [key, value] of Object.entries(parsed)) {
+      if (env[key] === undefined) {
+        env[key] = value;
+      }
+    }
+    env.MINICODE_BENCHMARK_ENV_FILE = envFilePath;
+  }
+
+  if (args.dryRun) {
+    console.log(`ts-bench path: ${tsBenchRoot}`);
+    console.log(`repo root: ${repoRoot}`);
+    console.log(`shim dir: ${shimDir}`);
+    console.log(`command: bun ${buildSmokeCommand(args).join(" ")}`);
+    return;
+  }
+
+  if (args.installDeps) {
+    await runCommand("bun", ["install"], { cwd: tsBenchRoot, env });
+    await runCommand("git", ["submodule", "update", "--init", "repos/exercism-typescript"], {
+      cwd: tsBenchRoot,
+      env,
+    });
+  }
+
+  await runCommand("bun", buildSmokeCommand(args), { cwd: tsBenchRoot, env });
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath && path.resolve(invokedPath) === path.resolve(fileURLToPath(import.meta.url))) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/ts-bench-adapter.ts
+++ b/scripts/ts-bench-adapter.ts
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const MINICODE_REGISTRY_ENTRY = `
+
+    minicode: {
+        defaultProvider: 'openrouter' as ProviderType,
+        install: { method: 'npm', bin: 'minicode', package: '@sean.holung/minicode' },
+        getEnv(config: AgentConfig): Record<string, string> {
+            const provider = config.provider ?? 'openrouter';
+            const env: Record<string, string> = {
+                MAX_STEPS: process.env.MINICODE_BENCHMARK_MAX_STEPS || '50',
+                MAX_CONTEXT_TOKENS: process.env.MINICODE_BENCHMARK_MAX_CONTEXT_TOKENS || '32000',
+                COMMAND_TIMEOUT_MS: process.env.MINICODE_BENCHMARK_COMMAND_TIMEOUT_MS || '30000',
+                MODEL_TIMEOUT_SECONDS: process.env.MINICODE_BENCHMARK_MODEL_TIMEOUT_SECONDS || '60',
+                MAX_TOOL_OUTPUT_CHARS: process.env.MINICODE_BENCHMARK_MAX_TOOL_OUTPUT_CHARS || '8000',
+                CONFIRM_DESTRUCTIVE: 'false'
+            };
+
+            switch (provider) {
+                case 'openrouter':
+                    env.OPENROUTER_API_KEY = requireEnv('OPENROUTER_API_KEY', 'Missing OPENROUTER_API_KEY for minicode (OpenRouter) provider');
+                    break;
+                case 'openai':
+                    env.OPENAI_API_KEY = requireEnv('OPENAI_API_KEY', 'Missing OPENAI_API_KEY for minicode (OpenAI) provider');
+                    break;
+                case 'anthropic':
+                    env.ANTHROPIC_API_KEY = requireEnv('ANTHROPIC_API_KEY', 'Missing ANTHROPIC_API_KEY for minicode (Anthropic) provider');
+                    break;
+                default:
+                    throw new Error(\`Unsupported provider for minicode: \${provider}. Use openrouter, openai, or anthropic.\`);
+            }
+
+            return env;
+        },
+        buildArgs(config: AgentConfig, instructions: string): string[] {
+            const provider = config.provider ?? 'openrouter';
+            const exerciseId = (config.exercise ?? 'benchmark').replace(/[^A-Za-z0-9._-]+/g, '-');
+            const args = [
+                'bash',
+                config.agentScriptPath,
+                'minicode',
+                'benchmark',
+                'run',
+                '--workspace-root',
+                '.',
+                '--out',
+                \`minicode-\${exerciseId}.json\`,
+                '--diff-out',
+                \`minicode-\${exerciseId}.patch\`
+            ];
+
+            const benchmarkConfig = process.env.MINICODE_BENCHMARK_CONFIG;
+            if (benchmarkConfig) {
+                args.push('--config', benchmarkConfig);
+            }
+
+            const benchmarkEnvFile = process.env.MINICODE_BENCHMARK_ENV_FILE;
+            if (benchmarkEnvFile) {
+                args.push('--env-file', benchmarkEnvFile);
+            }
+
+            switch (provider) {
+                case 'anthropic':
+                    args.push('--provider', 'anthropic');
+                    break;
+                case 'openai':
+                    args.push(
+                        '--provider',
+                        'openai-compatible',
+                        '--base-url',
+                        process.env.MINICODE_OPENAI_BASE_URL || 'https://api.openai.com/v1'
+                    );
+                    break;
+                case 'openrouter':
+                    args.push(
+                        '--provider',
+                        'openai-compatible',
+                        '--base-url',
+                        process.env.MINICODE_OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1'
+                    );
+                    break;
+                default:
+                    throw new Error(\`Unsupported provider for minicode: \${provider}. Use openrouter, openai, or anthropic.\`);
+            }
+
+            if (config.model) {
+                args.push('--model', config.model);
+            }
+
+            args.push(instructions);
+            return args;
+        }
+    }`;
+
+const MINICODE_AGENTS_JSON_ENTRY =
+  '  "minicode":  { "bin": "minicode",     "method": "npm",      "package": "@sean.holung/minicode" },';
+
+function insertBeforeMarker(
+  source: string,
+  marker: string,
+  insertion: string,
+  description: string,
+): string {
+  const index = source.indexOf(marker);
+  if (index === -1) {
+    throw new Error(`Could not find ${description} marker.`);
+  }
+  return `${source.slice(0, index)}${insertion}${source.slice(index)}`;
+}
+
+function insertBeforeNthOccurrence(
+  source: string,
+  marker: string,
+  occurrence: number,
+  insertion: string,
+  description: string,
+): string {
+  let searchIndex = 0;
+  let matchIndex = -1;
+
+  for (let count = 0; count < occurrence; count += 1) {
+    matchIndex = source.indexOf(marker, searchIndex);
+    if (matchIndex === -1) {
+      throw new Error(`Could not find ${description} occurrence ${occurrence}.`);
+    }
+    searchIndex = matchIndex + marker.length;
+  }
+
+  return `${source.slice(0, matchIndex)}${insertion}${source.slice(matchIndex)}`;
+}
+
+export function injectMinicodeRegistry(source: string): string {
+  if (source.includes("minicode: {")) {
+    return source;
+  }
+
+  return insertBeforeMarker(
+    source,
+    "\n} satisfies Record<string, AgentDefinition>;",
+    `,${MINICODE_REGISTRY_ENTRY}\n`,
+    "registry closing",
+  );
+}
+
+export function injectMinicodeAgentsJson(source: string): string {
+  if (source.includes('"minicode"')) {
+    return source;
+  }
+
+  if (source.includes('\n  "kimi":')) {
+    return source.replace('\n  "kimi":', `\n${MINICODE_AGENTS_JSON_ENTRY}\n\n  "kimi":`);
+  }
+
+  return insertBeforeMarker(source, "\n}", `\n${MINICODE_AGENTS_JSON_ENTRY}\n`, "agents.json closing");
+}
+
+export function injectMinicodeSiteDisplayName(source: string): string {
+  if (source.includes("case 'minicode':")) {
+    return source;
+  }
+
+  if (source.includes("case 'opencode':")) {
+    return source.replace(
+      "        case 'opencode': return 'OpenCode';",
+      "        case 'minicode': return 'minicode';\n        case 'opencode': return 'OpenCode';",
+    );
+  }
+
+  const next = source.replace(
+    "        default: return slug.charAt(0).toUpperCase() + slug.slice(1).toLowerCase();",
+    "        case 'minicode': return 'minicode';\n        default: return slug.charAt(0).toUpperCase() + slug.slice(1).toLowerCase();",
+  );
+  if (next === source) {
+    throw new Error("Could not find agent display-name switch marker.");
+  }
+  return next;
+}
+
+export function injectMinicodeVersionDetector(source: string): string {
+  if (
+    source.includes("return ['minicode', '--version'];")
+    && source.includes("case 'minicode':\n                return this.extractGenericVersion(cleanOutput);")
+  ) {
+    return source;
+  }
+
+  let next = source;
+  next = insertBeforeNthOccurrence(
+    next,
+    "            case 'opencode':",
+    1,
+    "            case 'minicode':\n                return ['minicode', '--version'];\n",
+    "version detector command switch",
+  );
+  next = insertBeforeNthOccurrence(
+    next,
+    "            case 'opencode':",
+    2,
+    "            case 'minicode':\n                return this.extractGenericVersion(cleanOutput);\n",
+    "version detector parse switch",
+  );
+  return next;
+}
+
+export function injectMinicodeLeaderboardName(source: string): string {
+  if (source.includes("case 'minicode': return 'minicode';")) {
+    return source;
+  }
+
+  const next = source.replace(
+    /(\s*case 'kimi': return 'Kimi Code CLI';)/,
+    "            case 'minicode': return 'minicode';\n$1",
+  );
+  if (next !== source) {
+    return next;
+  }
+
+  const fallback = source.replace(
+    /(\s*default: return agent\.charAt\(0\)\.toUpperCase\(\) \+ agent\.slice\(1\)\.toLowerCase\(\);)/,
+    "            case 'minicode': return 'minicode';\n$1",
+  );
+  if (fallback === source) {
+    throw new Error("Could not find leaderboard agent-name switch marker.");
+  }
+  return fallback;
+}
+
+export async function applyTsBenchMinicodeAdapter(tsBenchRoot: string): Promise<void> {
+  const files = [
+    {
+      path: path.join(tsBenchRoot, "src", "agents", "registry.ts"),
+      transform: injectMinicodeRegistry,
+    },
+    {
+      path: path.join(tsBenchRoot, "scripts", "agents.json"),
+      transform: injectMinicodeAgentsJson,
+    },
+    {
+      path: path.join(tsBenchRoot, "src", "site", "shared", "format.ts"),
+      transform: injectMinicodeSiteDisplayName,
+    },
+    {
+      path: path.join(tsBenchRoot, "src", "utils", "version-detector.ts"),
+      transform: injectMinicodeVersionDetector,
+    },
+    {
+      path: path.join(tsBenchRoot, "src", "utils", "leaderboard-generator.ts"),
+      transform: injectMinicodeLeaderboardName,
+    },
+  ];
+
+  for (const file of files) {
+    const current = await readFile(file.path, "utf8");
+    const updated = file.transform(current);
+    if (updated !== current) {
+      await writeFile(file.path, updated, "utf8");
+    }
+  }
+}
+
+interface AdapterCliArgs {
+  tsBenchPath: string;
+}
+
+function parseAdapterCliArgs(argv: string[]): AdapterCliArgs {
+  let tsBenchPath: string | undefined;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === undefined) {
+      continue;
+    }
+
+    if (arg === "--ts-bench-path") {
+      const next = argv[i + 1];
+      if (!next || next.startsWith("-")) {
+        throw new Error("--ts-bench-path requires a value.");
+      }
+      tsBenchPath = next;
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--ts-bench-path=")) {
+      tsBenchPath = arg.slice("--ts-bench-path=".length).trim();
+      continue;
+    }
+  }
+
+  if (!tsBenchPath) {
+    throw new Error("Usage: node --import tsx scripts/ts-bench-adapter.ts --ts-bench-path /path/to/ts-bench");
+  }
+
+  return { tsBenchPath };
+}
+
+async function main(): Promise<void> {
+  const args = parseAdapterCliArgs(process.argv.slice(2));
+  const tsBenchRoot = path.resolve(process.cwd(), args.tsBenchPath);
+  await applyTsBenchMinicodeAdapter(tsBenchRoot);
+  console.log(`Applied minicode adapter to ${tsBenchRoot}`);
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath && path.resolve(invokedPath) === path.resolve(fileURLToPath(import.meta.url))) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/tests/ts-bench-adapter.test.ts
+++ b/tests/ts-bench-adapter.test.ts
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, test } from "node:test";
+
+import {
+  applyTsBenchMinicodeAdapter,
+  injectMinicodeAgentsJson,
+  injectMinicodeLeaderboardName,
+  injectMinicodeRegistry,
+  injectMinicodeSiteDisplayName,
+  injectMinicodeVersionDetector,
+} from "../scripts/ts-bench-adapter.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+test("injectMinicodeRegistry inserts a minicode agent exactly once", () => {
+  const source = `export const AGENT_REGISTRY = {
+    codex: {
+        defaultProvider: 'openai' as ProviderType,
+        install: { method: 'npm', bin: 'codex', package: '@openai/codex' },
+        getEnv(_config: AgentConfig): Record<string, string> {
+            return {};
+        },
+        buildArgs(_config: AgentConfig, instructions: string): string[] {
+            return ['bash', 'run-agent.sh', 'codex', instructions];
+        }
+    }
+} satisfies Record<string, AgentDefinition>;
+`;
+
+  const once = injectMinicodeRegistry(source);
+  const twice = injectMinicodeRegistry(once);
+
+  assert.equal((once.match(/minicode: \{/g) ?? []).length, 1);
+  assert.equal(once, twice);
+  assert.match(once, /'minicode',\s+'benchmark',\s+'run'/);
+  assert.match(once, /MINICODE_BENCHMARK_CONFIG/);
+  assert.match(once, /MINICODE_OPENROUTER_BASE_URL/);
+});
+
+test("injectMinicodeAgentsJson adds the minicode package metadata exactly once", () => {
+  const source = `{
+  "claude":    { "bin": "claude",       "method": "npm",      "package": "@anthropic-ai/claude-code" },
+  "kimi":      { "bin": "kimi",         "method": "uv_tool",  "package": "kimi-cli",  "python": "3.13" }
+}
+`;
+
+  const once = injectMinicodeAgentsJson(source);
+  const twice = injectMinicodeAgentsJson(once);
+
+  assert.equal(once, twice);
+  assert.match(once, /"minicode":\s+\{\s+"bin": "minicode"/);
+  assert.match(once, /"package": "@sean\.holung\/minicode"/);
+});
+
+test("display-name injectors add minicode labels exactly once", () => {
+  const formatSource = `export function agentDisplayName(slug: string): string {
+    switch (slug.toLowerCase()) {
+        case 'claude': return 'Claude Code';
+        case 'opencode': return 'OpenCode';
+        default: return slug.charAt(0).toUpperCase() + slug.slice(1).toLowerCase();
+    }
+}
+`;
+  const leaderboardSource = `private capitalizeAgent(agent: string): string {
+        switch (agent.toLowerCase()) {
+            case 'copilot': return 'GitHub Copilot CLI';
+            case 'kimi': return 'Kimi Code CLI';
+            default: return agent.charAt(0).toUpperCase() + agent.slice(1).toLowerCase();
+        }
+    }
+`;
+
+  const formatOnce = injectMinicodeSiteDisplayName(formatSource);
+  const formatTwice = injectMinicodeSiteDisplayName(formatOnce);
+  assert.equal(formatOnce, formatTwice);
+  assert.match(formatOnce, /case 'minicode': return 'minicode';/);
+
+  const leaderboardOnce = injectMinicodeLeaderboardName(leaderboardSource);
+  const leaderboardTwice = injectMinicodeLeaderboardName(leaderboardOnce);
+  assert.equal(leaderboardOnce, leaderboardTwice);
+  assert.match(leaderboardOnce, /case 'minicode': return 'minicode';/);
+});
+
+test("injectMinicodeVersionDetector adds command and parser cases exactly once", () => {
+  const source = `private getAgentVersionCommand(agent: AgentType): string[] {
+        switch (agent) {
+            case 'qwen':
+                return ['qwen', '--version'];
+            case 'opencode':
+                return ['opencode', '--version'];
+            default:
+                throw new Error(\`Unknown agent: \${agent}\`);
+        }
+    }
+
+    private parseVersionOutput(agent: AgentType, output: string): string {
+        const cleanOutput = output.trim();
+
+        switch (agent) {
+            case 'qwen':
+                return this.extractGenericVersion(cleanOutput);
+            case 'opencode':
+                return this.extractGenericVersion(cleanOutput);
+            default:
+                return this.extractGenericVersion(cleanOutput);
+        }
+    }
+`;
+
+  const once = injectMinicodeVersionDetector(source);
+  const twice = injectMinicodeVersionDetector(once);
+
+  assert.equal(once, twice);
+  assert.equal((once.match(/case 'minicode':/g) ?? []).length, 2);
+  assert.match(once, /return \['minicode', '--version'\];/);
+  assert.match(once, /return this\.extractGenericVersion\(cleanOutput\);/);
+});
+
+test("applyTsBenchMinicodeAdapter patches a local ts-bench tree idempotently", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "minicode-ts-bench-adapter-"));
+  tempDirs.push(root);
+
+  const files = [
+    path.join(root, "src", "agents"),
+    path.join(root, "src", "site", "shared"),
+    path.join(root, "src", "utils"),
+    path.join(root, "scripts"),
+  ];
+  await Promise.all(files.map((dir) => mkdir(dir, { recursive: true })));
+
+  await writeFile(
+    path.join(root, "src", "agents", "registry.ts"),
+    `export const AGENT_REGISTRY = {
+    kimi: {
+        defaultProvider: 'moonshot' as ProviderType,
+        install: { method: 'uv_tool', bin: 'kimi', package: 'kimi-cli', python: '3.13' },
+        getEnv(_config: AgentConfig): Record<string, string> {
+            return {};
+        },
+        buildArgs(_config: AgentConfig, instructions: string): string[] {
+            return ['bash', 'run-agent.sh', 'kimi', instructions];
+        }
+    }
+} satisfies Record<string, AgentDefinition>;
+`,
+    "utf8",
+  );
+  await writeFile(
+    path.join(root, "scripts", "agents.json"),
+    `{
+  "claude":    { "bin": "claude",       "method": "npm",      "package": "@anthropic-ai/claude-code" },
+  "kimi":      { "bin": "kimi",         "method": "uv_tool",  "package": "kimi-cli",  "python": "3.13" }
+}
+`,
+    "utf8",
+  );
+  await writeFile(
+    path.join(root, "src", "site", "shared", "format.ts"),
+    `export function agentDisplayName(slug: string): string {
+    switch (slug.toLowerCase()) {
+        case 'opencode': return 'OpenCode';
+        default: return slug.charAt(0).toUpperCase() + slug.slice(1).toLowerCase();
+    }
+}
+`,
+    "utf8",
+  );
+  await writeFile(
+    path.join(root, "src", "utils", "version-detector.ts"),
+    `private getAgentVersionCommand(agent: AgentType): string[] {
+        switch (agent) {
+            case 'qwen':
+                return ['qwen', '--version'];
+            case 'opencode':
+                return ['opencode', '--version'];
+            default:
+                throw new Error(\`Unknown agent: \${agent}\`);
+        }
+    }
+
+    private parseVersionOutput(agent: AgentType, output: string): string {
+        const cleanOutput = output.trim();
+
+        switch (agent) {
+            case 'qwen':
+                return this.extractGenericVersion(cleanOutput);
+            case 'opencode':
+                return this.extractGenericVersion(cleanOutput);
+            default:
+                return this.extractGenericVersion(cleanOutput);
+        }
+    }
+`,
+    "utf8",
+  );
+  await writeFile(
+    path.join(root, "src", "utils", "leaderboard-generator.ts"),
+    `private capitalizeAgent(agent: string): string {
+        switch (agent.toLowerCase()) {
+            case 'copilot': return 'GitHub Copilot CLI';
+            case 'kimi': return 'Kimi Code CLI';
+            default: return agent.charAt(0).toUpperCase() + agent.slice(1).toLowerCase();
+        }
+    }
+`,
+    "utf8",
+  );
+
+  await applyTsBenchMinicodeAdapter(root);
+  await applyTsBenchMinicodeAdapter(root);
+
+  const registry = await readFile(path.join(root, "src", "agents", "registry.ts"), "utf8");
+  const agentsJson = await readFile(path.join(root, "scripts", "agents.json"), "utf8");
+  const format = await readFile(path.join(root, "src", "site", "shared", "format.ts"), "utf8");
+  const versionDetector = await readFile(path.join(root, "src", "utils", "version-detector.ts"), "utf8");
+  const leaderboard = await readFile(path.join(root, "src", "utils", "leaderboard-generator.ts"), "utf8");
+
+  assert.equal((registry.match(/minicode: \{/g) ?? []).length, 1);
+  assert.equal((agentsJson.match(/"minicode":/g) ?? []).length, 1);
+  assert.match(format, /case 'minicode': return 'minicode';/);
+  assert.equal((versionDetector.match(/case 'minicode':/g) ?? []).length, 2);
+  assert.match(leaderboard, /case 'minicode': return 'minicode';/);
+});


### PR DESCRIPTION
## Summary
- add a `ts-bench` adapter script that patches a local checkout to register `minicode`
- add a smoke helper that runs the current local branch through `ts-bench` via the merged benchmark runtime surface
- document the rerun flow and comparison lanes, and cover the adapter patching logic with targeted tests

## Validation
- `npm run build`
- `npm run lint -- --max-warnings=0`
- `npm test`
- `node --import tsx scripts/run-ts-bench-smoke.ts --ts-bench-path /tmp/ts-bench-clean --exercise acronym --provider openrouter --model google/gemini-3-flash-preview --env-file ~/.minicode/.env --skip-build`

## Notes
- Fresh smoke results were posted on issue #134: https://github.com/sean1588/minicode/issues/134#issuecomment-4340216628
