### PR TITLE
Add benchmark tool usage telemetry

### DIFF
--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -83,6 +83,8 @@ Benchmark mode emits structured JSON with:
 - resolved workspace root
 - resolved provider/model/base URL
 - changed files detected from git status, scoped to the selected workspace subtree
+- tool-call trace with each tool name, input, result, step, and skipped status
+- tool-usage summary for structured tools, file reads, searches, mutations, commands, skipped calls, and repeated-call stops
 - whether the workspace is a git repo
 - optional diff artifact path
 

--- a/packages/agent-sdk/src/agent/agent.ts
+++ b/packages/agent-sdk/src/agent/agent.ts
@@ -41,6 +41,36 @@ const SYMBOL_TOOLS = new Set([
   "search_code_map",
 ]);
 
+const MUTATING_TOOLS = new Set([
+  "edit_file",
+  "write_file",
+]);
+
+const STATE_SENSITIVE_TOOLS = new Set([
+  "find_path",
+  "find_references",
+  "get_dependencies",
+  "read_file",
+  "read_symbol",
+  "run_command",
+  "search",
+  "search_code_map",
+]);
+
+function isStateSensitiveFingerprint(fingerprint: string): boolean {
+  const separatorIndex = fingerprint.indexOf(":");
+  const toolName = separatorIndex === -1 ? fingerprint : fingerprint.slice(0, separatorIndex);
+  return STATE_SENSITIVE_TOOLS.has(toolName);
+}
+
+function clearStateSensitiveFingerprints(fingerprints: string[]): void {
+  for (let index = fingerprints.length - 1; index >= 0; index -= 1) {
+    if (isStateSensitiveFingerprint(fingerprints[index]!)) {
+      fingerprints.splice(index, 1);
+    }
+  }
+}
+
 /**
  * Extract the symbol name from a tool call input if the tool is symbol-aware.
  */
@@ -584,6 +614,9 @@ export class CodingAgent {
           toolName: toolCall.name,
           content: toolResult,
         });
+        if (MUTATING_TOOLS.has(toolCall.name)) {
+          clearStateSensitiveFingerprints(recentToolCallFingerprints);
+        }
       }
     }
 

--- a/src/cli/benchmark-run.ts
+++ b/src/cli/benchmark-run.ts
@@ -2,7 +2,12 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 
-import { CodingAgent, createModelClient } from "@minicode/agent-sdk";
+import {
+  CodingAgent,
+  createModelClient,
+  type SessionMessage,
+  type ToolCall,
+} from "@minicode/agent-sdk";
 
 import { getConfigSetupMessage } from "../agent/config.js";
 import {
@@ -47,6 +52,36 @@ export interface BenchmarkRunResult {
   isGitRepo: boolean;
   changedFiles: string[];
   diffOut?: string;
+  toolCalls: BenchmarkToolCallTrace[];
+  toolUsage: BenchmarkToolUsageSummary;
+}
+
+export interface BenchmarkToolCallTrace {
+  step: number;
+  name: string;
+  input: Record<string, unknown>;
+  result: string | null;
+  skipped: boolean;
+}
+
+export interface BenchmarkRepeatedToolCall {
+  name: string;
+  input: Record<string, unknown>;
+  count: number;
+}
+
+export interface BenchmarkToolUsageSummary {
+  total: number;
+  byName: Record<string, number>;
+  specializedTotal: number;
+  specializedByName: Record<string, number>;
+  fileReadTotal: number;
+  searchTotal: number;
+  mutationTotal: number;
+  commandTotal: number;
+  skippedTotal: number;
+  repeatedStop: boolean;
+  repeatedToolCalls: BenchmarkRepeatedToolCall[];
 }
 
 const BENCHMARK_SYSTEM_PROMPT_SUFFIX = [
@@ -78,6 +113,20 @@ const CONFIRMATION_REQUEST_PATTERNS = [
   /\bpermission\b/i,
 ];
 
+const SPECIALIZED_TOOL_NAMES = new Set([
+  "read_symbol",
+  "find_references",
+  "get_dependencies",
+  "search_code_map",
+  "find_path",
+]);
+
+const FILE_READ_TOOL_NAMES = new Set(["read_file"]);
+const SEARCH_TOOL_NAMES = new Set(["search"]);
+const MUTATION_TOOL_NAMES = new Set(["edit_file", "write_file"]);
+const COMMAND_TOOL_NAMES = new Set(["run_command"]);
+const REPEATED_TOOL_CALL_STOP_TEXT = "Stopped due to repeated identical tool calls";
+
 interface BenchmarkAttemptResult {
   text: string;
   usage?: {
@@ -85,6 +134,7 @@ interface BenchmarkAttemptResult {
     outputTokens: number;
   };
   streamed?: boolean;
+  messages: SessionMessage[];
 }
 
 export function getBenchmarkSystemPromptSuffix(): string {
@@ -96,6 +146,127 @@ export function isBenchmarkApprovalSeekingResponse(text: string): boolean {
     return false;
   }
   return CONFIRMATION_REQUEST_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function stableSerialize(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableSerialize(item)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableSerialize(entryValue)}`);
+    return `{${entries.join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function signatureForToolCall(toolCall: Pick<ToolCall, "name" | "input">): string {
+  return `${toolCall.name}:${stableSerialize(toolCall.input)}`;
+}
+
+export function buildBenchmarkToolTrace(messages: SessionMessage[]): BenchmarkToolCallTrace[] {
+  const toolResults = new Map<string, string>();
+  for (const message of messages) {
+    if (message.role === "tool") {
+      toolResults.set(message.toolCallId, message.content);
+    }
+  }
+
+  const traces: BenchmarkToolCallTrace[] = [];
+  let step = 0;
+  for (const message of messages) {
+    if (message.role !== "assistant" || !message.toolCalls?.length) {
+      continue;
+    }
+    step += 1;
+    for (const toolCall of message.toolCalls) {
+      const result = toolResults.get(toolCall.id) ?? null;
+      traces.push({
+        step,
+        name: toolCall.name,
+        input: toolCall.input,
+        result,
+        skipped: result?.startsWith("Tool skipped:") ?? false,
+      });
+    }
+  }
+
+  return traces;
+}
+
+export function summarizeBenchmarkToolUsage(
+  toolCalls: BenchmarkToolCallTrace[],
+  finalText: string,
+): BenchmarkToolUsageSummary {
+  const byName: Record<string, number> = {};
+  const specializedByName: Record<string, number> = {};
+  const repeatedCounts = new Map<string, {
+    name: string;
+    input: Record<string, unknown>;
+    count: number;
+  }>();
+
+  let specializedTotal = 0;
+  let fileReadTotal = 0;
+  let searchTotal = 0;
+  let mutationTotal = 0;
+  let commandTotal = 0;
+  let skippedTotal = 0;
+
+  for (const toolCall of toolCalls) {
+    byName[toolCall.name] = (byName[toolCall.name] ?? 0) + 1;
+
+    if (SPECIALIZED_TOOL_NAMES.has(toolCall.name)) {
+      specializedTotal += 1;
+      specializedByName[toolCall.name] = (specializedByName[toolCall.name] ?? 0) + 1;
+    }
+    if (FILE_READ_TOOL_NAMES.has(toolCall.name)) {
+      fileReadTotal += 1;
+    }
+    if (SEARCH_TOOL_NAMES.has(toolCall.name)) {
+      searchTotal += 1;
+    }
+    if (MUTATION_TOOL_NAMES.has(toolCall.name)) {
+      mutationTotal += 1;
+    }
+    if (COMMAND_TOOL_NAMES.has(toolCall.name)) {
+      commandTotal += 1;
+    }
+    if (toolCall.skipped) {
+      skippedTotal += 1;
+    }
+
+    const signature = signatureForToolCall(toolCall);
+    const existing = repeatedCounts.get(signature);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      repeatedCounts.set(signature, {
+        name: toolCall.name,
+        input: toolCall.input,
+        count: 1,
+      });
+    }
+  }
+
+  return {
+    total: toolCalls.length,
+    byName,
+    specializedTotal,
+    specializedByName,
+    fileReadTotal,
+    searchTotal,
+    mutationTotal,
+    commandTotal,
+    skippedTotal,
+    repeatedStop:
+      finalText.includes(REPEATED_TOOL_CALL_STOP_TEXT) ||
+      toolCalls.some((toolCall) => toolCall.result?.includes(REPEATED_TOOL_CALL_STOP_TEXT)),
+    repeatedToolCalls: [...repeatedCounts.values()]
+      .filter((entry) => entry.count > 1)
+      .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name)),
+  };
 }
 
 function readFlagValue(
@@ -287,7 +458,11 @@ async function runBenchmarkAttempt(
   },
 ): Promise<BenchmarkAttemptResult> {
   const agent = createBenchmarkAgent(params);
-  return agent.runTurn(prompt);
+  const result = await agent.runTurn(prompt);
+  return {
+    ...result,
+    messages: agent.getSession().getMessages(),
+  };
 }
 
 export async function runBenchmarkCommand(argv: string[]): Promise<void> {
@@ -373,6 +548,7 @@ export async function runBenchmarkCommand(argv: string[]): Promise<void> {
       await writeWorkspaceDiff(config.workspaceRoot, diffOutPath);
     }
 
+    const toolCalls = buildBenchmarkToolTrace(attempt.messages);
     const result: BenchmarkRunResult = {
       text: attempt.text,
       usage: attempt.usage ?? null,
@@ -386,6 +562,8 @@ export async function runBenchmarkCommand(argv: string[]): Promise<void> {
       isGitRepo: changes.isGitRepo,
       changedFiles: changes.changedFiles,
       ...(diffOutPath ? { diffOut: diffOutPath } : {}),
+      toolCalls,
+      toolUsage: summarizeBenchmarkToolUsage(toolCalls, attempt.text),
     };
     const payload = JSON.stringify(result, null, 2);
 

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -97,6 +97,37 @@ function createEchoTool(): ToolDefinition {
   };
 }
 
+function createEditTool(): ToolDefinition {
+  return {
+    name: "edit_file",
+    description: "Edits a file",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: { type: "string" },
+        content: { type: "string" },
+      },
+      required: ["path", "content"],
+    },
+    execute: async (input) => `edited:${String(input.path)}`,
+  };
+}
+
+function createRunCommandTool(): ToolDefinition {
+  return {
+    name: "run_command",
+    description: "Runs a shell command",
+    inputSchema: {
+      type: "object",
+      properties: {
+        command: { type: "string" },
+      },
+      required: ["command"],
+    },
+    execute: async (input) => `ran:${String(input.command)}`,
+  };
+}
+
 function assertToolCallTranscriptIsComplete(messages: SessionMessage[]): void {
   for (let i = 0; i < messages.length; i += 1) {
     const message = messages[i];
@@ -155,6 +186,95 @@ test("agent stops on repeated identical tool calls", async () => {
   });
 
   const { text } = await agent.runTurn("Do something");
+  assert.match(text, /repeated identical tool calls/);
+  assertToolCallTranscriptIsComplete(agent.getSession().getMessages());
+});
+
+test("agent does not treat repeated validation commands after edits as a loop", async () => {
+  const responses: ModelResponse[] = [
+    {
+      text: "test current state",
+      toolCalls: [{ id: "run-1", name: "run_command", input: { command: "npm test" } }],
+      stopReason: "tool_use",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    },
+    {
+      text: "first edit",
+      toolCalls: [{ id: "edit-1", name: "edit_file", input: { path: "app.ts", content: "one" } }],
+      stopReason: "tool_use",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    },
+    {
+      text: "test after first edit",
+      toolCalls: [{ id: "run-2", name: "run_command", input: { command: "npm test" } }],
+      stopReason: "tool_use",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    },
+    {
+      text: "second edit",
+      toolCalls: [{ id: "edit-2", name: "edit_file", input: { path: "app.ts", content: "two" } }],
+      stopReason: "tool_use",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    },
+    {
+      text: "test after second edit",
+      toolCalls: [{ id: "run-3", name: "run_command", input: { command: "npm test" } }],
+      stopReason: "tool_use",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    },
+    {
+      text: "Done.",
+      toolCalls: [],
+      stopReason: "end_turn",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    },
+  ];
+
+  const agent = new CodingAgent({
+    config: createTestAgentConfig("/tmp"),
+    modelClient: new SequenceModelClient(responses),
+    toolRegistry: new ToolRegistry([
+      createEditTool(),
+      createRunCommandTool(),
+    ]),
+  });
+
+  const { text } = await agent.runTurn("Fix and test");
+
+  assert.equal(text, "Done.");
+  assertToolCallTranscriptIsComplete(agent.getSession().getMessages());
+});
+
+test("agent still stops on repeated identical mutations", async () => {
+  const responses: ModelResponse[] = [
+    {
+      text: "first edit",
+      toolCalls: [{ id: "edit-1", name: "edit_file", input: { path: "app.ts", content: "same" } }],
+      stopReason: "tool_use",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    },
+    {
+      text: "second edit",
+      toolCalls: [{ id: "edit-2", name: "edit_file", input: { path: "app.ts", content: "same" } }],
+      stopReason: "tool_use",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    },
+    {
+      text: "third edit",
+      toolCalls: [{ id: "edit-3", name: "edit_file", input: { path: "app.ts", content: "same" } }],
+      stopReason: "tool_use",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    },
+  ];
+
+  const agent = new CodingAgent({
+    config: createTestAgentConfig("/tmp"),
+    modelClient: new SequenceModelClient(responses),
+    toolRegistry: new ToolRegistry([createEditTool()]),
+  });
+
+  const { text } = await agent.runTurn("Edit repeatedly");
+
   assert.match(text, /repeated identical tool calls/);
   assertToolCallTranscriptIsComplete(agent.getSession().getMessages());
 });

--- a/tests/benchmark-run.test.ts
+++ b/tests/benchmark-run.test.ts
@@ -2,10 +2,13 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
+  buildBenchmarkToolTrace,
   getBenchmarkSystemPromptSuffix,
   isBenchmarkApprovalSeekingResponse,
   parseBenchmarkRunArgs,
+  summarizeBenchmarkToolUsage,
 } from "../src/cli/benchmark-run.js";
+import type { SessionMessage } from "@minicode/agent-sdk";
 
 test("benchmark system prompt suffix clearly disables approval-seeking behavior", () => {
   const suffix = getBenchmarkSystemPromptSuffix();
@@ -76,4 +79,141 @@ test("parseBenchmarkRunArgs preserves prompt text and benchmark flags", () => {
   assert.equal(args.baseUrl, "https://openrouter.ai/api/v1");
   assert.equal(args.workspaceRoot, ".");
   assert.equal(args.outFile, "artifacts/result.json");
+});
+
+test("buildBenchmarkToolTrace extracts assistant tool calls and matching results", () => {
+  const messages: SessionMessage[] = [
+    { role: "user", content: "solve it" },
+    {
+      role: "assistant",
+      content: "reading",
+      toolCalls: [
+        { id: "call-1", name: "read_symbol", input: { name: "parse" } },
+        { id: "call-2", name: "read_file", input: { path: "parse.ts" } },
+      ],
+    },
+    {
+      role: "tool",
+      toolCallId: "call-1",
+      toolName: "read_symbol",
+      content: "symbol body",
+    },
+    {
+      role: "tool",
+      toolCallId: "call-2",
+      toolName: "read_file",
+      content: "file body",
+    },
+    { role: "assistant", content: "done" },
+  ];
+
+  const trace = buildBenchmarkToolTrace(messages);
+
+  assert.deepEqual(trace, [
+    {
+      step: 1,
+      name: "read_symbol",
+      input: { name: "parse" },
+      result: "symbol body",
+      skipped: false,
+    },
+    {
+      step: 1,
+      name: "read_file",
+      input: { path: "parse.ts" },
+      result: "file body",
+      skipped: false,
+    },
+  ]);
+});
+
+test("benchmark tool usage summary separates structured tools from file reads", () => {
+  const summary = summarizeBenchmarkToolUsage(
+    [
+      {
+        step: 1,
+        name: "read_symbol",
+        input: { name: "parse" },
+        result: "symbol body",
+        skipped: false,
+      },
+      {
+        step: 1,
+        name: "get_dependencies",
+        input: { name: "parse" },
+        result: "deps",
+        skipped: false,
+      },
+      {
+        step: 2,
+        name: "read_file",
+        input: { path: "parse.ts" },
+        result: "file body",
+        skipped: false,
+      },
+      {
+        step: 3,
+        name: "edit_file",
+        input: { path: "parse.ts", old_string: "a", new_string: "b" },
+        result: "edited",
+        skipped: false,
+      },
+      {
+        step: 4,
+        name: "run_command",
+        input: { command: "npm test" },
+        result: "ok",
+        skipped: false,
+      },
+    ],
+    "Done",
+  );
+
+  assert.equal(summary.total, 5);
+  assert.equal(summary.specializedTotal, 2);
+  assert.equal(summary.specializedByName.read_symbol, 1);
+  assert.equal(summary.specializedByName.get_dependencies, 1);
+  assert.equal(summary.fileReadTotal, 1);
+  assert.equal(summary.mutationTotal, 1);
+  assert.equal(summary.commandTotal, 1);
+  assert.deepEqual(summary.repeatedToolCalls, []);
+});
+
+test("benchmark tool usage summary reports repeated-call stops", () => {
+  const summary = summarizeBenchmarkToolUsage(
+    [
+      {
+        step: 1,
+        name: "read_file",
+        input: { path: "accumulate.ts" },
+        result: "stub",
+        skipped: false,
+      },
+      {
+        step: 2,
+        name: "read_file",
+        input: { path: "accumulate.ts" },
+        result: "stub",
+        skipped: false,
+      },
+      {
+        step: 3,
+        name: "read_file",
+        input: { path: "accumulate.ts" },
+        result: "Tool skipped: Stopped due to repeated identical tool calls. Please refine the prompt or provide additional constraints.",
+        skipped: true,
+      },
+    ],
+    "Stopped due to repeated identical tool calls. Please refine the prompt or provide additional constraints.",
+  );
+
+  assert.equal(summary.repeatedStop, true);
+  assert.equal(summary.skippedTotal, 1);
+  assert.deepEqual(summary.repeatedToolCalls, [
+    {
+      name: "read_file",
+      input: { path: "accumulate.ts" },
+      count: 3,
+    },
+  ]);
 });


### PR DESCRIPTION
## Summary
- emit benchmark tool-call traces and categorized tool-usage summaries in benchmark JSON artifacts
- surface repeated tool calls separately from actual repeated-call stops for easier diagnosis
- refine repeated-call detection so validation commands after successful edits are not treated as loops, while repeated identical mutations are still stopped

## Validation
- npm run build
- npm run lint -- --max-warnings=0
- TMPDIR=/tmp TEMP=/tmp TMP=/tmp npm test
- TS_BENCH_PATH=/tmp/ts-bench-clean TS_BENCH_MODEL=anthropic/claude-sonnet-4.6 TS_BENCH_EXERCISE=acronym TS_BENCH_SKIP_BUILD=1 bash ./scripts/run-ts-bench.sh