### PR TITLE
Prompt caching: opt in across both model clients

### DIFF
--- a/packages/agent-sdk/src/agent/agent.ts
+++ b/packages/agent-sdk/src/agent/agent.ts
@@ -349,7 +349,11 @@ export class CodingAgent {
     options?: { signal?: AbortSignal },
   ): Promise<{
     text: string;
-    usage?: { inputTokens: number; outputTokens: number };
+    usage?: {
+      inputTokens: number;
+      outputTokens: number;
+      cachedInputTokens?: number;
+    };
     streamed?: boolean;
   }> {
     this.session.addMessage({
@@ -361,6 +365,7 @@ export class CodingAgent {
     const recentToolCallFingerprints: string[] = [];
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
+    let totalCachedInputTokens = 0;
 
     for (let step = 0; step < this.config.maxSteps; step += 1) {
       ensureStepWithinLimit(step, this.config.maxSteps);
@@ -460,6 +465,11 @@ export class CodingAgent {
         messages,
         tools: toolSchemas,
         maxTokens: this.config.maxTokens,
+        // Caching is always-on for the stable prefix EXCEPT when
+        // dynamic prompts are enabled — then the system prompt rebuilds
+        // every step (focus-adaptive code map), so caching it would just
+        // burn cache writes that never get hit.
+        cacheableSystem: !this.config.enableDynamicPrompt,
         ...(this.config.reasoningEffort
           ? { reasoningEffort: this.config.reasoningEffort }
           : {}),
@@ -475,6 +485,7 @@ export class CodingAgent {
 
       totalInputTokens += response.usage.inputTokens;
       totalOutputTokens += response.usage.outputTokens;
+      totalCachedInputTokens += response.usage.cachedInputTokens ?? 0;
 
       if (this.verbose) {
         this.verboseLog(`\n${VERBOSE_SEP}`);
@@ -505,7 +516,13 @@ export class CodingAgent {
           this.config.modelProvider === "openai-compatible" && !!this.onUiUpdate;
         return {
           text: finalText,
-          usage: { inputTokens: totalInputTokens, outputTokens: totalOutputTokens },
+          usage: {
+            inputTokens: totalInputTokens,
+            outputTokens: totalOutputTokens,
+            ...(totalCachedInputTokens > 0
+              ? { cachedInputTokens: totalCachedInputTokens }
+              : {}),
+          },
           streamed,
         };
       }
@@ -569,7 +586,13 @@ export class CodingAgent {
           });
           return {
             text: loopMessage,
-            usage: { inputTokens: totalInputTokens, outputTokens: totalOutputTokens },
+            usage: {
+            inputTokens: totalInputTokens,
+            outputTokens: totalOutputTokens,
+            ...(totalCachedInputTokens > 0
+              ? { cachedInputTokens: totalCachedInputTokens }
+              : {}),
+          },
             streamed: false,
           };
         }
@@ -659,7 +682,13 @@ export class CodingAgent {
     });
     return {
       text: stepLimitMessage,
-      usage: { inputTokens: totalInputTokens, outputTokens: totalOutputTokens },
+      usage: {
+            inputTokens: totalInputTokens,
+            outputTokens: totalOutputTokens,
+            ...(totalCachedInputTokens > 0
+              ? { cachedInputTokens: totalCachedInputTokens }
+              : {}),
+          },
       streamed: false,
     };
   }

--- a/packages/agent-sdk/src/agent/types.ts
+++ b/packages/agent-sdk/src/agent/types.ts
@@ -107,6 +107,15 @@ export interface ModelResponse {
   usage: {
     inputTokens: number;
     outputTokens: number;
+    /**
+     * Tokens served from the provider's prompt cache, when reported.
+     * Anthropic exposes `cache_read_input_tokens`; OpenAI / OpenRouter /
+     * DeepSeek / Gemini expose `prompt_tokens_details.cached_tokens`.
+     * Both clients normalise to this field. Useful for surfacing cache
+     * effectiveness in the UI without callers needing to know the
+     * provider-specific shape.
+     */
+    cachedInputTokens?: number;
   };
 }
 
@@ -126,6 +135,14 @@ export interface ModelClient {
     reasoningEffort?: ReasoningEffort;
     onStream?: (chunk: string) => void;
     signal?: AbortSignal;
+    /**
+     * When true (default), the client tells the provider to cache the
+     * stable prefix of the request (system prompt + tools). Set to false
+     * when the system prompt is rebuilt on every step (e.g. with
+     * `enableDynamicPrompt: true`) so the cache isn't constantly
+     * invalidated and re-written. Tools are always cacheable separately.
+     */
+    cacheableSystem?: boolean;
   }): Promise<ModelResponse>;
 
   /** List models available from the provider. Returns empty array on failure. */

--- a/packages/agent-sdk/src/model/client.ts
+++ b/packages/agent-sdk/src/model/client.ts
@@ -91,6 +91,14 @@ function parseResponse(response: Anthropic.Messages.Message): ModelResponse {
     }
   }
 
+  // Anthropic reports `cache_read_input_tokens` (cache hits) separately
+  // from `input_tokens` (uncached portion that still got billed at the
+  // standard rate). Surface the cache hits so callers can show savings
+  // and so the rolled-up totals are honest about how much was billable.
+  const cacheReadTokens = (response.usage as {
+    cache_read_input_tokens?: number;
+  }).cache_read_input_tokens;
+
   return {
     text: textParts.join("\n").trim(),
     toolCalls,
@@ -103,6 +111,9 @@ function parseResponse(response: Anthropic.Messages.Message): ModelResponse {
     usage: {
       inputTokens: response.usage.input_tokens,
       outputTokens: response.usage.output_tokens,
+      ...(cacheReadTokens !== undefined && cacheReadTokens > 0
+        ? { cachedInputTokens: cacheReadTokens }
+        : {}),
     },
   };
 }
@@ -284,6 +295,14 @@ interface OpenAICompatibleCompletionResponse {
   usage?: {
     prompt_tokens?: number;
     completion_tokens?: number;
+    /**
+     * Prompt-caching stats. OpenAI, OpenRouter, DeepSeek, Gemini, Groq,
+     * and others all report cache hits via this nested shape; we normalise
+     * to `ModelResponse.usage.cachedInputTokens` for callers.
+     */
+    prompt_tokens_details?: {
+      cached_tokens?: number;
+    };
   };
 }
 
@@ -439,6 +458,8 @@ function parseOpenAICompatibleResponse(
           ? "tool_use"
           : "end_turn";
 
+  const cachedTokens = response.usage?.prompt_tokens_details?.cached_tokens;
+
   return {
     text: (message.content ?? "").trim(),
     toolCalls,
@@ -446,6 +467,9 @@ function parseOpenAICompatibleResponse(
     usage: {
       inputTokens: response.usage?.prompt_tokens ?? 0,
       outputTokens: response.usage?.completion_tokens ?? 0,
+      ...(cachedTokens !== undefined && cachedTokens > 0
+        ? { cachedInputTokens: cachedTokens }
+        : {}),
     },
   };
 }
@@ -502,13 +526,43 @@ export class AnthropicModelClient implements ModelClient {
     reasoningEffort?: ReasoningEffort;
     onStream?: (chunk: string) => void;
     signal?: AbortSignal;
+    cacheableSystem?: boolean;
   }): Promise<ModelResponse> {
+    // Anthropic prompt caching: mark stable parts of the prefix with
+    // `cache_control: { type: "ephemeral" }` so the provider serves
+    // them at the cache-read rate (~10% of input cost) on subsequent
+    // calls within ~5 minutes.
+    //   - System prompt: cacheable when the caller signals it's stable
+    //     across calls (i.e. not rebuilt every step). Skipped under
+    //     `cacheableSystem: false` to avoid constant cache writes.
+    //   - Tools: marking the LAST tool also caches every preceding
+    //     tool, so a single breakpoint covers the whole tool set.
+    //     Tools change rarely; always cache.
+    const cacheableSystem = params.cacheableSystem !== false;
+    const systemBlocks = cacheableSystem && params.system.length > 0
+      ? [
+          {
+            type: "text" as const,
+            text: params.system,
+            cache_control: { type: "ephemeral" as const },
+          },
+        ]
+      : params.system;
+    const toolsWithCache =
+      params.tools.length > 0
+        ? (params.tools as unknown as Anthropic.Messages.ToolUnion[]).map(
+            (tool, i) =>
+              i === params.tools.length - 1
+                ? { ...tool, cache_control: { type: "ephemeral" } }
+                : tool,
+          )
+        : params.tools;
     const baseParams = {
       model: params.model,
       max_tokens: params.maxTokens,
-      system: params.system,
+      system: systemBlocks,
       messages: toAnthropicMessages(params.messages),
-      tools: params.tools as unknown as Anthropic.Messages.ToolUnion[],
+      tools: toolsWithCache as unknown as Anthropic.Messages.ToolUnion[],
     };
 
     // Build thinking parameter for models that support extended thinking.
@@ -583,7 +637,13 @@ interface OpenAIStreamChunk {
     };
     finish_reason?: string;
   }>;
-  usage?: { prompt_tokens?: number; completion_tokens?: number };
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    prompt_tokens_details?: {
+      cached_tokens?: number;
+    };
+  };
 }
 
 async function parseOpenAIStream(
@@ -594,7 +654,7 @@ async function parseOpenAIStream(
   let buffer = "";
   let content = "";
   const toolCallsAcc: Array<{ id: string; name: string; arguments: string }> = [];
-  const usage = { prompt_tokens: 0, completion_tokens: 0 };
+  const usage = { prompt_tokens: 0, completion_tokens: 0, cached_tokens: 0 };
   let finishReason: string | null = null;
 
   const processLines = (lines: string[]) => {
@@ -631,6 +691,8 @@ async function parseOpenAIStream(
         if (chunk.usage) {
           usage.prompt_tokens = chunk.usage.prompt_tokens ?? 0;
           usage.completion_tokens = chunk.usage.completion_tokens ?? 0;
+          usage.cached_tokens =
+            chunk.usage.prompt_tokens_details?.cached_tokens ?? 0;
         }
       } catch {
         // skip malformed chunks
@@ -673,7 +735,13 @@ async function parseOpenAIStream(
     text: content.trim(),
     toolCalls,
     stopReason,
-    usage: { inputTokens: usage.prompt_tokens, outputTokens: usage.completion_tokens },
+    usage: {
+      inputTokens: usage.prompt_tokens,
+      outputTokens: usage.completion_tokens,
+      ...(usage.cached_tokens > 0
+        ? { cachedInputTokens: usage.cached_tokens }
+        : {}),
+    },
   };
 }
 
@@ -711,6 +779,7 @@ export class OpenAICompatibleModelClient implements ModelClient {
     reasoningEffort?: ReasoningEffort;
     onStream?: (chunk: string) => void;
     signal?: AbortSignal;
+    cacheableSystem?: boolean;
   }): Promise<ModelResponse> {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -747,6 +816,18 @@ export class OpenAICompatibleModelClient implements ModelClient {
 
     if (params.reasoningEffort) {
       requestBody.reasoning = { effort: params.reasoningEffort };
+    }
+
+    // Prompt caching. Most OpenAI-compatible providers (OpenAI, DeepSeek,
+    // Grok, Groq, Moonshot, Gemini) cache automatically and ignore this
+    // field. OpenRouter honours the Anthropic-shaped `cache_control` and
+    // routes it to underlying Claude models so they cache the stable
+    // prefix. We send it as a top-level shortcut: OpenRouter then
+    // auto-applies the breakpoint to the last cacheable block (system +
+    // tools). Skipped when the system prompt rebuilds every step
+    // (`cacheableSystem: false`) to avoid pointless cache writes.
+    if (params.cacheableSystem !== false) {
+      requestBody.cache_control = { type: "ephemeral" };
     }
 
     const response = await withRetry(

--- a/packages/agent-sdk/tests/agent.test.ts
+++ b/packages/agent-sdk/tests/agent.test.ts
@@ -472,3 +472,104 @@ test("compactContext uses compactionModel override when set", async () => {
     "compactionModel override should win over the primary model",
   );
 });
+
+test("agent passes cacheableSystem: true by default and accumulates cachedInputTokens across steps", async () => {
+  const cacheableSystemFlags: Array<boolean | undefined> = [];
+  const stepResponses: ModelResponse[] = [
+    {
+      text: "Step 1",
+      toolCalls: [{ id: "t1", name: "echo_tool", input: { value: "a" } }],
+      stopReason: "tool_use",
+      usage: { inputTokens: 100, outputTokens: 20, cachedInputTokens: 80 },
+    },
+    {
+      text: "Final",
+      toolCalls: [],
+      stopReason: "end_turn",
+      usage: { inputTokens: 110, outputTokens: 10, cachedInputTokens: 95 },
+    },
+  ];
+  const client: ModelClient = {
+    async chat(params) {
+      cacheableSystemFlags.push(
+        (params as { cacheableSystem?: boolean }).cacheableSystem,
+      );
+      const next = stepResponses.shift();
+      if (!next) throw new Error("ran out of queued responses");
+      return next;
+    },
+  };
+
+  const agent = new CodingAgent({
+    config: createTestAgentConfig("/tmp"),
+    modelClient: client,
+    toolRegistry: new ToolRegistry([createEchoTool()]),
+  });
+
+  const result = await agent.runTurn("Hello");
+
+  assert.deepEqual(
+    cacheableSystemFlags,
+    [true, true],
+    "agent should default to cacheableSystem: true on every step when enableDynamicPrompt is off",
+  );
+  assert.equal(result.usage?.cachedInputTokens, 175, "should sum 80 + 95 across the turn");
+  assert.equal(result.usage?.inputTokens, 210);
+});
+
+test("agent passes cacheableSystem: false when enableDynamicPrompt is enabled", async () => {
+  const cacheableSystemFlags: Array<boolean | undefined> = [];
+  const client: ModelClient = {
+    async chat(params) {
+      cacheableSystemFlags.push(
+        (params as { cacheableSystem?: boolean }).cacheableSystem,
+      );
+      return {
+        text: "Done",
+        toolCalls: [],
+        stopReason: "end_turn",
+        usage: { inputTokens: 50, outputTokens: 5 },
+      };
+    },
+  };
+
+  const agent = new CodingAgent({
+    config: { ...createTestAgentConfig("/tmp"), enableDynamicPrompt: true },
+    modelClient: client,
+    toolRegistry: new ToolRegistry([createEchoTool()]),
+  });
+
+  await agent.runTurn("Hello");
+
+  assert.deepEqual(
+    cacheableSystemFlags,
+    [false],
+    "dynamic prompts rebuild the system on every step, so caching it would just burn cache writes",
+  );
+});
+
+test("agent omits cachedInputTokens when no step reported any", async () => {
+  const client: ModelClient = {
+    async chat() {
+      return {
+        text: "Done",
+        toolCalls: [],
+        stopReason: "end_turn",
+        usage: { inputTokens: 50, outputTokens: 5 },
+      };
+    },
+  };
+  const agent = new CodingAgent({
+    config: createTestAgentConfig("/tmp"),
+    modelClient: client,
+    toolRegistry: new ToolRegistry([createEchoTool()]),
+  });
+
+  const result = await agent.runTurn("Hello");
+
+  assert.equal(
+    result.usage?.cachedInputTokens,
+    undefined,
+    "no cache hits should mean no cachedInputTokens field on the totals",
+  );
+});

--- a/packages/agent-sdk/tests/model-client-openai.test.ts
+++ b/packages/agent-sdk/tests/model-client-openai.test.ts
@@ -288,6 +288,132 @@ test("openai-compatible client retries when the model never starts responding", 
   assert.equal(attempts, 3);
 });
 
+test("openai-compatible client adds top-level cache_control by default (OpenRouter prompt-cache opt-in)", async () => {
+  let capturedBody = "";
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    capturedBody = String(init?.body ?? "");
+    return new Response(
+      JSON.stringify({
+        choices: [{ finish_reason: "stop", message: { content: "ok" } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+  await client.chat({
+    model: "test-model",
+    system: "Test",
+    messages: [{ role: "user", content: "Hi" }],
+    tools: [],
+    maxTokens: 64,
+  });
+
+  const body = JSON.parse(capturedBody) as { cache_control?: { type: string } };
+  assert.deepEqual(
+    body.cache_control,
+    { type: "ephemeral" },
+    "default request should include the top-level cache_control marker so OpenRouter caches the stable prefix",
+  );
+});
+
+test("openai-compatible client omits cache_control when cacheableSystem is false", async () => {
+  let capturedBody = "";
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    capturedBody = String(init?.body ?? "");
+    return new Response(
+      JSON.stringify({
+        choices: [{ finish_reason: "stop", message: { content: "ok" } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+  await client.chat({
+    model: "test-model",
+    system: "Dynamic Test",
+    messages: [{ role: "user", content: "Hi" }],
+    tools: [],
+    maxTokens: 64,
+    cacheableSystem: false,
+  });
+
+  const body = JSON.parse(capturedBody) as { cache_control?: { type: string } };
+  assert.equal(
+    body.cache_control,
+    undefined,
+    "cacheableSystem: false should suppress cache_control to avoid pointless cache writes when the system prompt rebuilds",
+  );
+});
+
+test("openai-compatible client surfaces cached_tokens via prompt_tokens_details", async () => {
+  const fetchImpl: typeof fetch = async () =>
+    new Response(
+      JSON.stringify({
+        choices: [{ finish_reason: "stop", message: { content: "hi" } }],
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 10,
+          prompt_tokens_details: { cached_tokens: 80 },
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+  const response = await client.chat({
+    model: "test-model",
+    system: "Test",
+    messages: [{ role: "user", content: "Hi" }],
+    tools: [],
+    maxTokens: 64,
+  });
+
+  assert.equal(response.usage.inputTokens, 100);
+  assert.equal(response.usage.cachedInputTokens, 80);
+});
+
+test("openai-compatible client omits cachedInputTokens when zero or absent", async () => {
+  const fetchImpl: typeof fetch = async () =>
+    new Response(
+      JSON.stringify({
+        choices: [{ finish_reason: "stop", message: { content: "hi" } }],
+        usage: { prompt_tokens: 100, completion_tokens: 10 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+  const response = await client.chat({
+    model: "test-model",
+    system: "Test",
+    messages: [{ role: "user", content: "Hi" }],
+    tools: [],
+    maxTokens: 64,
+  });
+
+  assert.equal(
+    response.usage.cachedInputTokens,
+    undefined,
+    "absent cached_tokens should not surface as 0 or noise",
+  );
+});
+
 test("createModelClient returns openai-compatible client", () => {
   const config = {
     ...createTestAgentConfig("/tmp"),


### PR DESCRIPTION
## Summary

Anthropic's prompt caching cuts the input cost of stable prefixes by ~10× and is available on both transports we use:

- **Direct Anthropic API** — opt in via `cache_control: { type: "ephemeral" }` on system blocks and on the last tool.
- **OpenAI-compatible API (OpenRouter, etc.)** — top-level `cache_control` on the request body. OpenRouter routes it to underlying Claude models. OpenAI / DeepSeek / Gemini / Grok / Groq / Moonshot all cache automatically and ignore unknown fields safely.

We were sending neither. This PR turns it on by default in both clients and surfaces cache-hit stats through `ModelResponse.usage.cachedInputTokens`.

## What changed

| File | Change |
|---|---|
| `packages/agent-sdk/src/agent/types.ts` | `ModelClient.chat` accepts `cacheableSystem?: boolean` (default true). `ModelResponse.usage.cachedInputTokens?: number` — normalised across both providers. |
| `packages/agent-sdk/src/model/client.ts` (Anthropic side) | `system` switches from a plain string to a cacheable text block when `cacheableSystem !== false`. Tags the last tool with `cache_control` (a single breakpoint covers all preceding tools). Parses `cache_read_input_tokens` from the response. |
| `packages/agent-sdk/src/model/client.ts` (OpenAI-compat side) | Adds top-level `cache_control` to the request body when `cacheableSystem !== false`. Parses `prompt_tokens_details.cached_tokens` from both the JSON and the streaming SSE response shapes. |
| `packages/agent-sdk/src/agent/agent.ts` | Passes `cacheableSystem: !this.config.enableDynamicPrompt` to every `chat()` call. Accumulates `cachedInputTokens` across steps and surfaces it on the rolled-up `result.usage`. Field is omitted when zero so "no cache hits" doesn't look like "0 hits". |

## Why always-on (no config flag)

Cache writes cost ~25% more than normal input tokens but pay back the moment a second request hits the cached prefix — which in agent loops is virtually every step after the first. Worst case (single-turn session) costs marginally more; typical case (multi-step agent runs) is order-of-magnitude cheaper.

The dynamic-prompt branch handles the only scenario where caching is net-negative: when `enableDynamicPrompt: true` (off by default since #138), the system rebuilds every step → caching it would just burn cache writes that never get hit. We skip the marker in that case. Tools are always cached since they're stable across the entire session.

## Tests

7 new tests:

- `model-client-openai.test.ts`: cache_control sent by default; suppressed under `cacheableSystem: false`; `cached_tokens` parsed and surfaced; absent `cached_tokens` leaves the field undefined.
- `agent.test.ts`: agent passes `cacheableSystem: true` by default and `false` when `enableDynamicPrompt`; `cachedInputTokens` accumulates across steps; field omitted when no step reports any.

Full suite: 634/638 (4 pre-existing sandbox-only failures unrelated). Lint clean, typecheck clean.

## Notes for the reviewer

- **`packages/agent-sdk/src/model/client.ts` has a noisy diff** — the file has mixed CRLF/LF line endings inherited from earlier history, and any edit to a CRLF region forces TypeScript / esbuild to normalise touched lines. `git diff -w packages/agent-sdk/src/model/client.ts` shows the real ~91-line change. Tried to surgically preserve line endings; ended up fighting the file. Functionally identical, just visually noisy.
- **Anthropic API tests are not added** — the SDK uses a real `Anthropic` client class that's awkward to mock at the request level. The OpenAI-compatible client tests cover the equivalent code path (`cache_control` on the request body, `cached_tokens` on the response). If the Anthropic path regresses we can add a fakeable client adapter; right now the simpler shape change speaks for itself in code review.
- **UI surfacing of `cachedInputTokens` intentionally not in this PR.** The data is now end-to-end via `result.usage.cachedInputTokens`; HeaderBar / web context indicator could show "(N cached)" as a small follow-up.
- **No new config field.** Adding a knob would be the "designing for hypothetical requirements" anti-pattern. The implicit behavior is correct without one.


---
_Generated by [Claude Code](https://claude.ai/code/session_012ajRQHucZRbcE39L9E75nw)_