### PR TITLE
Add CCBench JS/TS benchmark workflow

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1,9 +1,10 @@
 # Benchmarking
 
-`minicode` has two benchmark surfaces:
+`minicode` has three benchmark surfaces:
 
 - `minicode benchmark run` for non-interactive harness integrations
 - `ts-bench` for external TypeScript agent comparisons
+- `CCBench` through Harbor for realistic CodeCrafters JS/TS tasks
 
 ## Quick Start
 
@@ -29,6 +30,16 @@ By default the wrapper will:
 
 Results are written by `ts-bench` under `/tmp/ts-bench/results/`.
 
+Run the public CCBench JavaScript/TypeScript subset through Harbor:
+
+```bash
+npm run benchmark:ccbench:js-ts
+```
+
+By default the wrapper clones CCBench into `/tmp/ccbench`, filters to task names
+containing `javascript` or `typescript`, and writes Harbor jobs under
+`/tmp/minicode-ccbench-jobs`.
+
 ## Important env vars
 
 - `TS_BENCH_MODEL`: model id to evaluate, for example `openai/gpt-5`
@@ -37,6 +48,10 @@ Results are written by `ts-bench` under `/tmp/ts-bench/results/`.
 - `TS_BENCH_ENV_FILE`: dotenv file with provider credentials. Defaults to `~/.minicode/.env`
 - `TS_BENCH_INSTALL_DEPS`: set to `0` to skip `bun install`
 - `TS_BENCH_SKIP_BUILD`: set to `1` to skip rebuilding `minicode`
+- `CCBENCH_MODEL`: model id for CCBench, defaults to `anthropic/claude-sonnet-4.6`
+- `CCBENCH_PROVIDER`: `openrouter`, `openai`, `openai-compatible`, or `anthropic`
+- `CCBENCH_PACKAGE_SPEC`: npm package spec installed inside Harbor containers
+- `CCBENCH_ENV_FILE`: dotenv file with provider credentials. Defaults to `~/.minicode/.env`
 
 Advanced benchmark-layer tuning still works through the `MINICODE_BENCHMARK_*` env vars described in [benchmarks/ts-bench/README.md](./benchmarks/ts-bench/README.md).
 
@@ -54,4 +69,6 @@ Benchmark mode also adds a non-interactive system-prompt suffix so the agent act
 
 - Runtime/reference docs: [docs/BENCHMARKING.md](./docs/BENCHMARKING.md)
 - `ts-bench` workflow details: [benchmarks/ts-bench/README.md](./benchmarks/ts-bench/README.md)
-- Current recorded results: [benchmarks/ts-bench/RESULTS.md](./benchmarks/ts-bench/RESULTS.md)
+- CCBench workflow details: [benchmarks/ccbench/README.md](./benchmarks/ccbench/README.md)
+- Current `ts-bench` results: [benchmarks/ts-bench/RESULTS.md](./benchmarks/ts-bench/RESULTS.md)
+- Current CCBench results: [benchmarks/ccbench/RESULTS.md](./benchmarks/ccbench/RESULTS.md)

--- a/benchmarks/ccbench/README.md
+++ b/benchmarks/ccbench/README.md
@@ -1,0 +1,94 @@
+# CCBench JS/TS
+
+This directory documents running `minicode` against the public JavaScript and
+TypeScript subset of [`codecrafters-io/ccbench`](https://github.com/codecrafters-io/ccbench).
+
+CCBench tasks use the Harbor task format, so minicode runs through the generic
+Harbor adapter in [`benchmarks/harbor`](../harbor/README.md). The integration
+does not import or special-case product internals.
+
+## Scope
+
+The current public CCBench repository has 187 tasks. The JS/TS subset contains
+9 tasks:
+
+- `grep-backreferences-typescript-gnu-309`
+- `interpreter-control-flow-typescript-wolf-690`
+- `interpreter-resolving-binding-typescript-walrus-974`
+- `interpreter-statements-and-state-typescript-armadillo-657`
+- `kafka-consuming-messages-javascript-platypus-901`
+- `kafka-listing-partitions-javascript-beetle-650`
+- `kafka-listing-partitions-javascript-fox-266`
+- `redis-transactions-javascript-antelope-677`
+- `redis-transactions-typescript-mallard-191`
+
+## Run
+
+Use the wrapper from the repository root:
+
+```bash
+./scripts/run-ccbench-js-ts.sh
+```
+
+The wrapper clones or updates CCBench under `/tmp/ccbench`, filters Harbor to
+`*javascript*` and `*typescript*` task names, and stores jobs under
+`/tmp/minicode-ccbench-jobs`.
+
+Default settings:
+
+- provider: `openrouter`
+- model: `anthropic/claude-sonnet-4.6`
+- context: `100000` tokens
+- model start timeout: `180` seconds
+- concurrency: `1`
+- env file: `~/.minicode/.env`
+
+Override with environment variables:
+
+```bash
+CCBENCH_MODEL=openai/gpt-5.4 \
+CCBENCH_PROVIDER=openrouter \
+CCBENCH_PACKAGE_SPEC=@sean.holung/minicode \
+./scripts/run-ccbench-js-ts.sh
+```
+
+For local adapter/package development before publishing a release, build and
+serve a tarball:
+
+```bash
+source ~/.nvm/nvm.sh
+nvm use 22 >/dev/null
+npm run build
+npm pack --pack-destination /tmp
+cd /tmp && python3 -m http.server 18081 --bind 0.0.0.0
+```
+
+Then run:
+
+```bash
+CCBENCH_PACKAGE_SPEC=http://host.docker.internal:18081/sean.holung-minicode-0.2.0.tgz \
+./scripts/run-ccbench-js-ts.sh
+```
+
+## Published Comparison Points
+
+The official CCBench leaderboard reported these full-benchmark results on
+2026-02-11:
+
+| Agent | Model | Success rate |
+| --- | --- | --- |
+| Codex CLI | `gpt-5.2-codex` | `75.4%` |
+| Claude Code | `claude-opus-4.6` | `72.7%` |
+| Claude Code | `claude-opus-4.5` | `58.3%` |
+| Gemini CLI | `gemini-3-flash-preview` | `51.3%` |
+| Gemini CLI | `gemini-3-pro-preview` | `47.6%` |
+| Codex CLI | `gpt-5.1-codex-mini` | `42.2%` |
+| Claude Code | `claude-sonnet-4.5` | `34.2%` |
+| Claude Code | `claude-haiku-4.5` | `21.9%` |
+
+These are full CCBench results across roughly 180 tasks, not JS/TS-only results,
+so compare them directionally unless we also run the full suite.
+
+## Result Log
+
+Recorded minicode results live in [`RESULTS.md`](./RESULTS.md).

--- a/benchmarks/ccbench/RESULTS.md
+++ b/benchmarks/ccbench/RESULTS.md
@@ -1,0 +1,49 @@
+# CCBench JS/TS Results
+
+This file records minicode runs against the public JavaScript and TypeScript
+subset of [`codecrafters-io/ccbench`](https://github.com/codecrafters-io/ccbench).
+
+## Local Runs
+
+| Date | Agent | Provider | Model | Scope | Score | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2026-04-29 | minicode | OpenRouter | `anthropic/claude-sonnet-4.6` | 1 TypeScript smoke task | `0/1` | Harbor plumbing reached the task, but the model request failed with OpenRouter `402 Insufficient credits`; this is not a valid capability result. |
+
+## Current Status
+
+The Harbor adapter and CCBench JS/TS wrapper are ready, and the smoke run now
+fails honestly when the model provider rejects the request. A valid scored run
+still needs model credits or a direct provider key. Use:
+
+```bash
+CCBENCH_PACKAGE_SPEC=@sean.holung/minicode ./scripts/run-ccbench-js-ts.sh
+```
+
+For local unpublished changes, serve a tarball and set `CCBENCH_PACKAGE_SPEC` to
+the tarball URL as documented in [`README.md`](./README.md).
+
+## Fairness Notes
+
+- The official CCBench leaderboard reports full-suite results across roughly
+  180 tasks. This file tracks the JS/TS subset first because those languages
+  match minicode's strongest parser support today.
+- CCBench's official results use each agent's native harness and model pairing.
+  Minicode results should list provider, model, context limit, timeout, and
+  package version so future comparisons are honest.
+- A JS/TS-only score should not be presented as directly equivalent to the
+  official full-suite CCBench percentage.
+
+## Published Full-Suite Baselines
+
+Observed from the official CCBench README on 2026-04-29:
+
+| Agent | Model | Success rate |
+| --- | --- | --- |
+| Codex CLI | `gpt-5.2-codex` | `75.4%` |
+| Claude Code | `claude-opus-4.6` | `72.7%` |
+| Claude Code | `claude-opus-4.5` | `58.3%` |
+| Gemini CLI | `gemini-3-flash-preview` | `51.3%` |
+| Gemini CLI | `gemini-3-pro-preview` | `47.6%` |
+| Codex CLI | `gpt-5.1-codex-mini` | `42.2%` |
+| Claude Code | `claude-sonnet-4.5` | `34.2%` |
+| Claude Code | `claude-haiku-4.5` | `21.9%` |

--- a/benchmarks/ccbench/RESULTS.md
+++ b/benchmarks/ccbench/RESULTS.md
@@ -7,13 +7,20 @@ subset of [`codecrafters-io/ccbench`](https://github.com/codecrafters-io/ccbench
 
 | Date | Agent | Provider | Model | Scope | Score | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
+| 2026-04-29 | minicode | OpenRouter | `openai/gpt-5.4` | 9 public JS/TS tasks | `44.4%` (`4/9`) | Full JS/TS subset through Harbor. Runtime: `40m21s`. Exceptions: `0`. Job: `/tmp/minicode-ccbench-jobs/2026-04-29__22-07-41/result.json`. |
 | 2026-04-29 | minicode | OpenRouter | `anthropic/claude-sonnet-4.6` | 1 TypeScript smoke task | `0/1` | Harbor plumbing reached the task, but the model request failed with OpenRouter `402 Insufficient credits`; this is not a valid capability result. |
 
 ## Current Status
 
-The Harbor adapter and CCBench JS/TS wrapper are ready, and the smoke run now
-fails honestly when the model provider rejects the request. A valid scored run
-still needs model credits or a direct provider key. Use:
+The Harbor adapter and CCBench JS/TS wrapper are ready. The first valid JS/TS
+subset run completed with `minicode + openai/gpt-5.4` through OpenRouter:
+
+- score: `44.4%` (`4/9`)
+- runtime: `40m21s`
+- exceptions: `0`
+- tokens: `3,567,729` input and `75,391` output, as reported by Harbor
+
+To reproduce:
 
 ```bash
 CCBENCH_PACKAGE_SPEC=@sean.holung/minicode ./scripts/run-ccbench-js-ts.sh
@@ -32,6 +39,29 @@ the tarball URL as documented in [`README.md`](./README.md).
   package version so future comparisons are honest.
 - A JS/TS-only score should not be presented as directly equivalent to the
   official full-suite CCBench percentage.
+
+## 2026-04-29 GPT-5.4 JS/TS Breakdown
+
+| Task | Reward | Duration | Tool calls | Specialized | File reads | Searches | Commands | Mutations | Specialized tools |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `grep-backreferences-typescript-gnu-309` | `1.0` | `113.3s` | `20` | `1` | `6` | `0` | `8` | `2` | `read_symbol` `1` |
+| `interpreter-control-flow-typescript-wolf-690` | `1.0` | `104.2s` | `67` | `26` | `25` | `1` | `3` | `10` | `read_symbol` `23`, `search_code_map` `3` |
+| `interpreter-resolving-binding-typescript-walrus-974` | `0.0` | `142.7s` | `79` | `20` | `28` | `2` | `3` | `23` | `read_symbol` `12`, `search_code_map` `8` |
+| `interpreter-statements-and-state-typescript-armadillo-657` | `1.0` | `244.4s` | `65` | `5` | `17` | `1` | `30` | `10` | `read_symbol` `5` |
+| `kafka-consuming-messages-javascript-platypus-901` | `0.0` | `55.4s` | `43` | `9` | `17` | `7` | `1` | `5` | `read_symbol` `5`, `search_code_map` `4` |
+| `kafka-listing-partitions-javascript-fox-266` | `0.0` | `97.7s` | `20` | `0` | `8` | `2` | `4` | `2` | none |
+| `kafka-listing-partitions-javascript-beetle-650` | `0.0` | `95.8s` | `28` | `3` | `14` | `1` | `5` | `2` | `read_symbol` `3` |
+| `redis-transactions-javascript-antelope-677` | `0.0` | `100.0s` | `44` | `2` | `27` | `4` | `1` | `6` | `search_code_map` `2` |
+| `redis-transactions-typescript-mallard-191` | `1.0` | `86.3s` | `22` | `0` | `14` | `0` | `3` | `4` | none |
+
+Aggregate tool usage:
+
+- total tool calls: `388`
+- specialized structural tool calls: `66` (`17.0%`)
+- file reads: `156` (`40.2%`)
+- searches: `18`
+- shell commands: `58`
+- mutations: `64`
 
 ## Published Full-Suite Baselines
 

--- a/benchmarks/harbor/minicode_agent.py
+++ b/benchmarks/harbor/minicode_agent.py
@@ -191,7 +191,7 @@ class MinicodeAgent(BaseInstalledAgent):
         command = " ".join(shlex.quote(arg) for arg in args)
         await self.exec_as_agent(
             environment,
-            command=f"set -o pipefail; {command} 2>&1 | tee {STDOUT_PATH}",
+            command=f"{command} 2>&1 | tee {STDOUT_PATH}",
             env=env,
         )
 

--- a/benchmarks/harbor/minicode_agent.py
+++ b/benchmarks/harbor/minicode_agent.py
@@ -95,7 +95,8 @@ class MinicodeAgent(BaseInstalledAgent):
             environment,
             command=(
                 "if ! command -v node >/dev/null 2>&1 || "
-                "! node -e \"process.exit(Number(process.versions.node.split('.')[0]) >= 22 ? 0 : 1)\"; "
+                "! node -e \"process.exit(Number(process.versions.node.split('.')[0]) >= 22 ? 0 : 1)\" || "
+                "! command -v npm >/dev/null 2>&1; "
                 "then "
                 "curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && "
                 "apt-get install -y nodejs; "
@@ -190,7 +191,7 @@ class MinicodeAgent(BaseInstalledAgent):
         command = " ".join(shlex.quote(arg) for arg in args)
         await self.exec_as_agent(
             environment,
-            command=f"{command} 2>&1 | tee {STDOUT_PATH}",
+            command=f"set -o pipefail; {command} 2>&1 | tee {STDOUT_PATH}",
             env=env,
         )
 

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -102,5 +102,6 @@ minicode benchmark run \
 This is the recommended surface for integrating minicode with `ts-bench`, Harbor-based benchmarks like CCBench, and future patch-based evaluators.
 
 For the concrete `ts-bench` workflow, see [`benchmarks/ts-bench/README.md`](../benchmarks/ts-bench/README.md).
+For the CCBench JS/TS workflow, see [`benchmarks/ccbench/README.md`](../benchmarks/ccbench/README.md).
 For Harbor-compatible benchmarks, see [`benchmarks/harbor/README.md`](../benchmarks/harbor/README.md).
 For the quick-start wrapper, see [`BENCHMARK.md`](../BENCHMARK.md).

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "test": "node --test --import tsx \"tests/**/*.test.ts\" \"packages/*/tests/**/*.test.ts\"",
     "verify-index": "node --import tsx test-programs/verify-index/verify.ts",
     "benchmark": "node --import tsx scripts/run-benchmarks.ts",
-    "benchmark:ts-bench": "bash ./scripts/run-ts-bench.sh"
+    "benchmark:ts-bench": "bash ./scripts/run-ts-bench.sh",
+    "benchmark:ccbench:js-ts": "bash ./scripts/run-ccbench-js-ts.sh"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.76.0",

--- a/scripts/run-ccbench-js-ts.sh
+++ b/scripts/run-ccbench-js-ts.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CCBENCH_PATH="${CCBENCH_PATH:-/tmp/ccbench}"
+HARBOR_BIN="${HARBOR_BIN:-/tmp/harbor-framework/.venv/bin/harbor}"
+CCBENCH_JOBS_DIR="${CCBENCH_JOBS_DIR:-/tmp/minicode-ccbench-jobs}"
+CCBENCH_MODEL="${CCBENCH_MODEL:-anthropic/claude-sonnet-4.6}"
+CCBENCH_PROVIDER="${CCBENCH_PROVIDER:-openrouter}"
+CCBENCH_ENV_FILE="${CCBENCH_ENV_FILE:-$HOME/.minicode/.env}"
+CCBENCH_PACKAGE_SPEC="${CCBENCH_PACKAGE_SPEC:-@sean.holung/minicode}"
+CCBENCH_MAX_CONTEXT_TOKENS="${CCBENCH_MAX_CONTEXT_TOKENS:-100000}"
+CCBENCH_MODEL_TIMEOUT_SECONDS="${CCBENCH_MODEL_TIMEOUT_SECONDS:-180}"
+CCBENCH_N_CONCURRENT="${CCBENCH_N_CONCURRENT:-1}"
+
+if [[ ! -d "${CCBENCH_PATH}/.git" ]]; then
+  git clone https://github.com/codecrafters-io/ccbench.git "${CCBENCH_PATH}"
+else
+  git -C "${CCBENCH_PATH}" pull --ff-only
+fi
+
+if [[ ! -x "${HARBOR_BIN}" ]]; then
+  echo "Harbor CLI not found at ${HARBOR_BIN}." >&2
+  echo "Set HARBOR_BIN to a Harbor executable before running this script." >&2
+  exit 1
+fi
+
+ARGS=(
+  run
+  --path "${CCBENCH_PATH}/tasks"
+  --include-task-name "*javascript*"
+  --include-task-name "*typescript*"
+  --agent-import-path "benchmarks.harbor.minicode_agent:MinicodeAgent"
+  --model "${CCBENCH_MODEL}"
+  --agent-kwarg "provider=${CCBENCH_PROVIDER}"
+  --agent-kwarg "package_spec=${CCBENCH_PACKAGE_SPEC}"
+  --agent-kwarg "max_context_tokens=${CCBENCH_MAX_CONTEXT_TOKENS}"
+  --agent-kwarg "model_timeout_seconds=${CCBENCH_MODEL_TIMEOUT_SECONDS}"
+  --jobs-dir "${CCBENCH_JOBS_DIR}"
+  --n-concurrent "${CCBENCH_N_CONCURRENT}"
+  --yes
+)
+
+if [[ -n "${CCBENCH_ENV_FILE}" ]]; then
+  ARGS+=(--env-file "${CCBENCH_ENV_FILE}")
+fi
+
+export PYTHONPATH="${REPO_ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
+exec "${HARBOR_BIN}" "${ARGS[@]}" "$@"

--- a/tests/harbor-adapter.test.ts
+++ b/tests/harbor-adapter.test.ts
@@ -23,7 +23,6 @@ test("Harbor adapter shells out through benchmark mode with artifact outputs", a
   assert.match(source, /"--out",\s*RESULT_PATH/s);
   assert.match(source, /"--diff-out",\s*PATCH_PATH/s);
   assert.match(source, /shlex\.quote\(arg\)/);
-  assert.match(source, /set -o pipefail/);
 });
 
 test("Harbor adapter forwards benchmark env knobs", async () => {

--- a/tests/harbor-adapter.test.ts
+++ b/tests/harbor-adapter.test.ts
@@ -23,6 +23,7 @@ test("Harbor adapter shells out through benchmark mode with artifact outputs", a
   assert.match(source, /"--out",\s*RESULT_PATH/s);
   assert.match(source, /"--diff-out",\s*PATCH_PATH/s);
   assert.match(source, /shlex\.quote\(arg\)/);
+  assert.match(source, /set -o pipefail/);
 });
 
 test("Harbor adapter forwards benchmark env knobs", async () => {
@@ -60,6 +61,12 @@ test("Harbor adapter installs native build prerequisites for fresh containers", 
   const source = await readAdapter();
 
   assert.match(source, /build-essential python3/);
+});
+
+test("Harbor adapter installs Node when npm is missing from benchmark containers", async () => {
+  const source = await readAdapter();
+
+  assert.match(source, /command -v npm/);
 });
 
 test("Harbor adapter documents local tarball smoke testing", async () => {


### PR DESCRIPTION
## Summary
- add a CCBench JS/TS Harbor runner and npm script
- document the 9-task JS/TS subset and published full-suite CCBench baselines
- harden the Harbor adapter for benchmark containers that have node without npm
- record valid CCBench JS/TS results for minicode + OpenRouter + openai/gpt-5.4:
  - maxSteps=50/default: 44.4% (4/9), 0 exceptions, 40m21s
  - maxSteps=150: 22.2% (2/9), 0 exceptions, 33m14s
- add prompt regression tests confirming runtime budget knobs such as maxSteps are not exposed in model-facing base or benchmark prompts
- soften symbol-tool prompt guidance so frontier models are not over-steered away from broad file reads/search
- record a two-task prompt ablation: current prompt 2/2, softened prompt 2/2 with fewer tool calls and much lower input-token usage

## Validation
- npm run build
- npm test
- node --test --import tsx tests/harbor-adapter.test.ts
- node --test --import tsx tests/system-prompt.test.ts tests/benchmark-run.test.ts
- Harbor CCBench JS/TS full subset run, default 50 steps: /tmp/minicode-ccbench-jobs/2026-04-29__22-07-41/result.json
- Harbor CCBench JS/TS full subset run, 150 steps: /tmp/minicode-ccbench-jobs/2026-04-29__23-01-24/result.json
- Harbor two-task current-prompt ablation: /tmp/minicode-ccbench-ablation-jobs/current-prompt-two-task/result.json
- Harbor two-task soft-prompt ablation: /tmp/minicode-ccbench-ablation-jobs/soft-prompt-two-task/result.json

## Notes
The recorded scores are for the JS/TS subset only, not directly equivalent to CCBench's official full-suite leaderboard. The two-task ablation is preliminary, but it suggests the softened prompt is worth testing on the full JS/TS lane: it preserved 2/2 correctness while reducing input tokens from ~1.45M to ~571k on that slice.
