### PR TITLE
Compaction: default to LLM with the agent's primary model (closes #157)

### DIFF
--- a/packages/agent-sdk/src/agent/agent.ts
+++ b/packages/agent-sdk/src/agent/agent.ts
@@ -286,16 +286,17 @@ export class CodingAgent {
   }
 
   /**
-   * Manually compact the conversation context.
-   * Uses LLM-based summarization when compactionModel is configured,
-   * otherwise falls back to mechanical compaction.
+   * Manually compact the conversation context. Uses LLM-based
+   * summarization with `config.compactionModel` if set, otherwise the
+   * agent's primary model (`config.model`). Mechanical compaction is
+   * the internal fallback inside `compactWithLlm` when the LLM call
+   * fails — the result's `method` field tells you which strategy
+   * actually ran.
    */
   async compactContext(): Promise<CompactionResult | null> {
     const keepRecent = this.config.keepRecentMessages;
-    const compactionModel = this.config.compactionModel;
-    return compactionModel
-      ? this.session.compactWithLlm(keepRecent, this.modelClient, compactionModel)
-      : this.session.compact(keepRecent);
+    const model = this.config.compactionModel ?? this.config.model;
+    return this.session.compactWithLlm(keepRecent, this.modelClient, model);
   }
 
   private getFocusSet(): Set<string> | undefined {
@@ -377,23 +378,27 @@ export class CodingAgent {
         : this.config.keepRecentMessages;
 
       // Auto-compact when context exceeds the configured threshold.
-      // When compactionModel is set, use LLM-based summarization for higher
-      // quality summaries. Otherwise, fall back to mechanical compaction.
+      // Always uses LLM-based summarization (with `compactionModel` if
+      // set, otherwise the agent's primary model). `compactWithLlm`
+      // falls back to mechanical compaction internally on error; the
+      // `method` field on the result tells us which actually ran.
       const compactionThreshold = this.config.compactionThreshold;
       if (compactionThreshold !== undefined && this.session.shouldCompact(this.config.maxContextTokens, compactionThreshold)) {
-        const compactionModel = this.config.compactionModel;
-        const result = compactionModel
-          ? await this.session.compactWithLlm(effectiveKeepRecent, this.modelClient, compactionModel)
-          : this.session.compact(effectiveKeepRecent);
+        const compactionModel = this.config.compactionModel ?? this.config.model;
+        const result = await this.session.compactWithLlm(
+          effectiveKeepRecent,
+          this.modelClient,
+          compactionModel,
+        );
         if (result && this.onProgress) {
-          const method = compactionModel ? "LLM" : "mechanical";
+          const method = result.method === "llm" ? "LLM" : "mechanical";
           this.onProgress(
             `context compacted (${method}): ${result.removedMessages} messages summarized, ` +
             `${result.previousTokens} → ${result.newTokens} tokens`,
           );
         }
         if (result && this.onUiUpdate) {
-          const method = compactionModel ? "LLM" : "mechanical";
+          const method = result.method === "llm" ? "LLM" : "mechanical";
           this.onUiUpdate({
             type: "thinking",
             content:

--- a/packages/agent-sdk/src/agent/types.ts
+++ b/packages/agent-sdk/src/agent/types.ts
@@ -73,7 +73,13 @@ export interface AgentConfig {
   enableToolOutputTruncation?: boolean;
   /** Context fullness ratio (0-1) at which compaction triggers. Default: undefined (no auto-compaction) */
   compactionThreshold?: number;
-  /** Model to use for LLM-based compaction. When set, compaction uses an LLM to summarize instead of mechanical truncation. */
+  /**
+   * Override the model used for LLM-based compaction. Compaction always
+   * uses an LLM by default (with `model` as the implicit choice); set this
+   * to use a different, typically cheaper or faster, model for the
+   * summarization call. Mechanical compaction is the internal fallback
+   * if the LLM call fails.
+   */
   compactionModel?: string;
   /** Reasoning effort level for models that support reasoning tokens. When unset, no reasoning parameters are sent. */
   reasoningEffort?: ReasoningEffort;

--- a/packages/agent-sdk/src/session/session.ts
+++ b/packages/agent-sdk/src/session/session.ts
@@ -40,6 +40,14 @@ export interface CompactionResult {
   summaryTokens: number;
   previousTokens: number;
   newTokens: number;
+  /**
+   * Which strategy actually produced the summary. `compactWithLlm` falls
+   * back to mechanical compaction on error, so the method that *attempted*
+   * the work isn't always the one that finished it. UI surfaces this so
+   * users know whether the LLM call ran (slow, billable) or the
+   * deterministic fallback fired (instant, free).
+   */
+  method: "llm" | "mechanical";
 }
 
 export class Session {
@@ -209,6 +217,7 @@ export class Session {
       summaryTokens,
       previousTokens,
       newTokens,
+      method: "mechanical",
     };
   }
 
@@ -303,6 +312,7 @@ export class Session {
       summaryTokens,
       previousTokens,
       newTokens,
+      method: "llm",
     };
   }
 

--- a/packages/agent-sdk/tests/agent.test.ts
+++ b/packages/agent-sdk/tests/agent.test.ts
@@ -402,3 +402,73 @@ test("beforeToolCall: hook receives the tool name and full input payload", async
   assert.equal(captured[0]!.name, "echo_tool");
   assert.deepEqual(captured[0]!.input, { value: "hello world" });
 });
+
+function createSummarizerClient(captured: string[]): ModelClient {
+  return {
+    async chat(params) {
+      captured.push(params.model);
+      return {
+        text: "Summary",
+        toolCalls: [],
+        stopReason: "end_turn",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      };
+    },
+  };
+}
+
+function seedCompactableSession(agent: CodingAgent): void {
+  // keepRecentMessages defaults to 2 in this helper's caller; seed 10
+  // messages so there's something to summarize.
+  for (let i = 0; i < 5; i += 1) {
+    agent.getSession().addMessage({ role: "user", content: `msg ${i}` });
+    agent.getSession().addMessage({ role: "assistant", content: `reply ${i}` });
+  }
+}
+
+test("compactContext defaults to LLM compaction with the agent's primary model", async () => {
+  const captured: string[] = [];
+  const agent = new CodingAgent({
+    config: {
+      ...createTestAgentConfig("/tmp"),
+      model: "primary-model",
+      keepRecentMessages: 2,
+    },
+    modelClient: createSummarizerClient(captured),
+    toolRegistry: new ToolRegistry([]),
+  });
+  seedCompactableSession(agent);
+
+  const result = await agent.compactContext();
+
+  assert.ok(result, "compactContext should produce a result");
+  assert.equal(result!.method, "llm");
+  assert.deepEqual(
+    captured,
+    ["primary-model"],
+    "summarizer should have been called with the agent's primary model",
+  );
+});
+
+test("compactContext uses compactionModel override when set", async () => {
+  const captured: string[] = [];
+  const agent = new CodingAgent({
+    config: {
+      ...createTestAgentConfig("/tmp"),
+      model: "primary-model",
+      compactionModel: "cheap-summarizer",
+      keepRecentMessages: 2,
+    },
+    modelClient: createSummarizerClient(captured),
+    toolRegistry: new ToolRegistry([]),
+  });
+  seedCompactableSession(agent);
+
+  await agent.compactContext();
+
+  assert.deepEqual(
+    captured,
+    ["cheap-summarizer"],
+    "compactionModel override should win over the primary model",
+  );
+});

--- a/packages/agent-sdk/tests/session.test.ts
+++ b/packages/agent-sdk/tests/session.test.ts
@@ -240,3 +240,44 @@ test("compactWithLlm falls back to mechanical compaction on error", async () => 
   assert.ok(messages[0]?.content.includes("Conversation Summary"));
   assert.ok(!messages[0]?.content.includes("LLM summarization"));
 });
+
+test("CompactionResult.method reflects which strategy actually ran", async () => {
+  // Mechanical path
+  const mech = new Session("method-mech");
+  mech.addMessage({ role: "user", content: "a" });
+  mech.addMessage({ role: "assistant", content: "b" });
+  mech.addMessage({ role: "user", content: "c" });
+  mech.addMessage({ role: "assistant", content: "d" });
+  const mechResult = mech.compact(2);
+  assert.ok(mechResult);
+  assert.equal(mechResult!.method, "mechanical");
+
+  // LLM success path
+  const llm = new Session("method-llm");
+  llm.addMessage({ role: "user", content: "a" });
+  llm.addMessage({ role: "assistant", content: "b" });
+  llm.addMessage({ role: "user", content: "c" });
+  llm.addMessage({ role: "assistant", content: "d" });
+  const llmResult = await llm.compactWithLlm(2, new FakeModelClient(), "test-haiku");
+  assert.ok(llmResult);
+  assert.equal(llmResult!.method, "llm");
+
+  // LLM fallback path — error in chat() → mechanical compaction
+  const fallback = new Session("method-fallback");
+  fallback.addMessage({ role: "user", content: "a" });
+  fallback.addMessage({ role: "assistant", content: "b" });
+  fallback.addMessage({ role: "user", content: "c" });
+  fallback.addMessage({ role: "assistant", content: "d" });
+  const failing: ModelClient = {
+    async chat() {
+      throw new Error("API down");
+    },
+  };
+  const fallbackResult = await fallback.compactWithLlm(2, failing, "test-haiku");
+  assert.ok(fallbackResult);
+  assert.equal(
+    fallbackResult!.method,
+    "mechanical",
+    "fallback should report mechanical, not the originally-attempted LLM",
+  );
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,10 +163,11 @@ async function runInteractive(
     if (trimmed === "/compact") {
       const session = agent.getSession();
       const tokensBefore = session.getTokenEstimate();
-      const result = session.compact(config.keepRecentMessages);
+      const result = await agent.compactContext();
       if (result) {
+        const method = result.method === "llm" ? "LLM" : "mechanical";
         console.log(
-          `Compacted: ${result.removedMessages} messages summarized, ` +
+          `Compacted (${method}): ${result.removedMessages} messages summarized, ` +
           `${result.previousTokens} → ${result.newTokens} tokens ` +
           `(saved ${result.previousTokens - result.newTokens} tokens)`,
         );

--- a/src/ui/cli-ink.ts
+++ b/src/ui/cli-ink.ts
@@ -191,7 +191,7 @@ export async function runInkCli(
       const session = agent.getSession();
       const result = await agent.compactContext();
       if (result) {
-        const method = config.compactionModel ? "LLM" : "mechanical";
+        const method = result.method === "llm" ? "LLM" : "mechanical";
         store.addItem({
           type: "system",
           content:


### PR DESCRIPTION
## Summary

Compaction was effectively defaulting to mechanical (deterministic truncation-and-paste) — `compactContext()` and the auto-compact path inside `runTurn` only switched to LLM-based summarization when `config.compactionModel` was explicitly set. Per #157:

> we should have it use llm based compaction using the user's current model and then override with a specific compaction model if specified.

This PR flips the default. LLM compaction is now the standard path, using the agent's primary model (`config.model`) by default. `compactionModel` becomes a true override for users who want a cheaper or faster summarizer (e.g. claude-haiku while running with claude-sonnet). Mechanical compaction is now only the internal fallback inside `compactWithLlm` when the LLM call fails — preserving the existing graceful-degradation behavior.

Closes #157.

## What changed

| File | Change |
|---|---|
| `packages/agent-sdk/src/agent/agent.ts` | `compactContext()` and the auto-compact branch always call `compactWithLlm` with `compactionModel ?? config.model`. |
| `packages/agent-sdk/src/session/session.ts` | New `method: "llm" \| "mechanical"` field on `CompactionResult`. `compact()` sets it to `"mechanical"`; `compactWithLlm()` sets it to `"llm"` on the success path. The internal fallback inside `compactWithLlm` delegates to `compact()` and inherits its `"mechanical"` value, so the field accurately reports which strategy actually produced the summary — not which one was attempted. |
| `packages/agent-sdk/src/agent/types.ts` | `compactionModel` JSDoc updated to reflect the new override semantics. |
| `src/index.ts` (legacy non-Ink CLI) | `/compact` now goes through `agent.compactContext()` instead of reaching into `session.compact()` directly. Status message reads `result.method`. |
| `src/ui/cli-ink.ts` | Status message reads `result.method` instead of guessing from `config.compactionModel`. |

## Tests

- `CompactionResult.method reflects which strategy actually ran` — pins all three paths: pure mechanical, pure LLM, and LLM-with-fallback (verifies the fallback reports `"mechanical"`, not the originally-attempted `"llm"`).
- `compactContext defaults to LLM compaction with the agent's primary model` — captures the model name the chat client gets called with.
- `compactContext uses compactionModel override when set` — same idea with the override populated.

Full suite: 627/631 (4 pre-existing sandbox-only failures unrelated). Lint clean, typecheck clean.

## Notes for the reviewer

- **Behavior change for users with no `compactionModel` set**: their `/compact` and auto-compaction now make an LLM call rather than running mechanical compaction silently. This costs tokens (estimated 1.5K output max per call, plus the conversation in the prompt). The LLM produces noticeably better summaries, which is the whole point — but worth flagging so we can decide if this needs a release-note callout.
- **The `method` field is honest**: when `compactWithLlm` falls back internally on an LLM error, the result reports `"mechanical"` because that's what actually ran. UIs no longer need to guess from config; they read the field.
- **No prompt changes needed** — the system prompt doesn't reference compaction strategies.


---
_Generated by [Claude Code](https://claude.ai/code/session_012ajRQHucZRbcE39L9E75nw)_