### PR TITLE
Web graph: detail panel pushes canvas instead of overlaying (closes #152)

### DIFF
--- a/src/web/graph.ts
+++ b/src/web/graph.ts
@@ -251,6 +251,27 @@ export function resizeGraph(): void {
   if (cy) cy.resize();
 }
 
+/**
+ * Notify cytoscape that its container's width changed. The
+ * symbol-detail side panel is a real flex sibling of `#cy`, so showing
+ * or hiding it (via the `hidden` class) automatically redistributes
+ * width. Cytoscape doesn't pick that up on its own — we have to call
+ * `cy.resize()` so it re-measures. Optionally re-fits the visible
+ * graph into the new canvas bounds.
+ *
+ * @param fit when true, also re-fit the visible graph after resize.
+ *   Use this on panel open (so right-side nodes that just got hidden
+ *   behind the panel get repacked). Skip on close and during
+ *   drag-resize so the user's current view stays put.
+ */
+function syncDetailPanelLayout({ fit = false }: { fit?: boolean } = {}): void {
+  if (!cy) return;
+  cy.resize();
+  if (fit && cy.nodes().length > 0) {
+    cy.fit(80);
+  }
+}
+
 // -- Graph building (incremental) --
 
 async function loadGraphSnapshot(refreshIndex: boolean): Promise<boolean> {
@@ -328,6 +349,7 @@ function renderGraphAfterDataRefresh(previousVisibleIds: string[], preserveVisib
 
   cy.elements().remove();
   document.getElementById('symbol-detail')?.classList.add('hidden');
+  syncDetailPanelLayout();
 
   const visibleIds = preserveVisible
     ? [...new Set(previousVisibleIds)].filter((id) => graphNodes.has(id))
@@ -439,6 +461,7 @@ function focusFileInGraph(filePath: string): void {
   });
   cy.elements().remove();
   document.getElementById('symbol-detail')?.classList.add('hidden');
+  syncDetailPanelLayout();
 
   if (selection.nodeIds.length === 0) {
     const cyEl = document.getElementById('cy');
@@ -1151,6 +1174,7 @@ function setupInteractions(cyInst: CyInstance, detailEl: HTMLElement): void {
   cyInst.on('tap', function (evt: CyEvent) {
     if (evt.target === (cyInst as unknown)) {
       detailEl.classList.add('hidden');
+      syncDetailPanelLayout();
     }
   });
 }
@@ -1224,6 +1248,9 @@ async function showDetail(node: CyCollection, detailEl: HTMLElement): Promise<vo
 
   detailEl.innerHTML = '<div class="resize-handle"></div>' + html;
   detailEl.classList.remove('hidden');
+  // Shrink the cytoscape canvas to make room for the panel and re-fit so
+  // any nodes the panel just covered get repacked into the visible area.
+  syncDetailPanelLayout({ fit: true });
 
   // Setup resize handle drag
   const handle = detailEl.querySelector('.resize-handle') as HTMLElement;
@@ -1235,6 +1262,10 @@ async function showDetail(node: CyCollection, detailEl: HTMLElement): Promise<vo
     function onMove(ev: MouseEvent) {
       const newWidth = startWidth - (ev.clientX - startX);
       detailEl.style.width = Math.max(200, newWidth) + 'px';
+      // Track the panel's width live so the canvas grows/shrinks with the
+      // drag. Skip the fit — the user is actively manipulating the layout
+      // and would find auto-fit jarring.
+      syncDetailPanelLayout();
     }
     function onUp() {
       handle.classList.remove('dragging');
@@ -1590,6 +1621,7 @@ function setupToolbar(): void {
     if (!cy) return;
     cy.elements().remove();
     document.getElementById('symbol-detail')!.classList.add('hidden');
+    syncDetailPanelLayout();
     const cyEl = document.getElementById('cy');
     if (cyEl) showOnboardingHint(cyEl);
     refreshAnalysisGraphState();

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -1545,6 +1545,16 @@ main::-webkit-scrollbar-thumb {
 }
 
 #graph-stage {
+  /*
+   * Flex row so the symbol-detail side panel (#symbol-detail, when not
+   * hidden) sits as a real layout sibling to #cy and the cytoscape
+   * canvas automatically shrinks to fill the remaining space. Mirrors
+   * the chat ↔ graph divider pattern at the workspace level. The
+   * analysis panel stays absolute (it's an overlay, not a layout
+   * participant).
+   */
+  display: flex;
+  flex-direction: row;
   position: relative;
   flex: 1;
   min-height: 0;
@@ -1634,7 +1644,9 @@ main::-webkit-scrollbar-thumb {
 }
 
 #cy {
-  width: 100%;
+  /* Fill the row, leaving the symbol-detail panel its declared width. */
+  flex: 1;
+  min-width: 0;
   height: 100%;
   background: var(--bg);
   position: relative;
@@ -2004,11 +2016,11 @@ main::-webkit-scrollbar-thumb {
   line-height: 1.5;
 }
 
-/* Symbol detail panel */
+/* Symbol detail panel — flex sibling of #cy inside #graph-stage. */
 #symbol-detail {
-  position: absolute;
-  top: 0;
-  right: 0;
+  flex-shrink: 0;
+  /* Width is the user's drag-resizable value (default 380px, set on
+   * the element style). Flex layout takes care of pushing #cy aside. */
   width: 380px;
   min-width: 200px;
   max-width: 80%;
@@ -2017,7 +2029,8 @@ main::-webkit-scrollbar-thumb {
   border-left: 1px solid var(--border);
   overflow-y: auto;
   padding: 16px;
-  z-index: 50;
+  position: relative;
+  /* Soft shadow at the boundary; reads as a layered seam against the graph. */
   box-shadow: -4px 0 16px rgba(0, 0, 0, 0.3);
 }
 


### PR DESCRIPTION
## Summary

The symbol-detail side panel was a `position: absolute` overlay on the right edge of the graph stage, so opening it covered cytoscape nodes that the canvas didn't know to make room for. This PR makes the panel a real flex sibling of `#cy` — same shape as the existing chat ↔ graph divider — so opening the panel actually pushes the canvas aside, and dragging its resize handle pushes the boundary live.

Closes #152.

## What changed

- `#graph-stage` becomes `display: flex; flex-direction: row;`
- `#cy` switches from `width: 100%` to `flex: 1; min-width: 0;`
- `#symbol-detail` drops `position: absolute` (and its `top`/`right` anchoring), gains `flex-shrink: 0`. Its width (default 380px, plus the drag-resizable inline `style.width`) drives its layout slot. `display: none` (via the `hidden` class) yields the slot back to the canvas.
- New `syncDetailPanelLayout({ fit })` helper in `graph.ts`. Calls `cy.resize()` (cytoscape doesn't notice flex-driven container changes on its own) and optionally `cy.fit(80)`. Wired into all five panel-toggle sites: one open (in `showDetail`), three explicit `classList.add('hidden')` calls, and the click-away tap handler at the end of `initGraph`.
- Fit policy: **fit: true on panel open** so the right-side nodes that just got pushed off the canvas get repacked into the new bounds. **fit: false on close, drag-resize, and click-away** so the user's view persists.

## Notes for the reviewer

- The analysis panel is unaffected — it's `position: absolute` and left-anchored, so it doesn't share a layout slot with the right-anchored detail panel. It stays as an overlay.
- I went through two iterations on this. First version used a CSS variable (`--detail-panel-width`) on `#graph-stage` that the JS would update on each toggle, with `#cy` doing a `calc(100% - var(...))` for its width. Worked, but kept the panel as an overlay just with the canvas reserving space underneath. Second iteration (this PR) uses real flexbox so the panel's a true layout participant — matches how the chat ↔ graph divider works at the workspace level and is the cleaner story.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run build:web` succeeds
- [x] Full test suite: 624/628 (4 pre-existing sandbox failures in `workspace-changes.test.ts` unrelated)
- [x] Manual: clicking a node opens the panel, the canvas shrinks, right-side nodes pack into the visible area
- [x] Manual: dragging the resize handle pushes/pulls the boundary live, canvas grows/shrinks correspondingly
- [x] Manual: clicking on the graph background dismisses the panel and the canvas reclaims the full width
- [x] Manual: clicking Refresh / Clear buttons hides the panel and the canvas reclaims the width


---
_Generated by [Claude Code](https://claude.ai/code/session_012ajRQHucZRbcE39L9E75nw)_