### PR TITLE
Agent SDK: configurable system prompt + narrow tool factory options

### DIFF
--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -195,6 +195,20 @@ const combined = new ToolRegistry([
 
 In practice, the simplest pattern is usually to create the built-in registry and wrap or extend it in your own application code. The SDK does not currently expose a public "appendTool" helper.
 
+Each `createXTool` factory also accepts a narrow per-tool options interface
+(`ReadFileToolOptions`, `WriteFileToolOptions`, `EditFileToolOptions`,
+`ListFilesToolOptions`, `SearchToolOptions`, `RunCommandToolOptions`) so you
+can wire individual tools without constructing a full `AgentConfig`.
+`AgentConfig` satisfies all of them structurally, so passing the full config
+keeps working.
+
+```typescript
+const readTool = createReadFileTool({
+  workspaceRoot: "/path/to/repo",
+  maxFileSizeBytes: 1_000_000,
+});
+```
+
 ## Tool Hooks (Indexer Integration)
 
 When integrating with a project indexer, use `CoreToolHooks` to get notified after file writes/edits:
@@ -256,14 +270,45 @@ Generate a system prompt tailored to the workspace and available tools:
 ```typescript
 import { buildSystemPrompt } from "@minicode/agent-sdk";
 
-const toolSchemas = toolRegistry.getToolSchemas();
-const systemPrompt = buildSystemPrompt(config, toolSchemas);
+const tools = toolRegistry.getToolSchemas();
+const systemPrompt = buildSystemPrompt({ config, tools });
 
 // Optionally include a code map for symbol-aware navigation
-const systemPromptWithCodeMap = buildSystemPrompt(config, toolSchemas, {
-  text: "src/index.ts: main(), startServer()\nsrc/db.ts: connect(), query()",
-  totalCount: 50,
-  shownCount: 2,
+const systemPromptWithCodeMap = buildSystemPrompt({
+  config,
+  tools,
+  codeMap: {
+    text: "src/index.ts: main(), startServer()\nsrc/db.ts: connect(), query()",
+    totalCount: 50,
+    shownCount: 2,
+  },
+});
+```
+
+### Overriding the system prompt
+
+`CodingAgent` accepts an optional `buildSystemPrompt` builder. Return a string
+(or `Promise<string>`) to fully replace the default prompt — handy for review
+bots, RAG assistants, or other non-coding use cases. Import the default
+builder and call it from your override to extend rather than replace it.
+
+```typescript
+import {
+  buildSystemPrompt,
+  CodingAgent,
+  type SystemPromptBuilder,
+} from "@minicode/agent-sdk";
+
+const myBuilder: SystemPromptBuilder = async ({ config, tools, codeMap }) => {
+  const base = buildSystemPrompt({ config, tools, codeMap });
+  return `${base}\n\nAdditional house rules: be terse.`;
+};
+
+const agent = new CodingAgent({
+  config,
+  modelClient,
+  toolRegistry,
+  buildSystemPrompt: myBuilder,
 });
 ```
 

--- a/packages/agent-sdk/src/agent/agent.ts
+++ b/packages/agent-sdk/src/agent/agent.ts
@@ -246,8 +246,9 @@ export class CodingAgent {
      *
      * Use this to point the agent at a different domain (review bot,
      * RAG assistant, non-coding use case) without rewriting the rest
-     * of the SDK. Import `defaultBuildSystemPrompt` to extend the
-     * default rather than replace it.
+     * of the SDK. Import `buildSystemPrompt` from `@minicode/agent-sdk`
+     * and call it from your builder to extend the default rather than
+     * replace it.
      */
     buildSystemPrompt?: SystemPromptBuilder;
     /**

--- a/packages/agent-sdk/src/agent/agent.ts
+++ b/packages/agent-sdk/src/agent/agent.ts
@@ -1,4 +1,7 @@
-import { buildSystemPrompt } from "../prompt/system-prompt.js";
+import {
+  buildSystemPrompt as defaultBuildSystemPrompt,
+  type SystemPromptBuilder,
+} from "../prompt/system-prompt.js";
 import type { CodeMapResult } from "../indexer/types.js";
 import { ensureStepWithinLimit, formatStepLimitMessage } from "../safety/guardrails.js";
 import { Session } from "../session/session.js";
@@ -204,6 +207,7 @@ export class CodingAgent {
   private readonly onUiUpdate: ((event: UiUpdate) => void) | undefined;
   private readonly onVerbose: ((message: string) => void) | undefined;
   private readonly getSystemPromptSuffix: (() => string | undefined) | undefined;
+  private readonly buildSystemPrompt: SystemPromptBuilder;
   private readonly beforeToolCall: BeforeToolCallHook | undefined;
 
   /**
@@ -235,6 +239,18 @@ export class CodingAgent {
     onVerbose?: (message: string) => void;
     getSystemPromptSuffix?: () => string | undefined;
     /**
+     * Replace the default system-prompt builder. Receives the agent's
+     * config, the active tools, and the current code-map snippet (when
+     * available). Return a string or a Promise<string>. When omitted,
+     * minicode's default coding-agent prompt is used.
+     *
+     * Use this to point the agent at a different domain (review bot,
+     * RAG assistant, non-coding use case) without rewriting the rest
+     * of the SDK. Import `defaultBuildSystemPrompt` to extend the
+     * default rather than replace it.
+     */
+    buildSystemPrompt?: SystemPromptBuilder;
+    /**
      * Called before each tool call. Return `{outcome: "deny", reason}` to
      * skip execution; the reason is fed back to the model as the tool's
      * result. Hosts use this to implement permission prompts (web UI
@@ -251,6 +267,7 @@ export class CodingAgent {
     this.onProgress = params.onProgress;
     this.onUiUpdate = params.onUiUpdate;
     this.onVerbose = params.onVerbose;
+    this.buildSystemPrompt = params.buildSystemPrompt ?? defaultBuildSystemPrompt;
     this.getSystemPromptSuffix = params.getSystemPromptSuffix;
     this.beforeToolCall = params.beforeToolCall;
   }
@@ -434,12 +451,12 @@ export class CodingAgent {
       const dynamicPrompt = this.config.enableDynamicPrompt !== false;
       let systemPrompt: string;
       if (dynamicPrompt || !this.cachedSystemPrompt) {
-        const codeMapResult = this.getCodeMap?.(dynamicPrompt ? this.getFocusSet() : undefined);
-        const basePrompt = buildSystemPrompt(
-          this.config,
-          toolSchemas,
-          codeMapResult,
-        );
+        const codeMap = this.getCodeMap?.(dynamicPrompt ? this.getFocusSet() : undefined);
+        const basePrompt = await this.buildSystemPrompt({
+          config: this.config,
+          tools: toolSchemas,
+          codeMap,
+        });
         const suffix = this.getSystemPromptSuffix?.();
         systemPrompt = suffix ? basePrompt + "\n\n" + suffix : basePrompt;
         if (!dynamicPrompt) {

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -42,12 +42,33 @@ export {
 export { ToolRegistry, type CoreToolHooks } from "./tools/registry.js";
 
 // Individual tool factories
-export { createReadFileTool } from "./tools/read-file.js";
-export { createWriteFileTool, type WriteFileHooks } from "./tools/write-file.js";
-export { createEditFileTool, type EditFileHooks } from "./tools/edit-file.js";
-export { createSearchTool } from "./tools/search.js";
-export { createListFilesTool } from "./tools/list-files.js";
-export { createRunCommandTool, type RunCommandHooks } from "./tools/run-command.js";
+export {
+  createReadFileTool,
+  type ReadFileToolOptions,
+} from "./tools/read-file.js";
+export {
+  createWriteFileTool,
+  type WriteFileHooks,
+  type WriteFileToolOptions,
+} from "./tools/write-file.js";
+export {
+  createEditFileTool,
+  type EditFileHooks,
+  type EditFileToolOptions,
+} from "./tools/edit-file.js";
+export {
+  createSearchTool,
+  type SearchToolOptions,
+} from "./tools/search.js";
+export {
+  createListFilesTool,
+  type ListFilesToolOptions,
+} from "./tools/list-files.js";
+export {
+  createRunCommandTool,
+  type RunCommandHooks,
+  type RunCommandToolOptions,
+} from "./tools/run-command.js";
 
 // Tool helpers
 export {
@@ -73,6 +94,8 @@ export {
 // System prompt
 export {
   buildSystemPrompt,
+  type SystemPromptBuilder,
+  type SystemPromptContext,
 } from "./prompt/system-prompt.js";
 
 // Focus tracker

--- a/packages/agent-sdk/src/prompt/system-prompt.ts
+++ b/packages/agent-sdk/src/prompt/system-prompt.ts
@@ -33,11 +33,42 @@ function hasTool(tools: ToolSchema[], name: string): boolean {
   return tools.some((t) => t.name === name);
 }
 
-export function buildSystemPrompt(
-  config: AgentConfig,
-  tools: ToolSchema[],
-  codeMapResult?: CodeMapResult,
-): string {
+/**
+ * Inputs to a system-prompt builder. Passed to the default
+ * `buildSystemPrompt` and to any custom builder a consumer wires into
+ * `CodingAgent` via the `buildSystemPrompt` constructor option.
+ *
+ * Custom builders can use these freely or ignore them — minicode's
+ * default ships a coding-agent identity, workspace context, tool
+ * guidelines, code-map injection, and safety rules. Consumers building
+ * domain-specific agents (review bots, RAG assistants, non-coding
+ * use cases) typically want to drop most of that and assemble their
+ * own from these inputs.
+ */
+export interface SystemPromptContext {
+  config: AgentConfig;
+  tools: ToolSchema[];
+  /**
+   * The current code map snippet, when one is available. Built once per
+   * turn (or per session, depending on `enableDynamicPrompt`) and
+   * passed in so builders can inject it without knowing how it was
+   * computed. May be undefined when no language plugin is active.
+   */
+  codeMap?: CodeMapResult | undefined;
+}
+
+/**
+ * Function shape for a system-prompt builder. Returning a Promise is
+ * supported so consumers can fetch context from external sources (RAG
+ * snippets, git status, on-disk preferences, etc.) before assembling
+ * the prompt.
+ */
+export type SystemPromptBuilder = (
+  ctx: SystemPromptContext,
+) => string | Promise<string>;
+
+export function buildSystemPrompt(ctx: SystemPromptContext): string {
+  const { config, tools, codeMap } = ctx;
   const projectType = detectProjectType(config.workspaceRoot);
 
   const sections: string[] = [
@@ -52,17 +83,17 @@ export function buildSystemPrompt(
 
   const hasSearchCodeMap = hasTool(tools, "search_code_map");
 
-  if (codeMapResult && codeMapResult.text.length > 0) {
-    sections.push("[Project Code Map]", codeMapResult.text, "");
+  if (codeMap && codeMap.text.length > 0) {
+    sections.push("[Project Code Map]", codeMap.text, "");
     const truncated =
-      codeMapResult.totalCount > 0 &&
-      codeMapResult.shownCount < codeMapResult.totalCount;
+      codeMap.totalCount > 0 &&
+      codeMap.shownCount < codeMap.totalCount;
     if (truncated) {
       const hint = hasSearchCodeMap
         ? " Use search_code_map to find symbols not listed above."
         : "";
       sections.push(
-        `Showing ${codeMapResult.shownCount} of ${codeMapResult.totalCount} symbols.${hint}`,
+        `Showing ${codeMap.shownCount} of ${codeMap.totalCount} symbols.${hint}`,
         "",
       );
     }

--- a/packages/agent-sdk/src/tools/edit-file.ts
+++ b/packages/agent-sdk/src/tools/edit-file.ts
@@ -1,8 +1,16 @@
 import { readFile, writeFile } from "node:fs/promises";
 
-import type { AgentConfig, ToolDefinition } from "../agent/types.js";
+import type { ToolDefinition } from "../agent/types.js";
 import { resolveWorkspacePath } from "../safety/guardrails.js";
 import { expectNonEmptyString } from "./helpers.js";
+
+/**
+ * Minimal options needed by the edit_file tool. `AgentConfig` satisfies
+ * this structurally, so passing the full config keeps working.
+ */
+export interface EditFileToolOptions {
+  workspaceRoot: string;
+}
 
 function expectString(input: Record<string, unknown>, key: string): string {
   const value = input[key];
@@ -37,7 +45,7 @@ export interface EditFileHooks {
 }
 
 export function createEditFileTool(
-  config: AgentConfig,
+  options: EditFileToolOptions,
   hooks?: EditFileHooks,
 ): ToolDefinition {
   return {
@@ -68,7 +76,7 @@ export function createEditFileTool(
       const oldString = expectNonEmptyString(input, "old_string");
       const newString = expectString(input, "new_string");
 
-      const filePath = resolveWorkspacePath(requestedPath, config.workspaceRoot);
+      const filePath = resolveWorkspacePath(requestedPath, options.workspaceRoot);
       const current = await readFile(filePath, "utf8");
       const occurrences = countOccurrences(current, oldString);
 

--- a/packages/agent-sdk/src/tools/list-files.ts
+++ b/packages/agent-sdk/src/tools/list-files.ts
@@ -1,9 +1,17 @@
 import { readdir } from "node:fs/promises";
 import path from "node:path";
 
-import type { AgentConfig, ToolDefinition } from "../agent/types.js";
+import type { ToolDefinition } from "../agent/types.js";
 import { resolveWorkspacePath } from "../safety/guardrails.js";
 import { expectOptionalNumber } from "./helpers.js";
+
+/**
+ * Minimal options needed by the list_files tool. `AgentConfig` satisfies
+ * this structurally, so passing the full config keeps working.
+ */
+export interface ListFilesToolOptions {
+  workspaceRoot: string;
+}
 
 const EXCLUDED_DIRS = new Set(["node_modules", ".git", ".minicode"]);
 const DEFAULT_LIMIT = 200;
@@ -19,7 +27,7 @@ function parsePath(input: Record<string, unknown>): string {
   return value;
 }
 
-export function createListFilesTool(config: AgentConfig): ToolDefinition {
+export function createListFilesTool(options: ListFilesToolOptions): ToolDefinition {
   return {
     name: "list_files",
     description: "List files and directories at a path.",
@@ -49,7 +57,7 @@ export function createListFilesTool(config: AgentConfig): ToolDefinition {
       const skip = Math.max(0, expectOptionalNumber(input, "skip") ?? 0);
       const limit = Math.max(1, Math.min(500, expectOptionalNumber(input, "limit") ?? DEFAULT_LIMIT));
 
-      const dirPath = resolveWorkspacePath(requestedPath, config.workspaceRoot);
+      const dirPath = resolveWorkspacePath(requestedPath, options.workspaceRoot);
       const entries = await readdir(dirPath, { withFileTypes: true });
 
       const filtered = entries.filter(

--- a/packages/agent-sdk/src/tools/read-file.ts
+++ b/packages/agent-sdk/src/tools/read-file.ts
@@ -1,10 +1,21 @@
 import { readFile, stat } from "node:fs/promises";
 
-import type { AgentConfig, ToolDefinition } from "../agent/types.js";
+import type { ToolDefinition } from "../agent/types.js";
 import {
   resolveWorkspacePath,
   validateFileReadSize,
 } from "../safety/guardrails.js";
+
+/**
+ * Minimal options needed by the read_file tool. `AgentConfig` satisfies
+ * this structurally, so existing callers passing the full config keep
+ * working — but consumers building embedded agents can now pass just
+ * the two fields the tool actually uses.
+ */
+export interface ReadFileToolOptions {
+  workspaceRoot: string;
+  maxFileSizeBytes: number;
+}
 import {
   expectNonEmptyString,
   expectOptionalNumber,
@@ -44,7 +55,7 @@ function parseLimit(
   return totalLines;
 }
 
-export function createReadFileTool(config: AgentConfig): ToolDefinition {
+export function createReadFileTool(options: ReadFileToolOptions): ToolDefinition {
   return {
     name: "read_file",
     description:
@@ -74,13 +85,13 @@ export function createReadFileTool(config: AgentConfig): ToolDefinition {
       const offset = expectOptionalNumber(input, "offset");
       const limit = expectOptionalNumber(input, "limit");
 
-      const filePath = resolveWorkspacePath(requestedPath, config.workspaceRoot);
+      const filePath = resolveWorkspacePath(requestedPath, options.workspaceRoot);
       const fileStat = await stat(filePath);
       if (!fileStat.isFile()) {
         throw new Error(`"${requestedPath}" is not a file.`);
       }
 
-      validateFileReadSize(fileStat.size, config.maxFileSizeBytes);
+      validateFileReadSize(fileStat.size, options.maxFileSizeBytes);
       const content = await readFile(filePath, "utf8");
       if (content.length === 0) {
         return "File is empty.";

--- a/packages/agent-sdk/src/tools/run-command.ts
+++ b/packages/agent-sdk/src/tools/run-command.ts
@@ -1,11 +1,22 @@
 import { spawn } from "node:child_process";
 
-import type { AgentConfig, ToolDefinition } from "../agent/types.js";
+import type { ToolDefinition } from "../agent/types.js";
 import {
   isDestructiveCommand,
   validateCommand,
 } from "../safety/guardrails.js";
 import { expectNonEmptyString, expectOptionalNumber } from "./helpers.js";
+
+/**
+ * Minimal options needed by the run_command tool. `AgentConfig` satisfies
+ * this structurally, so passing the full config keeps working.
+ */
+export interface RunCommandToolOptions {
+  workspaceRoot: string;
+  commandTimeoutMs: number;
+  commandDenylist: RegExp[];
+  confirmDestructive: boolean;
+}
 
 interface CommandExecutionResult {
   stdout: string;
@@ -124,7 +135,7 @@ function parseTimeout(
 }
 
 export function createRunCommandTool(
-  config: AgentConfig,
+  options: RunCommandToolOptions,
   hooks?: RunCommandHooks,
 ): ToolDefinition {
   return {
@@ -150,10 +161,10 @@ export function createRunCommandTool(
     execute: async (input: Record<string, unknown>): Promise<string> => {
       const command = expectNonEmptyString(input, "command");
       const rawTimeout = expectOptionalNumber(input, "timeout");
-      const timeoutMs = parseTimeout(rawTimeout, config.commandTimeoutMs);
+      const timeoutMs = parseTimeout(rawTimeout, options.commandTimeoutMs);
 
-      validateCommand(command, config.commandDenylist);
-      if (config.confirmDestructive && isDestructiveCommand(command)) {
+      validateCommand(command, options.commandDenylist);
+      if (options.confirmDestructive && isDestructiveCommand(command)) {
         throw new Error(
           `Command "${command}" appears destructive and requires explicit user confirmation.`,
         );
@@ -161,7 +172,7 @@ export function createRunCommandTool(
 
       const result = await executeBashCommand(
         command,
-        config.workspaceRoot,
+        options.workspaceRoot,
         timeoutMs,
       );
 

--- a/packages/agent-sdk/src/tools/search.ts
+++ b/packages/agent-sdk/src/tools/search.ts
@@ -1,9 +1,18 @@
 import { spawn } from "node:child_process";
 import path from "node:path";
 
-import type { AgentConfig, ToolDefinition } from "../agent/types.js";
+import type { ToolDefinition } from "../agent/types.js";
 import { resolveWorkspacePath } from "../safety/guardrails.js";
 import { expectNonEmptyString } from "./helpers.js";
+
+/**
+ * Minimal options needed by the search tool. `AgentConfig` satisfies
+ * this structurally, so passing the full config keeps working.
+ */
+export interface SearchToolOptions {
+  workspaceRoot: string;
+  commandTimeoutMs: number;
+}
 
 interface CommandResult {
   stdout: string;
@@ -73,7 +82,7 @@ function getOptionalString(
   return value;
 }
 
-export function createSearchTool(config: AgentConfig): ToolDefinition {
+export function createSearchTool(options: SearchToolOptions): ToolDefinition {
   return {
     name: "search",
     description:
@@ -104,10 +113,10 @@ export function createSearchTool(config: AgentConfig): ToolDefinition {
       const include = getOptionalString(input, "include");
       const targetPath = resolveWorkspacePath(
         requestedPath,
-        config.workspaceRoot,
+        options.workspaceRoot,
       );
       const relativeTarget =
-        path.relative(config.workspaceRoot, targetPath) || ".";
+        path.relative(options.workspaceRoot, targetPath) || ".";
 
       const rgArgs = [
         "--line-number",
@@ -142,8 +151,8 @@ export function createSearchTool(config: AgentConfig): ToolDefinition {
         const result = await runCommand(
           "rg",
           rgArgs,
-          config.workspaceRoot,
-          config.commandTimeoutMs,
+          options.workspaceRoot,
+          options.commandTimeoutMs,
         );
 
         if (result.code !== 0) {
@@ -184,8 +193,8 @@ export function createSearchTool(config: AgentConfig): ToolDefinition {
       const fallbackResult = await runCommand(
         "grep",
         grepArgs,
-        config.workspaceRoot,
-        config.commandTimeoutMs,
+        options.workspaceRoot,
+        options.commandTimeoutMs,
       );
       if (fallbackResult.code !== 0) {
         if (fallbackResult.code === 1) {

--- a/packages/agent-sdk/src/tools/write-file.ts
+++ b/packages/agent-sdk/src/tools/write-file.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import type { AgentConfig, ToolDefinition } from "../agent/types.js";
+import type { ToolDefinition } from "../agent/types.js";
 import { resolveWorkspacePath } from "../safety/guardrails.js";
 import { expectNonEmptyString } from "./helpers.js";
 
@@ -19,8 +19,16 @@ export interface WriteFileHooks {
     | undefined;
 }
 
+/**
+ * Minimal options needed by the write_file tool. `AgentConfig` satisfies
+ * this structurally, so passing the full config keeps working.
+ */
+export interface WriteFileToolOptions {
+  workspaceRoot: string;
+}
+
 export function createWriteFileTool(
-  config: AgentConfig,
+  options: WriteFileToolOptions,
   hooks?: WriteFileHooks,
 ): ToolDefinition {
   return {
@@ -46,7 +54,7 @@ export function createWriteFileTool(
       const requestedPath = expectNonEmptyString(input, "path");
       const content = expectString(input, "content");
 
-      const filePath = resolveWorkspacePath(requestedPath, config.workspaceRoot);
+      const filePath = resolveWorkspacePath(requestedPath, options.workspaceRoot);
       await mkdir(path.dirname(filePath), { recursive: true });
       await writeFile(filePath, content, "utf8");
 

--- a/packages/agent-sdk/tests/agent.test.ts
+++ b/packages/agent-sdk/tests/agent.test.ts
@@ -573,3 +573,130 @@ test("agent omits cachedInputTokens when no step reported any", async () => {
     "no cache hits should mean no cachedInputTokens field on the totals",
   );
 });
+
+test("buildSystemPrompt override replaces the default builder", async () => {
+  let capturedSystem = "";
+  const spyClient: ModelClient = {
+    async chat(params) {
+      capturedSystem = params.system;
+      return {
+        text: "ok",
+        toolCalls: [],
+        stopReason: "end_turn",
+        usage: { inputTokens: 1, outputTokens: 1 },
+      };
+    },
+  };
+
+  const agent = new CodingAgent({
+    config: createTestAgentConfig("/tmp"),
+    modelClient: spyClient,
+    toolRegistry: new ToolRegistry([createEchoTool()]),
+    buildSystemPrompt: () => "CUSTOM PROMPT — nothing else",
+  });
+
+  await agent.runTurn("Hello");
+
+  assert.equal(capturedSystem, "CUSTOM PROMPT — nothing else");
+  assert.ok(
+    !capturedSystem.includes("[Identity]"),
+    "default coding-agent identity should not appear when overridden",
+  );
+});
+
+test("buildSystemPrompt override receives config, tools, and codeMap context", async () => {
+  const seenCtx: Array<{ workspaceRoot: string; toolNames: string[]; hasCodeMap: boolean }> = [];
+  const spyClient: ModelClient = {
+    async chat() {
+      return {
+        text: "ok",
+        toolCalls: [],
+        stopReason: "end_turn",
+        usage: { inputTokens: 1, outputTokens: 1 },
+      };
+    },
+  };
+
+  const agent = new CodingAgent({
+    config: { ...createTestAgentConfig("/some/workspace"), enableDynamicPrompt: true },
+    modelClient: spyClient,
+    toolRegistry: new ToolRegistry([createEchoTool()]),
+    getCodeMap: () => ({ text: "# map", shownCount: 1, totalCount: 1 }),
+    buildSystemPrompt: (ctx) => {
+      seenCtx.push({
+        workspaceRoot: ctx.config.workspaceRoot,
+        toolNames: ctx.tools.map((t) => t.name),
+        hasCodeMap: ctx.codeMap !== undefined,
+      });
+      return "x";
+    },
+  });
+
+  await agent.runTurn("Hi");
+
+  assert.equal(seenCtx.length, 1);
+  assert.equal(seenCtx[0]!.workspaceRoot, "/some/workspace");
+  assert.deepEqual(seenCtx[0]!.toolNames, ["echo_tool"]);
+  assert.equal(seenCtx[0]!.hasCodeMap, true);
+});
+
+test("buildSystemPrompt override may return a Promise (async builder)", async () => {
+  let capturedSystem = "";
+  const spyClient: ModelClient = {
+    async chat(params) {
+      capturedSystem = params.system;
+      return {
+        text: "ok",
+        toolCalls: [],
+        stopReason: "end_turn",
+        usage: { inputTokens: 1, outputTokens: 1 },
+      };
+    },
+  };
+
+  const agent = new CodingAgent({
+    config: createTestAgentConfig("/tmp"),
+    modelClient: spyClient,
+    toolRegistry: new ToolRegistry([createEchoTool()]),
+    buildSystemPrompt: async () => {
+      // Simulate fetching context async (e.g. RAG, git status, on-disk prefs).
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      return "ASYNC PROMPT";
+    },
+  });
+
+  await agent.runTurn("Hello");
+
+  assert.equal(capturedSystem, "ASYNC PROMPT");
+});
+
+test("getSystemPromptSuffix still appends after the buildSystemPrompt override", async () => {
+  let capturedSystem = "";
+  const spyClient: ModelClient = {
+    async chat(params) {
+      capturedSystem = params.system;
+      return {
+        text: "ok",
+        toolCalls: [],
+        stopReason: "end_turn",
+        usage: { inputTokens: 1, outputTokens: 1 },
+      };
+    },
+  };
+
+  const agent = new CodingAgent({
+    config: createTestAgentConfig("/tmp"),
+    modelClient: spyClient,
+    toolRegistry: new ToolRegistry([createEchoTool()]),
+    buildSystemPrompt: () => "BASE",
+    getSystemPromptSuffix: () => "EXTRA",
+  });
+
+  await agent.runTurn("Hello");
+
+  assert.equal(
+    capturedSystem,
+    "BASE\n\nEXTRA",
+    "suffix should append regardless of which builder produced the base",
+  );
+});

--- a/packages/agent-sdk/tests/system-prompt.test.ts
+++ b/packages/agent-sdk/tests/system-prompt.test.ts
@@ -6,7 +6,7 @@ import { createTestAgentConfig } from "./test-utils.js";
 
 test("system prompt includes identity and workspace context", () => {
   const config = createTestAgentConfig("/tmp/myproject");
-  const prompt = buildSystemPrompt(config, []);
+  const prompt = buildSystemPrompt({ config, tools: [] });
 
   assert.ok(prompt.includes("[Identity]"));
   assert.ok(prompt.includes("coding agent"));
@@ -24,7 +24,7 @@ test("system prompt includes tool descriptions", () => {
     },
   ];
 
-  const prompt = buildSystemPrompt(config, tools);
+  const prompt = buildSystemPrompt({ config, tools });
   assert.ok(prompt.includes("read_file: Read a file"));
 });
 
@@ -36,7 +36,7 @@ test("system prompt includes code map when provided", () => {
     totalCount: 2,
   };
 
-  const prompt = buildSystemPrompt(config, [], codeMap);
+  const prompt = buildSystemPrompt({ config, tools: [], codeMap });
   assert.ok(prompt.includes("[Project Code Map]"));
   assert.ok(prompt.includes("FooClass"));
   assert.ok(prompt.includes("BarFunction"));
@@ -50,19 +50,19 @@ test("system prompt shows truncation hint when code map is partial", () => {
     totalCount: 100,
   };
 
-  const prompt = buildSystemPrompt(config, [], codeMap);
+  const prompt = buildSystemPrompt({ config, tools: [], codeMap });
   assert.ok(prompt.includes("Showing 1 of 100 symbols"));
 });
 
 test("system prompt omits code map when not provided", () => {
   const config = createTestAgentConfig("/tmp");
-  const prompt = buildSystemPrompt(config, []);
+  const prompt = buildSystemPrompt({ config, tools: [] });
   assert.ok(!prompt.includes("[Project Code Map]"));
 });
 
 test("system prompt includes safety rules", () => {
   const config = createTestAgentConfig("/tmp");
-  const prompt = buildSystemPrompt(config, []);
+  const prompt = buildSystemPrompt({ config, tools: [] });
   assert.ok(prompt.includes("[Safety Rules]"));
   assert.ok(prompt.includes("Never modify files outside the workspace"));
 });
@@ -82,7 +82,7 @@ test("system prompt includes specialized tool guidance when present", () => {
     },
   ];
 
-  const prompt = buildSystemPrompt(config, tools);
+  const prompt = buildSystemPrompt({ config, tools });
   assert.ok(prompt.includes("PREFER read_symbol"));
   assert.ok(prompt.includes("find_references"));
 });

--- a/packages/agent-sdk/tests/tool-factory-options.test.ts
+++ b/packages/agent-sdk/tests/tool-factory-options.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  createEditFileTool,
+  createListFilesTool,
+  createReadFileTool,
+  createRunCommandTool,
+  createSearchTool,
+  createWriteFileTool,
+  type EditFileToolOptions,
+  type ListFilesToolOptions,
+  type ReadFileToolOptions,
+  type RunCommandToolOptions,
+  type SearchToolOptions,
+  type WriteFileToolOptions,
+} from "../src/index.js";
+
+async function createTempWorkspace(): Promise<string> {
+  return mkdtemp(path.join(tmpdir(), "tool-options-tests-"));
+}
+
+test("createReadFileTool accepts a narrow ReadFileToolOptions object", async () => {
+  const workspaceRoot = await createTempWorkspace();
+  await writeFile(path.join(workspaceRoot, "hi.txt"), "hi\n", "utf8");
+
+  const opts: ReadFileToolOptions = {
+    workspaceRoot,
+    maxFileSizeBytes: 1_000,
+  };
+  const tool = createReadFileTool(opts);
+  const result = await tool.execute({ path: "hi.txt" });
+  assert.ok(result.includes("1|hi"));
+});
+
+test("createWriteFileTool accepts a narrow WriteFileToolOptions object", async () => {
+  const workspaceRoot = await createTempWorkspace();
+  const opts: WriteFileToolOptions = { workspaceRoot };
+  const tool = createWriteFileTool(opts);
+  const result = await tool.execute({ path: "out.txt", content: "data" });
+  assert.match(result, /Wrote 4 characters/);
+});
+
+test("createEditFileTool accepts a narrow EditFileToolOptions object", async () => {
+  const workspaceRoot = await createTempWorkspace();
+  await writeFile(path.join(workspaceRoot, "f.txt"), "alpha", "utf8");
+
+  const opts: EditFileToolOptions = { workspaceRoot };
+  const tool = createEditFileTool(opts);
+  const result = await tool.execute({
+    path: "f.txt",
+    old_string: "alpha",
+    new_string: "beta",
+  });
+  assert.match(result, /Updated/);
+});
+
+test("createListFilesTool accepts a narrow ListFilesToolOptions object", async () => {
+  const workspaceRoot = await createTempWorkspace();
+  await writeFile(path.join(workspaceRoot, "a.txt"), "x", "utf8");
+
+  const opts: ListFilesToolOptions = { workspaceRoot };
+  const tool = createListFilesTool(opts);
+  const result = await tool.execute({});
+  assert.ok(result.includes("a.txt"));
+});
+
+test("createSearchTool accepts a narrow SearchToolOptions object", async () => {
+  const workspaceRoot = await createTempWorkspace();
+  await writeFile(path.join(workspaceRoot, "src.txt"), "needle\n", "utf8");
+
+  const opts: SearchToolOptions = {
+    workspaceRoot,
+    commandTimeoutMs: 5_000,
+  };
+  const tool = createSearchTool(opts);
+  const result = await tool.execute({ pattern: "needle" });
+  assert.ok(result.includes("needle"));
+});
+
+test("createRunCommandTool accepts a narrow RunCommandToolOptions object", async () => {
+  const workspaceRoot = await createTempWorkspace();
+  const opts: RunCommandToolOptions = {
+    workspaceRoot,
+    commandTimeoutMs: 5_000,
+    commandDenylist: [],
+    confirmDestructive: false,
+  };
+  const tool = createRunCommandTool(opts);
+  const result = await tool.execute({ command: "echo hello" });
+  assert.match(result, /exit_code: 0/);
+  assert.match(result, /hello/);
+});

--- a/tests/system-prompt.test.ts
+++ b/tests/system-prompt.test.ts
@@ -43,53 +43,53 @@ const TOOLS_WITH_SEARCH_CODE_MAP: ToolSchema[] = [
 ];
 
 test("buildSystemPrompt omits code map when undefined", () => {
-  const prompt = buildSystemPrompt(
-    createMinimalConfig("/tmp"),
-    MINIMAL_TOOLS,
-  );
+  const prompt = buildSystemPrompt({
+    config: createMinimalConfig("/tmp"),
+    tools: MINIMAL_TOOLS,
+  });
   assert.ok(!prompt.includes("[Project Code Map]"));
   assert.ok(prompt.includes("[Identity]"));
   assert.ok(prompt.includes("[Tool Descriptions]"));
 });
 
 test("buildSystemPrompt omits code map when empty", () => {
-  const prompt = buildSystemPrompt(
-    createMinimalConfig("/tmp"),
-    MINIMAL_TOOLS,
-    { text: "", shownCount: 0, totalCount: 0 },
-  );
+  const prompt = buildSystemPrompt({
+    config: createMinimalConfig("/tmp"),
+    tools: MINIMAL_TOOLS,
+    codeMap: { text: "", shownCount: 0, totalCount: 0 },
+  });
   assert.ok(!prompt.includes("[Project Code Map]"));
 });
 
 test("buildSystemPrompt includes code map when provided", () => {
-  const codeMapResult = {
+  const codeMap = {
     text: "# Project Code Map\n\n  src/foo.ts\n    function bar()",
     shownCount: 1,
     totalCount: 1,
   };
-  const prompt = buildSystemPrompt(
-    createMinimalConfig("/tmp"),
-    MINIMAL_TOOLS,
-    codeMapResult,
-  );
+  const prompt = buildSystemPrompt({
+    config: createMinimalConfig("/tmp"),
+    tools: MINIMAL_TOOLS,
+    codeMap,
+  });
   assert.ok(prompt.includes("[Project Code Map]"));
   assert.ok(prompt.includes("src/foo.ts"));
   assert.ok(prompt.includes("function bar()"));
 });
 
 test("buildSystemPrompt includes workspace context", () => {
-  const prompt = buildSystemPrompt(
-    createMinimalConfig("/home/user/project"),
-    MINIMAL_TOOLS,
-  );
+  const prompt = buildSystemPrompt({
+    config: createMinimalConfig("/home/user/project"),
+    tools: MINIMAL_TOOLS,
+  });
   assert.ok(prompt.includes("/home/user/project"));
 });
 
 test("buildSystemPrompt omits runtime budget knobs", () => {
-  const prompt = buildSystemPrompt(
-    createMinimalConfig("/tmp"),
-    MINIMAL_TOOLS,
-  );
+  const prompt = buildSystemPrompt({
+    config: createMinimalConfig("/tmp"),
+    tools: MINIMAL_TOOLS,
+  });
 
   assert.doesNotMatch(prompt, /maxSteps/i);
   assert.doesNotMatch(prompt, /maxTokens/i);
@@ -99,35 +99,35 @@ test("buildSystemPrompt omits runtime budget knobs", () => {
 });
 
 test("buildSystemPrompt includes tool list", () => {
-  const prompt = buildSystemPrompt(
-    createMinimalConfig("/tmp"),
-    MINIMAL_TOOLS,
-  );
+  const prompt = buildSystemPrompt({
+    config: createMinimalConfig("/tmp"),
+    tools: MINIMAL_TOOLS,
+  });
   assert.ok(prompt.includes("read_file"));
   assert.ok(prompt.includes("Read a file"));
 });
 
 test("buildSystemPrompt shows truncated stats and search_code_map hint when truncated", () => {
-  const codeMapResult = {
+  const codeMap = {
     text: "# Project Code Map\n\n  src/foo.ts\n    function bar()",
     shownCount: 5,
     totalCount: 100,
   };
-  const prompt = buildSystemPrompt(
-    createMinimalConfig("/tmp"),
-    TOOLS_WITH_SEARCH_CODE_MAP,
-    codeMapResult,
-  );
+  const prompt = buildSystemPrompt({
+    config: createMinimalConfig("/tmp"),
+    tools: TOOLS_WITH_SEARCH_CODE_MAP,
+    codeMap,
+  });
   assert.ok(prompt.includes("Showing 5 of 100 symbols"));
   assert.ok(prompt.includes("search_code_map to find symbols not listed above"));
 });
 
 test("buildSystemPrompt detects project type from workspace", () => {
   const root = path.resolve(import.meta.dirname, "..");
-  const prompt = buildSystemPrompt(
-    createMinimalConfig(root),
-    MINIMAL_TOOLS,
-  );
+  const prompt = buildSystemPrompt({
+    config: createMinimalConfig(root),
+    tools: MINIMAL_TOOLS,
+  });
   assert.ok(
     prompt.includes("Node.js") || prompt.includes("TypeScript"),
     "minicode has package.json",


### PR DESCRIPTION
## Summary

Two SDK-usability improvements that together make `@minicode/agent-sdk` more pleasant to embed in third-party agents. Part of the broader push (alongside #168 for MCP) to make the SDK actually consumable by external code.

### 1. Configurable system prompt

External consumers couldn't override the system prompt — it was hardcoded into `runTurn`. Now:

- `buildSystemPrompt(ctx)` takes a `SystemPromptContext { config, tools, codeMap }` object instead of positional args
- New `SystemPromptBuilder` type — sync or async
- `CodingAgent` constructor accepts an optional `buildSystemPrompt?: SystemPromptBuilder` that replaces the default builder
- `getSystemPromptSuffix` is still appended on top of whatever the override returns, so callers can replace the body and keep the suffix mechanism (or vice versa)

```ts
new CodingAgent({
  config,
  modelClient,
  toolRegistry,
  buildSystemPrompt: async ({ config, tools, codeMap }) => {
    return `You are MyBot. Workspace: ${config.workspaceRoot}\nTools: ${tools.map(t => t.name).join(", ")}`;
  },
});
```

### 2. Tool factory cleanup

Every `createXTool` factory used to take the entire `AgentConfig`, even when it only needed two fields. External consumers had to construct a 20-field config object just to wire one tool. Now each factory accepts a narrow per-tool options interface:

| Factory | Options interface | Fields |
|---|---|---|
| `createReadFileTool` | `ReadFileToolOptions` | `workspaceRoot`, `maxFileSizeBytes` |
| `createWriteFileTool` | `WriteFileToolOptions` | `workspaceRoot` |
| `createEditFileTool` | `EditFileToolOptions` | `workspaceRoot` |
| `createListFilesTool` | `ListFilesToolOptions` | `workspaceRoot` |
| `createSearchTool` | `SearchToolOptions` | `workspaceRoot`, `commandTimeoutMs` |
| `createRunCommandTool` | `RunCommandToolOptions` | `workspaceRoot`, `commandTimeoutMs`, `commandDenylist`, `confirmDestructive` |

`AgentConfig` satisfies all six structurally, so `ToolRegistry.createDefault` and any existing caller passing the full config keeps working unchanged — TypeScript's structural typing absorbs the migration.

## Test plan

- [x] 4 new agent.test.ts cases pin the `buildSystemPrompt` override behavior (replace, context shape, async, suffix still appended)
- [x] Existing system-prompt tests updated to the new context-object signature
- [x] New `tool-factory-options.test.ts` exercises each factory with its narrow options type and asserts behavior end-to-end
- [x] `npm run build --workspace=packages/agent-sdk` clean
- [x] Root `tsc --noEmit` clean
- [x] All 90 agent-sdk tests pass; 644/648 root tests pass (4 failures in `workspace-changes.test.ts` are pre-existing — `git commit -m init` fails because the test env has no git user configured; identical failures on main)

Related: #168 (Agent SDK: connect to external MCP servers as tool sources) — next item in the SDK-consumability push.

https://claude.ai/code/session_012ajRQHucZRbcE39L9E75nw

---
_Generated by [Claude Code](https://claude.ai/code/session_012ajRQHucZRbcE39L9E75nw)_