### PR TITLE
Record Claude Sonnet 4.6 ts-bench result

### DIFF
--- a/benchmarks/ts-bench/RESULTS.md
+++ b/benchmarks/ts-bench/RESULTS.md
@@ -7,6 +7,7 @@ This file records the current benchmark numbers we have gathered for `minicode` 
 | Date | Agent | Provider | Model | Context | Start timeout | Score | Solved | Avg time | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | 2026-04-29 | minicode | OpenRouter | `anthropic/claude-sonnet-4.6` | `100k` | `120s` | `100%` | `25/25` | `31.6s` | Post-hardening full top-25 run |
+| 2026-04-29 | minicode | OpenRouter | `z-ai/glm-4.6` | `100k` | `120s` | `0%` | `0/25` | `55.7s` | All tasks stopped on repeated identical tool calls before source edits |
 | 2026-04-29 | minicode | OpenRouter | `google/gemini-3-flash-preview` | `32k` | `60s` | `88%` | `22/25` | `39.3s` | Failed: `accumulate`, `all-your-base`, `diamond` |
 | 2026-04-29 | minicode | OpenRouter | `openai/gpt-5` | `100k` | `60s` | `92%` | `23/25` | `93.7s` | Failed: `alphametics` (`300s` task timeout), `bowling` (`60s` model-start timeout) |
 
@@ -37,6 +38,7 @@ Observed from the official `ts-bench` README leaderboard snapshot on 2026-04-28:
 ## Reading the numbers
 
 - The strongest local baseline we currently have is `minicode + anthropic/claude-sonnet-4.6` at `100%`.
+- The `z-ai/glm-4.6` lane is not competitive under the current minicode harness; every task stopped on repeated identical tool calls before modifying the exercise source.
 - The `gemini-3-flash-preview` lane is much faster and cheaper, but clearly not as capable on this benchmark.
 - The Codex-model lane surfaced a prompt-mode mismatch rather than a pure capability limit, which is why this branch adds benchmark-specific non-interactive execution guidance.
 

--- a/benchmarks/ts-bench/RESULTS.md
+++ b/benchmarks/ts-bench/RESULTS.md
@@ -6,16 +6,17 @@ This file records the current benchmark numbers we have gathered for `minicode` 
 
 | Date | Agent | Provider | Model | Context | Start timeout | Score | Solved | Avg time | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 2026-04-29 | minicode | OpenRouter | `anthropic/claude-sonnet-4.6` | `100k` | `120s` | `100%` | `25/25` | `31.6s` | Post-hardening full top-25 run |
 | 2026-04-29 | minicode | OpenRouter | `google/gemini-3-flash-preview` | `32k` | `60s` | `88%` | `22/25` | `39.3s` | Failed: `accumulate`, `all-your-base`, `diamond` |
 | 2026-04-29 | minicode | OpenRouter | `openai/gpt-5` | `100k` | `60s` | `92%` | `23/25` | `93.7s` | Failed: `alphametics` (`300s` task timeout), `bowling` (`60s` model-start timeout) |
 
-These two runs were captured before the benchmark hardening in this branch. After this work lands, the default benchmark profile will move to:
+The Gemini and GPT-5 runs were captured before the benchmark hardening landed. The Claude Sonnet 4.6 run uses the current default benchmark profile:
 
 - `maxContextTokens = 100000`
 - `modelTimeoutSeconds = 120`
 - benchmark-specific non-interactive prompt guidance with a one-time approval-seeking retry
 
-That means the next reruns should be a cleaner baseline, especially for slower frontier models.
+That makes the Claude Sonnet 4.6 lane the current clean baseline for the hardened benchmark setup.
 
 ## Smoke validation after hardening
 
@@ -35,7 +36,7 @@ Observed from the official `ts-bench` README leaderboard snapshot on 2026-04-28:
 
 ## Reading the numbers
 
-- The strongest apples-to-apples local baseline we currently have is `minicode + openai/gpt-5` at `92%`.
+- The strongest local baseline we currently have is `minicode + anthropic/claude-sonnet-4.6` at `100%`.
 - The `gemini-3-flash-preview` lane is much faster and cheaper, but clearly not as capable on this benchmark.
 - The Codex-model lane surfaced a prompt-mode mismatch rather than a pure capability limit, which is why this branch adds benchmark-specific non-interactive execution guidance.
 


### PR DESCRIPTION
## Summary
- record the post-hardening `minicode + anthropic/claude-sonnet-4.6` ts-bench v1 top-25 result
- update the benchmark interpretation notes to make Sonnet 4.6 the current clean baseline

## Result
- Score: 100%
- Solved: 25/25
- Average time: 31.6s
- Result artifact: `/tmp/ts-bench-clean/results/benchmark-minicode-anthropic-claude-sonnet-4.6-2026-04-29T17-34-31.json`

## Validation
- Full `ts-bench` v1 top-25 lane completed successfully with `TS_BENCH_MODEL=anthropic/claude-sonnet-4.6`.