### PR TITLE
Web UI: syntax-highlight Python in file-preview modal (closes #154)

### DIFF
--- a/src/web/graph.ts
+++ b/src/web/graph.ts
@@ -457,13 +457,23 @@ function focusFileInGraph(filePath: string): void {
   runLayout();
 }
 
-function getFilePreviewLanguage(filePath: string): string {
+/**
+ * Map a file path to a highlight.js language name. Falls back to `plaintext`
+ * for unknown extensions — never to a guessed language, since a wrong guess
+ * (e.g. rendering Python as TypeScript) is worse than no highlighting.
+ *
+ * Adding a new language: add the extension here AND load the matching
+ * `languages/<lang>.min.js` script in `index.html`.
+ */
+function getHljsLanguage(filePath: string): string {
   const ext = filePath.split('.').pop()?.toLowerCase() || '';
   const langMap: Record<string, string> = {
     ts: 'typescript',
     tsx: 'typescript',
     js: 'javascript',
     jsx: 'javascript',
+    py: 'python',
+    pyi: 'python',
     json: 'json',
     md: 'markdown',
     css: 'css',
@@ -527,7 +537,7 @@ async function openFilePreview(filePath: string): Promise<void> {
     }
 
     pathEl.textContent = data.filePath;
-    codeEl.className = `file-preview-code language-${getFilePreviewLanguage(data.filePath)}`;
+    codeEl.className = `file-preview-code language-${getHljsLanguage(data.filePath)}`;
     codeEl.textContent = data.source;
     if (typeof hljs !== 'undefined') {
       hljs.highlightElement(codeEl);
@@ -1285,9 +1295,7 @@ async function loadSource(name: string, detailEl: HTMLElement): Promise<void> {
     const res = await fetch(`/api/symbols/${encodeURIComponent(name)}/source`);
     if (res.ok) {
       const data = await res.json();
-      const ext = (data.filePath || '').split('.').pop() || '';
-      const langMap: Record<string, string> = { ts: 'typescript', tsx: 'typescript', js: 'javascript', jsx: 'javascript' };
-      const lang = langMap[ext] || 'typescript';
+      const lang = getHljsLanguage(data.filePath || '');
       codeEl.className = 'detail-code language-' + lang;
       codeEl.textContent = data.source;
       if (typeof hljs !== 'undefined') {

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@11.11.1/styles/tokyo-night-dark.min.css">
   <script src="https://unpkg.com/@highlightjs/cdn-assets@11.11.1/highlight.min.js"></script>
   <script src="https://unpkg.com/@highlightjs/cdn-assets@11.11.1/languages/typescript.min.js"></script>
+  <script src="https://unpkg.com/@highlightjs/cdn-assets@11.11.1/languages/python.min.js"></script>
 </head>
 <body>
   <div id="app">


### PR DESCRIPTION
## Summary

- Adds the highlight.js Python language pack to `src/web/index.html` so `.py` and `.pyi` files render with proper syntax highlighting in the file-preview modal and symbol detail panel.
- Consolidates the two duplicated `langMap` objects in `src/web/graph.ts` into a single `getHljsLanguage` helper, with `py`/`pyi` entries added.
- Fixes a latent bug at the symbol-detail call site: unknown extensions previously fell back to `'typescript'`, so a Python file rendered there would display as broken-looking TS. The shared helper falls back to `'plaintext'` everywhere — a wrong guess is worse than no highlighting.

Closes #154.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run build:web` succeeds
- [x] Manual: open a `.py` file in the file-preview modal — syntax highlighted as Python (was plain text)
- [x] Manual: open a Python symbol's source in the detail panel — syntax highlighted as Python (was rendering as broken TS due to the `'typescript'` fallback)
- [x] TypeScript/JavaScript highlighting still works (regression check)

## Notes for the reviewer

The shared helper has a reminder comment that adding a language requires **both** a `langMap` entry **and** loading the matching `languages/<lang>.min.js` script in `index.html`. That should prevent the same drift from recurring next time someone adds another language.

Discovered while testing #149 (Python language plugin). Independent of that PR — the `'typescript'` fallback bug at line 1289 predates the Python work but starts visibly biting now that `.py` files are indexed and browsable in the graph.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ajRQHucZRbcE39L9E75nw)_