### PR TITLE
Agent SDK: connect to external MCP servers as tool sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3846,12 +3846,14 @@
       "name": "@minicode/agent-sdk",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.76.0"
+        "@anthropic-ai/sdk": "^0.76.0",
+        "@modelcontextprotocol/sdk": "^1.29.0"
       },
       "devDependencies": {
         "@types/node": "^25.2.3",
         "tsx": "^4.21.0",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "zod": "^3.25.76"
       },
       "engines": {
         "node": ">=22.0.0"

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -399,6 +399,12 @@ await mcp.close();
   (e.g. `github__create_issue`) so two servers can both expose
   `read_file` without collisions. Pass `{ namespace: false }` to opt out
   when you control the server set.
+- **Name sanitization.** Anthropic and OpenAI-compatible providers
+  restrict tool names to `[a-zA-Z0-9_-]{1,64}`. Server and tool names
+  outside that pattern (e.g. `github mcp`, `repo.create_issue`) get
+  invalid characters replaced with `_` and the result truncated to 64
+  chars before exposure. The original MCP tool name is preserved for
+  `callTool` dispatch — sanitization only changes what the model sees.
 - **Failure isolation.** A server that fails to start or list its tools
   is skipped with a warning; other servers keep working. Pass `onError`
   to override the default `console.warn`.

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -348,6 +348,76 @@ const agent = new CodingAgent({
 | `list_files` | List files and directories with pagination |
 | `run_command` | Execute shell commands with timeout and safety checks |
 
+## External MCP Servers
+
+Connect to one or more MCP (Model Context Protocol) servers and pull
+their tools into the agent's `ToolRegistry` alongside the built-in
+ones. The SDK ships the entire MCP client stack — no extra dependency
+is required — and supports the three common transports: `stdio`
+(subprocess), `http` (Streamable-HTTP), and `sse` (legacy SSE).
+
+```typescript
+import {
+  CodingAgent,
+  ToolRegistry,
+  createMcpTools,
+  createReadFileTool,
+} from "@minicode/agent-sdk";
+
+const mcp = await createMcpTools({
+  servers: [
+    {
+      name: "github",
+      transport: "stdio",
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-github"],
+      env: { GITHUB_PERSONAL_ACCESS_TOKEN: process.env.GH_TOKEN! },
+    },
+    {
+      name: "fs",
+      transport: "stdio",
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "/path"],
+    },
+  ],
+});
+
+const registry = new ToolRegistry([
+  createReadFileTool({ workspaceRoot, maxFileSizeBytes: 1_000_000 }),
+  ...mcp.tools,
+]);
+
+const agent = new CodingAgent({ config, modelClient, toolRegistry: registry });
+
+// On shutdown:
+await mcp.close();
+```
+
+### Behavior notes
+
+- **Namespacing.** Tool names are prefixed with `<server>__` by default
+  (e.g. `github__create_issue`) so two servers can both expose
+  `read_file` without collisions. Pass `{ namespace: false }` to opt out
+  when you control the server set.
+- **Failure isolation.** A server that fails to start or list its tools
+  is skipped with a warning; other servers keep working. Pass `onError`
+  to override the default `console.warn`.
+- **Permission gate.** MCP tools flow through the existing
+  `beforeToolCall` hook unchanged — hosts can gate them by tool name
+  the same way they gate built-in tools.
+- **Result formatting.** Text content blocks are concatenated into
+  the tool's string output. Image, audio, and binary resource blocks
+  are replaced with bracketed placeholders for now.
+- **Lifecycle.** Connections open at `createMcpTools()` time and stay
+  open until `bundle.close()`. There is no auto-reconnect in v1; if a
+  server crashes mid-session, the next call returns an error and the
+  model can react.
+
+For advanced use cases (custom transport, in-process server, BYO
+`Client`), use the `wrapMcpClients(servers, options)` lower-level
+entry point instead — it takes pre-connected clients and produces the
+same `McpToolBundle`.
+
 ## Development
 
 ```bash

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -22,11 +22,13 @@
     "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" --max-warnings=0"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.76.0"
+    "@anthropic-ai/sdk": "^0.76.0",
+    "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "devDependencies": {
     "@types/node": "^25.2.3",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "zod": "^3.25.76"
   }
 }

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -111,3 +111,13 @@ export type {
   ProjectIndex,
   SymbolKind,
 } from "./indexer/types.js";
+
+// MCP client integration
+export {
+  createMcpTools,
+  formatMcpResult,
+  wrapMcpClients,
+  type CreateMcpToolsOptions,
+  type McpServerConfig,
+  type McpToolBundle,
+} from "./mcp/client-registry.js";

--- a/packages/agent-sdk/src/mcp/client-registry.ts
+++ b/packages/agent-sdk/src/mcp/client-registry.ts
@@ -241,6 +241,11 @@ function buildToolDefinition(
  * spawning / connecting the underlying transport. Useful when the
  * caller wants to bring its own `Client` (e.g. a custom transport or
  * an in-memory test server).
+ *
+ * Ownership: the returned bundle takes ownership of every client
+ * passed in. `bundle.close()` closes successful clients; any client
+ * whose `listTools()` throws is also closed before `onError` fires,
+ * so callers don't have to worry about leaked transports.
  */
 export async function wrapMcpClients(
   servers: Array<{ name: string; client: Client }>,
@@ -264,6 +269,15 @@ export async function wrapMcpClients(
           })),
         });
       } catch (error) {
+        // Transport may have already connected before listTools threw —
+        // close it so we don't leak the spawned subprocess / HTTP /
+        // SSE connection. Errors during cleanup are swallowed; the
+        // original failure is what the caller cares about.
+        try {
+          await client.close();
+        } catch {
+          // ignore
+        }
         onError(name, error);
       }
     }),

--- a/packages/agent-sdk/src/mcp/client-registry.ts
+++ b/packages/agent-sdk/src/mcp/client-registry.ts
@@ -208,12 +208,39 @@ async function connectServer(
   return { name: config.name, client };
 }
 
+/**
+ * Anthropic and OpenAI-compatible providers restrict tool names to
+ * `^[a-zA-Z0-9_-]{1,64}$`. MCP servers and config impose no such
+ * limit (a server might be named `github mcp` or expose a tool
+ * `repo.create_issue`), so we sanitize each segment by replacing any
+ * disallowed character with `_` and truncating to 64 chars. The
+ * original MCP tool name is preserved separately for `callTool`
+ * dispatch — sanitization only affects what the model sees.
+ */
+const TOOL_NAME_INVALID = /[^a-zA-Z0-9_-]/g;
+const TOOL_NAME_MAX_LENGTH = 64;
+
+function sanitizeNameSegment(segment: string): string {
+  return segment.replace(TOOL_NAME_INVALID, "_");
+}
+
+function buildExposedName(
+  serverName: string,
+  toolName: string,
+  namespace: boolean,
+): string {
+  const raw = namespace
+    ? `${sanitizeNameSegment(serverName)}__${sanitizeNameSegment(toolName)}`
+    : sanitizeNameSegment(toolName);
+  return raw.slice(0, TOOL_NAME_MAX_LENGTH);
+}
+
 function buildToolDefinition(
   server: ConnectedServer,
   tool: ConnectedServer["tools"][number],
   namespace: boolean,
 ): ToolDefinition {
-  const exposedName = namespace ? `${server.name}__${tool.name}` : tool.name;
+  const exposedName = buildExposedName(server.name, tool.name, namespace);
   return {
     name: exposedName,
     description: tool.description ?? `Tool from MCP server "${server.name}".`,
@@ -288,6 +315,15 @@ export async function wrapMcpClients(
   for (const server of connected) {
     for (const tool of server.tools) {
       const def = buildToolDefinition(server, tool, namespace);
+      if (def.name.length === 0) {
+        onError(
+          server.name,
+          new Error(
+            `Tool "${tool.name}" sanitized to an empty name; skipping.`,
+          ),
+        );
+        continue;
+      }
       if (seenNames.has(def.name)) {
         onError(
           server.name,

--- a/packages/agent-sdk/src/mcp/client-registry.ts
+++ b/packages/agent-sdk/src/mcp/client-registry.ts
@@ -1,0 +1,327 @@
+/**
+ * MCP (Model Context Protocol) client integration for the Agent SDK.
+ *
+ * Connects to one or more external MCP servers, lists their tools, and
+ * wraps each as a `ToolDefinition` ready to drop into a `ToolRegistry`.
+ * Consumers get the entire MCP ecosystem (filesystem, github, sqlite,
+ * puppeteer, ...) without hand-wrapping every tool.
+ *
+ * Symmetric to `src/serve/mcp-server.ts` (which exposes minicode's
+ * tools as an MCP *server*); this is the *client* side.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+import type { ToolDefinition } from "../agent/types.js";
+
+type AnyTransport =
+  | StdioClientTransport
+  | StreamableHTTPClientTransport
+  | SSEClientTransport;
+
+/**
+ * Configuration for a single MCP server. Three transports are
+ * supported: spawn a subprocess (`stdio`, the most common shape),
+ * connect to a hosted Streamable-HTTP endpoint (`http`), or connect
+ * to a legacy SSE endpoint (`sse`).
+ */
+export type McpServerConfig =
+  | {
+      name: string;
+      transport: "stdio";
+      command: string;
+      args?: string[];
+      env?: Record<string, string>;
+      cwd?: string;
+    }
+  | {
+      name: string;
+      transport: "http";
+      url: string;
+      headers?: Record<string, string>;
+    }
+  | {
+      name: string;
+      transport: "sse";
+      url: string;
+      headers?: Record<string, string>;
+    };
+
+export interface CreateMcpToolsOptions {
+  servers: McpServerConfig[];
+  /**
+   * Prefix tool names with `<server>__` to avoid collisions across
+   * servers that happen to expose the same tool name (e.g. multiple
+   * servers exposing `read_file`). Default: true.
+   */
+  namespace?: boolean;
+  /**
+   * Called when a server fails to connect or list its tools. The
+   * agent continues with the rest of the servers — a flaky GitHub
+   * MCP shouldn't break filesystem MCP. Default: `console.warn`.
+   */
+  onError?: (server: string, error: unknown) => void;
+}
+
+export interface McpToolBundle {
+  /** Tools ready to drop into a `ToolRegistry`. */
+  tools: ToolDefinition[];
+  /** Disconnect every connected client. Call on agent shutdown. */
+  close: () => Promise<void>;
+}
+
+interface ConnectedServer {
+  name: string;
+  client: Client;
+  /**
+   * Tools as the server reports them, keyed by their original (un-namespaced)
+   * name so we can dispatch `callTool` with the unprefixed name.
+   */
+  tools: Array<{
+    name: string;
+    description?: string | undefined;
+    inputSchema: Record<string, unknown>;
+  }>;
+}
+
+function createTransport(config: McpServerConfig): AnyTransport {
+  switch (config.transport) {
+    case "stdio": {
+      const params: ConstructorParameters<typeof StdioClientTransport>[0] = {
+        command: config.command,
+        args: config.args ?? [],
+      };
+      if (config.env) params.env = config.env;
+      if (config.cwd) params.cwd = config.cwd;
+      return new StdioClientTransport(params);
+    }
+    case "http": {
+      const opts = config.headers
+        ? { requestInit: { headers: config.headers } }
+        : undefined;
+      return new StreamableHTTPClientTransport(new URL(config.url), opts);
+    }
+    case "sse": {
+      const opts = config.headers
+        ? { requestInit: { headers: config.headers } }
+        : undefined;
+      return new SSEClientTransport(new URL(config.url), opts);
+    }
+  }
+}
+
+interface McpContentBlock {
+  type: string;
+  text?: string;
+  data?: string;
+  mimeType?: string;
+  resource?: {
+    uri: string;
+    text?: string;
+    blob?: string;
+    mimeType?: string;
+  };
+  uri?: string;
+  name?: string;
+}
+
+/**
+ * Render an MCP tool result into a string the model can read.
+ * Concatenates text blocks; non-text blocks become bracketed
+ * placeholders so the model knows something was returned without
+ * us having to support binary content end-to-end (out of scope for
+ * v1 — see #168).
+ */
+export function formatMcpResult(
+  content: ReadonlyArray<McpContentBlock>,
+): string {
+  if (content.length === 0) {
+    return "(empty result)";
+  }
+
+  const parts: string[] = [];
+  for (const block of content) {
+    switch (block.type) {
+      case "text":
+        if (typeof block.text === "string") {
+          parts.push(block.text);
+        }
+        break;
+      case "image":
+        parts.push(
+          `[image content omitted (${block.mimeType ?? "unknown type"})]`,
+        );
+        break;
+      case "audio":
+        parts.push(
+          `[audio content omitted (${block.mimeType ?? "unknown type"})]`,
+        );
+        break;
+      case "resource": {
+        const r = block.resource;
+        if (r && typeof r.text === "string") {
+          parts.push(r.text);
+        } else if (r) {
+          parts.push(
+            `[resource ${r.uri}${r.mimeType ? ` (${r.mimeType})` : ""}]`,
+          );
+        } else {
+          parts.push("[resource]");
+        }
+        break;
+      }
+      case "resource_link": {
+        const label = block.name ?? block.uri ?? "unknown";
+        parts.push(`[resource_link ${label}]`);
+        break;
+      }
+      default:
+        parts.push(`[unsupported content type: ${block.type}]`);
+    }
+  }
+  return parts.join("\n");
+}
+
+function defaultOnError(server: string, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  console.warn(
+    `[minicode-mcp] Failed to load tools from server "${server}": ${message}`,
+  );
+}
+
+async function connectServer(
+  config: McpServerConfig,
+): Promise<{ name: string; client: Client }> {
+  const transport = createTransport(config);
+  const client = new Client(
+    { name: "@minicode/agent-sdk", version: "0.1.0" },
+    { capabilities: {} },
+  );
+  // The MCP SDK's Transport interface uses `string` for some fields the
+  // concrete transports declare as `string | undefined`. Cast to bypass
+  // the exactOptionalPropertyTypes mismatch — same pattern used on the
+  // server side in src/serve/mcp-server.ts.
+  await client.connect(transport as Parameters<typeof client.connect>[0]);
+  return { name: config.name, client };
+}
+
+function buildToolDefinition(
+  server: ConnectedServer,
+  tool: ConnectedServer["tools"][number],
+  namespace: boolean,
+): ToolDefinition {
+  const exposedName = namespace ? `${server.name}__${tool.name}` : tool.name;
+  return {
+    name: exposedName,
+    description: tool.description ?? `Tool from MCP server "${server.name}".`,
+    inputSchema: tool.inputSchema,
+    execute: async (input: Record<string, unknown>): Promise<string> => {
+      const result = await server.client.callTool({
+        name: tool.name,
+        arguments: input,
+      });
+      const formatted = formatMcpResult(
+        (result.content ?? []) as McpContentBlock[],
+      );
+      if (result.isError) {
+        return `MCP tool error (${exposedName}): ${formatted}`;
+      }
+      return formatted;
+    },
+  };
+}
+
+/**
+ * Discover tools on a list of already-connected MCP clients and wrap
+ * each as a `ToolDefinition`. The advanced entry point — most
+ * consumers want `createMcpTools` instead, which also handles
+ * spawning / connecting the underlying transport. Useful when the
+ * caller wants to bring its own `Client` (e.g. a custom transport or
+ * an in-memory test server).
+ */
+export async function wrapMcpClients(
+  servers: Array<{ name: string; client: Client }>,
+  options?: { namespace?: boolean; onError?: CreateMcpToolsOptions["onError"] },
+): Promise<McpToolBundle> {
+  const namespace = options?.namespace ?? true;
+  const onError = options?.onError ?? defaultOnError;
+
+  const connected: ConnectedServer[] = [];
+  await Promise.all(
+    servers.map(async ({ name, client }) => {
+      try {
+        const result = await client.listTools();
+        connected.push({
+          name,
+          client,
+          tools: result.tools.map((t) => ({
+            name: t.name,
+            description: t.description,
+            inputSchema: t.inputSchema as Record<string, unknown>,
+          })),
+        });
+      } catch (error) {
+        onError(name, error);
+      }
+    }),
+  );
+
+  const tools: ToolDefinition[] = [];
+  const seenNames = new Set<string>();
+  for (const server of connected) {
+    for (const tool of server.tools) {
+      const def = buildToolDefinition(server, tool, namespace);
+      if (seenNames.has(def.name)) {
+        onError(
+          server.name,
+          new Error(
+            `Tool name collision: "${def.name}" is already exposed by another server.`,
+          ),
+        );
+        continue;
+      }
+      seenNames.add(def.name);
+      tools.push(def);
+    }
+  }
+
+  const close = async (): Promise<void> => {
+    await Promise.allSettled(connected.map((s) => s.client.close()));
+  };
+
+  return { tools, close };
+}
+
+/**
+ * Connect to each configured MCP server, discover its tools, and
+ * return them as `ToolDefinition`s ready to register. Servers that
+ * fail to connect or list their tools are skipped (with a warning);
+ * the bundle still includes tools from the servers that succeeded.
+ */
+export async function createMcpTools(
+  options: CreateMcpToolsOptions,
+): Promise<McpToolBundle> {
+  const onError = options.onError ?? defaultOnError;
+
+  const settled = await Promise.allSettled(
+    options.servers.map((s) => connectServer(s)),
+  );
+
+  const connected: Array<{ name: string; client: Client }> = [];
+  settled.forEach((result, idx) => {
+    const cfg = options.servers[idx];
+    if (!cfg) return;
+    if (result.status === "fulfilled") {
+      connected.push(result.value);
+    } else {
+      onError(cfg.name, result.reason);
+    }
+  });
+
+  const wrapOpts: { namespace?: boolean; onError: typeof onError } = { onError };
+  if (options.namespace !== undefined) wrapOpts.namespace = options.namespace;
+  return wrapMcpClients(connected, wrapOpts);
+}

--- a/packages/agent-sdk/tests/fixtures/mcp-stdio-fixture.mjs
+++ b/packages/agent-sdk/tests/fixtures/mcp-stdio-fixture.mjs
@@ -1,0 +1,34 @@
+// A tiny MCP server used by mcp-client.integration.test.ts to verify
+// stdio roundtrips end-to-end. Mirrors the shape of real MCP servers
+// that ship as `npx`-spawned subprocesses (e.g. server-filesystem,
+// server-github) without pulling them in as test deps.
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const server = new McpServer(
+  { name: "fixture", version: "0.0.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.tool(
+  "add",
+  "Add two numbers and return the sum.",
+  { a: z.number(), b: z.number() },
+  async ({ a, b }) => ({
+    content: [{ type: "text", text: String(a + b) }],
+  }),
+);
+
+server.tool(
+  "echo",
+  "Echo the provided message.",
+  { message: z.string() },
+  async ({ message }) => ({
+    content: [{ type: "text", text: message }],
+  }),
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/agent-sdk/tests/mcp-client.integration.test.ts
+++ b/packages/agent-sdk/tests/mcp-client.integration.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import { createMcpTools } from "../src/mcp/client-registry.js";
+
+const FIXTURE_PATH = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "fixtures",
+  "mcp-stdio-fixture.mjs",
+);
+
+test("createMcpTools roundtrips end-to-end against a stdio MCP server", async () => {
+  const bundle = await createMcpTools({
+    servers: [
+      {
+        name: "math",
+        transport: "stdio",
+        command: process.execPath,
+        args: [FIXTURE_PATH],
+      },
+    ],
+  });
+
+  try {
+    const names = bundle.tools.map((t) => t.name).sort();
+    assert.deepEqual(names, ["math__add", "math__echo"]);
+
+    const addTool = bundle.tools.find((t) => t.name === "math__add");
+    assert.ok(addTool, "expected math__add to be present");
+    const addOut = await addTool.execute({ a: 2, b: 40 });
+    assert.equal(addOut, "42");
+
+    const echoTool = bundle.tools.find((t) => t.name === "math__echo");
+    assert.ok(echoTool, "expected math__echo to be present");
+    const echoOut = await echoTool.execute({ message: "hi mom" });
+    assert.equal(echoOut, "hi mom");
+  } finally {
+    await bundle.close();
+  }
+});
+
+test("createMcpTools merges tools from multiple stdio servers", async () => {
+  const bundle = await createMcpTools({
+    servers: [
+      {
+        name: "alpha",
+        transport: "stdio",
+        command: process.execPath,
+        args: [FIXTURE_PATH],
+      },
+      {
+        name: "beta",
+        transport: "stdio",
+        command: process.execPath,
+        args: [FIXTURE_PATH],
+      },
+    ],
+  });
+
+  try {
+    const names = bundle.tools.map((t) => t.name).sort();
+    assert.deepEqual(names, [
+      "alpha__add",
+      "alpha__echo",
+      "beta__add",
+      "beta__echo",
+    ]);
+  } finally {
+    await bundle.close();
+  }
+});

--- a/packages/agent-sdk/tests/mcp-client.test.ts
+++ b/packages/agent-sdk/tests/mcp-client.test.ts
@@ -85,6 +85,34 @@ test("formatMcpResult inlines text from resource blocks", () => {
   assert.equal(out, "resource body");
 });
 
+test("formatMcpResult labels binary resource blocks with uri and mime type", () => {
+  const out = formatMcpResult([
+    {
+      type: "resource",
+      resource: {
+        uri: "test://blob",
+        blob: "base64...",
+        mimeType: "application/octet-stream",
+      },
+    },
+  ]);
+  assert.equal(out, "[resource test://blob (application/octet-stream)]");
+});
+
+test("formatMcpResult renders resource_link blocks", () => {
+  const out = formatMcpResult([
+    { type: "resource_link", uri: "test://link", name: "linked-thing" },
+  ]);
+  assert.equal(out, "[resource_link linked-thing]");
+});
+
+test("formatMcpResult labels unsupported content types", () => {
+  const out = formatMcpResult([
+    { type: "video", data: "..." },
+  ]);
+  assert.equal(out, "[unsupported content type: video]");
+});
+
 test("formatMcpResult returns sentinel on empty content", () => {
   assert.equal(formatMcpResult([]), "(empty result)");
 });

--- a/packages/agent-sdk/tests/mcp-client.test.ts
+++ b/packages/agent-sdk/tests/mcp-client.test.ts
@@ -138,6 +138,66 @@ test("wrapMcpClients omits namespacing when namespace is false", async () => {
   await bundle.close();
 });
 
+test("wrapMcpClients sanitizes invalid characters in server and tool names", async () => {
+  // Anthropic / OpenAI restrict tool names to [a-zA-Z0-9_-]{1,64}.
+  // A server / tool with dots or spaces would otherwise crash the API call.
+  const seenArgs: Array<Record<string, unknown>> = [];
+  const client = await spawnInMemoryServer({
+    name: "fixture",
+    tools: [
+      {
+        name: "repo.create_issue",
+        description: "namespaced tool",
+        schema: { title: z.string() },
+        handler: async (args) => {
+          seenArgs.push(args);
+          return { content: [{ type: "text" as const, text: "ok" }] };
+        },
+      },
+    ],
+  });
+
+  const bundle = await wrapMcpClients([
+    { name: "github mcp", client },
+  ]);
+
+  assert.equal(bundle.tools.length, 1);
+  assert.equal(bundle.tools[0]!.name, "github_mcp__repo_create_issue");
+  // Original MCP tool name must be preserved for the actual callTool dispatch.
+  await bundle.tools[0]!.execute({ title: "hello" });
+  assert.equal(seenArgs.length, 1);
+  assert.equal(seenArgs[0]!.title, "hello");
+  await bundle.close();
+});
+
+test("wrapMcpClients truncates exposed names that exceed 64 chars", async () => {
+  const longTool = "x".repeat(80);
+  const client = await spawnInMemoryServer({
+    name: "fixture",
+    tools: [
+      {
+        name: longTool,
+        description: "very long",
+        schema: {},
+        handler: async () => ({
+          content: [{ type: "text" as const, text: "ok" }],
+        }),
+      },
+    ],
+  });
+
+  const bundle = await wrapMcpClients(
+    [{ name: "s", client }],
+    { namespace: false },
+  );
+  assert.equal(bundle.tools.length, 1);
+  assert.ok(
+    bundle.tools[0]!.name.length <= 64,
+    `expected <= 64 chars, got ${bundle.tools[0]!.name.length}`,
+  );
+  await bundle.close();
+});
+
 test("wrapMcpClients reports name collisions via onError and skips duplicates", async () => {
   const a = await spawnInMemoryServer({
     name: "a",

--- a/packages/agent-sdk/tests/mcp-client.test.ts
+++ b/packages/agent-sdk/tests/mcp-client.test.ts
@@ -212,6 +212,47 @@ test("wrapMcpClients forwards isError through the wrapped result", async () => {
   await bundle.close();
 });
 
+test("wrapMcpClients closes clients whose listTools throws (no transport leak)", async () => {
+  // Build a real connected client, then monkey-patch listTools to throw.
+  // We'd otherwise leak its in-memory transport — verify close() ran.
+  const client = await spawnInMemoryServer({
+    name: "leaky",
+    tools: [
+      {
+        name: "noop",
+        description: "noop",
+        schema: {},
+        handler: async () => ({ content: [{ type: "text" as const, text: "" }] }),
+      },
+    ],
+  });
+
+  let closed = false;
+  const originalClose = client.close.bind(client);
+  client.close = async () => {
+    closed = true;
+    await originalClose();
+  };
+  client.listTools = async () => {
+    throw new Error("listTools failed");
+  };
+
+  const errors: string[] = [];
+  const bundle = await wrapMcpClients(
+    [{ name: "leaky", client }],
+    {
+      onError: (name) => {
+        errors.push(name);
+      },
+    },
+  );
+
+  assert.equal(bundle.tools.length, 0);
+  assert.deepEqual(errors, ["leaky"]);
+  assert.equal(closed, true, "client.close() should have been called when listTools threw");
+  await bundle.close();
+});
+
 test("wrapMcpClients uses onError when listTools rejects, skips that server", async () => {
   const good = await spawnInMemoryServer({
     name: "good",

--- a/packages/agent-sdk/tests/mcp-client.test.ts
+++ b/packages/agent-sdk/tests/mcp-client.test.ts
@@ -1,0 +1,308 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import {
+  createMcpTools,
+  formatMcpResult,
+  wrapMcpClients,
+} from "../src/mcp/client-registry.js";
+
+interface TestServerSpec {
+  name: string;
+  version?: string;
+  tools: Array<{
+    name: string;
+    description: string;
+    schema: Record<string, z.ZodTypeAny>;
+    handler: (args: Record<string, unknown>) => Promise<{
+      content: Array<{ type: string; text?: string; [k: string]: unknown }>;
+      isError?: boolean;
+    }>;
+  }>;
+}
+
+/**
+ * Spin up an in-process MCP server, link it to a client via
+ * InMemoryTransport, and return the connected client.
+ */
+async function spawnInMemoryServer(spec: TestServerSpec): Promise<Client> {
+  const server = new McpServer(
+    { name: spec.name, version: spec.version ?? "1.0.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  for (const t of spec.tools) {
+    server.tool(t.name, t.description, t.schema, async (args) => {
+      const result = await t.handler(args as Record<string, unknown>);
+      return result as never;
+    });
+  }
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport as never);
+
+  const client = new Client(
+    { name: "test-client", version: "1.0.0" },
+    { capabilities: {} },
+  );
+  await client.connect(clientTransport as never);
+  return client;
+}
+
+test("formatMcpResult concatenates text blocks", () => {
+  const out = formatMcpResult([
+    { type: "text", text: "hello" },
+    { type: "text", text: "world" },
+  ]);
+  assert.equal(out, "hello\nworld");
+});
+
+test("formatMcpResult substitutes placeholders for non-text blocks", () => {
+  const out = formatMcpResult([
+    { type: "text", text: "before" },
+    { type: "image", mimeType: "image/png", data: "..." },
+    { type: "audio", mimeType: "audio/wav", data: "..." },
+    { type: "text", text: "after" },
+  ]);
+  assert.equal(
+    out,
+    "before\n[image content omitted (image/png)]\n[audio content omitted (audio/wav)]\nafter",
+  );
+});
+
+test("formatMcpResult inlines text from resource blocks", () => {
+  const out = formatMcpResult([
+    {
+      type: "resource",
+      resource: { uri: "test://file", text: "resource body" },
+    },
+  ]);
+  assert.equal(out, "resource body");
+});
+
+test("formatMcpResult returns sentinel on empty content", () => {
+  assert.equal(formatMcpResult([]), "(empty result)");
+});
+
+test("wrapMcpClients discovers tools and namespaces them", async () => {
+  const client = await spawnInMemoryServer({
+    name: "fs-mock",
+    tools: [
+      {
+        name: "read",
+        description: "read a file",
+        schema: { path: z.string() },
+        handler: async ({ path }) => ({
+          content: [{ type: "text" as const, text: `read ${String(path)}` }],
+        }),
+      },
+    ],
+  });
+
+  const bundle = await wrapMcpClients([{ name: "fs", client }]);
+  assert.equal(bundle.tools.length, 1);
+  assert.equal(bundle.tools[0]!.name, "fs__read");
+  assert.equal(bundle.tools[0]!.description, "read a file");
+
+  const out = await bundle.tools[0]!.execute({ path: "/tmp/x" });
+  assert.equal(out, "read /tmp/x");
+  await bundle.close();
+});
+
+test("wrapMcpClients omits namespacing when namespace is false", async () => {
+  const client = await spawnInMemoryServer({
+    name: "fs-mock",
+    tools: [
+      {
+        name: "list",
+        description: "list files",
+        schema: {},
+        handler: async () => ({
+          content: [{ type: "text" as const, text: "a\nb\nc" }],
+        }),
+      },
+    ],
+  });
+
+  const bundle = await wrapMcpClients(
+    [{ name: "fs", client }],
+    { namespace: false },
+  );
+  assert.equal(bundle.tools.length, 1);
+  assert.equal(bundle.tools[0]!.name, "list");
+  await bundle.close();
+});
+
+test("wrapMcpClients reports name collisions via onError and skips duplicates", async () => {
+  const a = await spawnInMemoryServer({
+    name: "a",
+    tools: [
+      {
+        name: "echo",
+        description: "echo",
+        schema: { msg: z.string() },
+        handler: async ({ msg }) => ({
+          content: [{ type: "text" as const, text: `a:${String(msg)}` }],
+        }),
+      },
+    ],
+  });
+  const b = await spawnInMemoryServer({
+    name: "b",
+    tools: [
+      {
+        name: "echo",
+        description: "echo",
+        schema: { msg: z.string() },
+        handler: async ({ msg }) => ({
+          content: [{ type: "text" as const, text: `b:${String(msg)}` }],
+        }),
+      },
+    ],
+  });
+
+  const errors: Array<{ server: string; message: string }> = [];
+  const bundle = await wrapMcpClients(
+    [
+      { name: "shared", client: a },
+      { name: "shared", client: b },
+    ],
+    {
+      namespace: true,
+      onError: (server, error) => {
+        errors.push({
+          server,
+          message: error instanceof Error ? error.message : String(error),
+        });
+      },
+    },
+  );
+
+  assert.equal(bundle.tools.length, 1);
+  assert.equal(bundle.tools[0]!.name, "shared__echo");
+  assert.equal(errors.length, 1);
+  assert.match(errors[0]!.message, /Tool name collision/);
+  await bundle.close();
+});
+
+test("wrapMcpClients forwards isError through the wrapped result", async () => {
+  const client = await spawnInMemoryServer({
+    name: "errorful",
+    tools: [
+      {
+        name: "boom",
+        description: "always fails",
+        schema: {},
+        handler: async () => ({
+          content: [{ type: "text" as const, text: "kaboom" }],
+          isError: true,
+        }),
+      },
+    ],
+  });
+
+  const bundle = await wrapMcpClients([{ name: "x", client }]);
+  const out = await bundle.tools[0]!.execute({});
+  assert.match(out, /MCP tool error \(x__boom\): kaboom/);
+  await bundle.close();
+});
+
+test("wrapMcpClients uses onError when listTools rejects, skips that server", async () => {
+  const good = await spawnInMemoryServer({
+    name: "good",
+    tools: [
+      {
+        name: "ping",
+        description: "ping",
+        schema: {},
+        handler: async () => ({
+          content: [{ type: "text" as const, text: "pong" }],
+        }),
+      },
+    ],
+  });
+
+  // A client that's never been connected — listTools throws.
+  const broken = new Client(
+    { name: "broken", version: "1.0.0" },
+    { capabilities: {} },
+  );
+
+  const errors: string[] = [];
+  const bundle = await wrapMcpClients(
+    [
+      { name: "broken", client: broken },
+      { name: "good", client: good },
+    ],
+    {
+      onError: (name) => {
+        errors.push(name);
+      },
+    },
+  );
+
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0], "broken");
+  assert.equal(bundle.tools.length, 1);
+  assert.equal(bundle.tools[0]!.name, "good__ping");
+  await bundle.close();
+});
+
+test("createMcpTools surfaces transport-level connect failures via onError", async () => {
+  // Use a stdio command that doesn't exist so the spawn fails.
+  const errors: Array<{ name: string; message: string }> = [];
+  const bundle = await createMcpTools({
+    servers: [
+      {
+        name: "missing",
+        transport: "stdio",
+        command: "/nonexistent/path/that/should/not/exist",
+        args: [],
+      },
+    ],
+    onError: (name, error) => {
+      errors.push({
+        name,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    },
+  });
+
+  assert.equal(bundle.tools.length, 0);
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0]!.name, "missing");
+  await bundle.close();
+});
+
+test("wrapped tool roundtrips arguments to client.callTool", async () => {
+  const seenArgs: Array<Record<string, unknown>> = [];
+  const client = await spawnInMemoryServer({
+    name: "arg-spy",
+    tools: [
+      {
+        name: "spy",
+        description: "captures its args",
+        schema: { a: z.number(), b: z.string() },
+        handler: async (args) => {
+          seenArgs.push(args);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(args) }],
+          };
+        },
+      },
+    ],
+  });
+
+  const bundle = await wrapMcpClients([{ name: "s", client }]);
+  const out = await bundle.tools[0]!.execute({ a: 7, b: "hi" });
+  assert.equal(out, '{"a":7,"b":"hi"}');
+  assert.equal(seenArgs.length, 1);
+  assert.equal(seenArgs[0]!.a, 7);
+  assert.equal(seenArgs[0]!.b, "hi");
+  await bundle.close();
+});


### PR DESCRIPTION
## Summary

Closes #168. Adds `createMcpTools(options)` — connect to external MCP servers, discover their tools, and wrap each as a `ToolDefinition` ready to drop into a `ToolRegistry` alongside the built-in tools. This is the inverse of the existing minicode-as-MCP-server in `src/serve/mcp-server.ts`: external SDK consumers now get the entire MCP ecosystem (`server-github`, `server-filesystem`, `server-sqlite`, `server-puppeteer`, `server-postgres`, …) without hand-wrapping every tool.

```typescript
import {
  CodingAgent,
  ToolRegistry,
  createMcpTools,
  createReadFileTool,
} from "@minicode/agent-sdk";

const mcp = await createMcpTools({
  servers: [
    {
      name: "github",
      transport: "stdio",
      command: "npx",
      args: ["-y", "@modelcontextprotocol/server-github"],
      env: { GITHUB_PERSONAL_ACCESS_TOKEN: process.env.GH_TOKEN! },
    },
    {
      name: "fs",
      transport: "stdio",
      command: "npx",
      args: ["-y", "@modelcontextprotocol/server-filesystem", "/path"],
    },
  ],
});

const registry = new ToolRegistry([
  createReadFileTool({ workspaceRoot, maxFileSizeBytes: 1_000_000 }),
  ...mcp.tools,
]);

const agent = new CodingAgent({ config, modelClient, toolRegistry: registry });

// On shutdown:
await mcp.close();
```

### What's included

- **All three transports in one PR** — `stdio` (subprocess), `http` (Streamable-HTTP), and `sse` (legacy SSE). The MCP SDK we already bundle ships every client transport, so the only dependency change was promoting `@modelcontextprotocol/sdk` from a transitive (via the root) to a declared dep of `@minicode/agent-sdk`.
- **`__` tool namespacing by default** — prevents collisions across servers that expose the same name (e.g. `read_file`). Opt-out via `{ namespace: false }`.
- **Failure isolation** — a server that fails to connect or list its tools is skipped with a warning; other servers keep working. `onError` is configurable.
- **Result formatting** — text content blocks concatenated into the tool's string output; image/audio/binary resource blocks become bracketed placeholders (binary support is out of scope for v1).
- **Lifecycle** — `bundle.close()` cleanly disconnects every connected client.
- **Advanced entry point** — `wrapMcpClients(servers, options)` accepts pre-connected MCP `Client`s, useful for in-process tests or custom transports.
- **Permission gate** — MCP tools flow through the existing `beforeToolCall` hook unchanged; hosts can gate them by tool name like any built-in tool.

### Out of scope (per #168)

MCP resources, prompts, sampling, hot-reload, web UI for managing servers, binary content blocks. Hot-reload + the web UI are good follow-ups once we see real usage.

## Test plan

- [x] 11 unit tests using `InMemoryTransport.createLinkedPair()`: tool discovery, namespacing on/off, collision handling, `isError` forwarding, argument roundtrip, and connection-failure paths
- [x] 2 integration tests spawning a real stdio MCP server fixture (`tests/fixtures/mcp-stdio-fixture.mjs`, a tiny Node script using `StdioServerTransport`) — proves the same path that real `npx`-spawned servers take, end-to-end
- [x] `npm run build --workspace=packages/agent-sdk` clean
- [x] All 103 agent-sdk tests pass (was 90 before; +13 new)
- [x] Full root suite: 657/661 pass — the 4 failures (`workspace-changes.test.ts`) are pre-existing on main, unrelated to this PR (`git commit` failing because the test env has no git user configured)
- [x] Lint clean

Part of the broader push (alongside #169, now merged) to make `@minicode/agent-sdk` actually consumable by external apps.

https://claude.ai/code/session_012ajRQHucZRbcE39L9E75nw

---
_Generated by [Claude Code](https://claude.ai/code/session_012ajRQHucZRbcE39L9E75nw)_