### PR TITLE
Agent SDK: structured output via synthetic tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3847,7 +3847,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.76.0",
-        "@modelcontextprotocol/sdk": "^1.29.0"
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "ajv": "^8.18.0"
       },
       "devDependencies": {
         "@types/node": "^25.2.3",
@@ -3858,6 +3859,28 @@
       "engines": {
         "node": ">=22.0.0"
       }
+    },
+    "packages/agent-sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/agent-sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "packages/minicode-plugin-python": {
       "version": "0.1.0",

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -424,6 +424,81 @@ For advanced use cases (custom transport, in-process server, BYO
 entry point instead — it takes pre-connected clients and produces the
 same `McpToolBundle`.
 
+## Structured Output
+
+Ask a turn to return validated, schema-conformant JSON instead of free-form
+text. Useful for extraction, classification, and any "agent that thinks via
+tools, then commits to a structured answer" workflow.
+
+Under the hood: when you pass an `outputSchema`, the SDK appends a synthetic
+tool with that input shape to the model's tool list. The model decides to
+"call" it the same way it'd call any other tool; the SDK intercepts the call,
+validates the arguments against your schema, and returns them as
+`result.output`. Real tools and the synthetic tool coexist — the model can
+gather data via real tool calls and then deliver the structured answer.
+
+```typescript
+import {
+  CodingAgent,
+  ToolRegistry,
+  createMcpTools,
+  type OutputSchema,
+} from "@minicode/agent-sdk";
+
+const InvoiceSchema: OutputSchema = {
+  name: "Invoice",
+  description: "Call this with the extracted invoice once you've finished reading the file.",
+  schema: {
+    type: "object",
+    properties: {
+      vendor: { type: "string" },
+      total: { type: "number" },
+      items: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            description: { type: "string" },
+            quantity: { type: "number" },
+            price: { type: "number" },
+          },
+          required: ["description", "quantity", "price"],
+        },
+      },
+    },
+    required: ["vendor", "total", "items"],
+  },
+};
+
+const result = await agent.runTurn(invoiceText, {
+  outputSchema: InvoiceSchema,
+});
+
+// result.output is { vendor: "...", total: 1234, items: [...] }, validated.
+// result.text is the free-form text the model produced (often empty when the
+// model "spoke" entirely via the synthetic tool call).
+```
+
+### Behavior notes
+
+- **Schema mismatch throws.** When the model produces arguments that don't
+  match `outputSchema.schema`, the call rejects with `OutputValidationError`
+  carrying the raw value and ajv's error path list. Catch and retry, or
+  surface diagnostics — silent fallback isn't supported by design.
+- **Loop termination.** A turn with `outputSchema` exits as soon as the
+  model calls the synthetic tool. If real-tool calls and the synthetic call
+  arrive in the same step, the structured answer wins and side-effect calls
+  in that step are ignored.
+- **No output → `result.output === undefined`.** If the model returns plain
+  text and never calls the synthetic tool, you get the same shape as a
+  normal `runTurn` — `result.text` carries the answer. This is rare in
+  practice but worth catching defensively.
+- **Tool-name collisions.** `outputSchema.name` must not match any tool
+  registered with the agent's `ToolRegistry`; the model client throws at
+  call time if it does.
+- **Provider-agnostic.** The same code works against Anthropic and any
+  OpenAI-compatible backend. No provider-specific switches.
+
 ## Development
 
 ```bash

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -23,7 +23,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.76.0",
-    "@modelcontextprotocol/sdk": "^1.29.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "ajv": "^8.18.0"
   },
   "devDependencies": {
     "@types/node": "^25.2.3",

--- a/packages/agent-sdk/src/agent/agent.ts
+++ b/packages/agent-sdk/src/agent/agent.ts
@@ -12,6 +12,7 @@ import type {
   AgentConfig,
   BeforeToolCallHook,
   ModelClient,
+  OutputSchema,
   ToolCall,
 } from "./types.js";
 
@@ -364,9 +365,10 @@ export class CodingAgent {
 
   async runTurn(
     userMessage: string,
-    options?: { signal?: AbortSignal },
+    options?: { signal?: AbortSignal; outputSchema?: OutputSchema },
   ): Promise<{
     text: string;
+    output?: unknown;
     usage?: {
       inputTokens: number;
       outputTokens: number;
@@ -499,6 +501,7 @@ export class CodingAgent {
             }
           : {}),
         ...(options?.signal && { signal: options.signal }),
+        ...(options?.outputSchema && { outputSchema: options.outputSchema }),
       });
 
       totalInputTokens += response.usage.inputTokens;
@@ -519,6 +522,33 @@ export class CodingAgent {
         }
         this.verboseLog("Usage:", response.usage);
         this.verboseLog(VERBOSE_SEP);
+      }
+
+      // Structured-output turn: the model called the synthetic respond
+      // tool. The validated value is on `response.output`; the synthetic
+      // call has already been stripped from `toolCalls`. Terminate the
+      // loop immediately. Any other tool calls in the same step are
+      // ignored — when the model has decided on a final answer we don't
+      // try to fold side-effects back into history.
+      if (response.output !== undefined) {
+        this.session.addMessage({
+          role: "assistant",
+          content: response.text,
+        });
+        const streamed =
+          this.config.modelProvider === "openai-compatible" && !!this.onUiUpdate;
+        return {
+          text: response.text,
+          output: response.output,
+          usage: {
+            inputTokens: totalInputTokens,
+            outputTokens: totalOutputTokens,
+            ...(totalCachedInputTokens > 0
+              ? { cachedInputTokens: totalCachedInputTokens }
+              : {}),
+          },
+          streamed,
+        };
       }
 
       if (response.toolCalls.length === 0) {

--- a/packages/agent-sdk/src/agent/structured-output.ts
+++ b/packages/agent-sdk/src/agent/structured-output.ts
@@ -1,0 +1,135 @@
+/**
+ * Helpers shared by both model clients to support
+ * structured-output turns. The agent's structured-output design uses a
+ * "synthetic tool" — when a caller supplies an `outputSchema`, we
+ * append one extra `ToolSchema` to the tools list for the request.
+ * The model decides to "call" that tool the same way it'd call any
+ * other; we intercept the call in the response, validate the
+ * arguments, and surface them as `ModelResponse.output` instead of
+ * dispatching anything.
+ *
+ * This is kept provider-agnostic so the Anthropic and
+ * OpenAI-compatible clients can share the wiring.
+ */
+
+import { Ajv2020 } from "ajv/dist/2020.js";
+import type { ErrorObject } from "ajv/dist/2020.js";
+
+import type {
+  OutputSchema,
+  ToolCall,
+  ToolSchema,
+} from "./types.js";
+import { OutputValidationError } from "./types.js";
+
+const TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
+
+const DEFAULT_DESCRIPTION =
+  "Call this with your final answer once you have everything you need.";
+
+let cachedAjv: Ajv2020 | null = null;
+function getValidator(): Ajv2020 {
+  if (!cachedAjv) {
+    cachedAjv = new Ajv2020({ allErrors: true, strict: false });
+  }
+  return cachedAjv;
+}
+
+/**
+ * Build the synthetic `ToolSchema` for a structured-output turn.
+ * The schema is passed through verbatim — both providers accept
+ * draft-2020-12 JSON Schema for tool input.
+ */
+export function synthesizeRespondTool(
+  outputSchema: OutputSchema,
+): ToolSchema {
+  return {
+    name: outputSchema.name,
+    description: outputSchema.description ?? DEFAULT_DESCRIPTION,
+    input_schema: outputSchema.schema,
+  };
+}
+
+/**
+ * Reject obvious problems early so we surface actionable errors
+ * instead of letting the provider fail mid-request.
+ */
+export function validateOutputSchema(
+  outputSchema: OutputSchema,
+  realTools: ReadonlyArray<ToolSchema>,
+): void {
+  if (!outputSchema.name || !TOOL_NAME_PATTERN.test(outputSchema.name)) {
+    throw new Error(
+      `outputSchema.name must match ${TOOL_NAME_PATTERN}. Got "${outputSchema.name}".`,
+    );
+  }
+  if (
+    typeof outputSchema.schema !== "object" ||
+    outputSchema.schema === null ||
+    Array.isArray(outputSchema.schema)
+  ) {
+    throw new Error("outputSchema.schema must be a JSON Schema object.");
+  }
+  for (const tool of realTools) {
+    if (tool.name === outputSchema.name) {
+      throw new Error(
+        `outputSchema.name "${outputSchema.name}" collides with a registered tool. Pick a different name.`,
+      );
+    }
+  }
+}
+
+function formatPath(path: string): string {
+  // Ajv's instancePath is "/items/0/price" style. Render as JSON-pointer
+  // for the consumer; empty string means the root object.
+  return path === "" ? "(root)" : path;
+}
+
+function ajvErrorsToFlat(
+  errors: ReadonlyArray<ErrorObject> | null | undefined,
+): Array<{ path: string; message: string }> {
+  if (!errors) return [];
+  return errors.map((e) => ({
+    path: formatPath(e.instancePath ?? ""),
+    message: e.message ?? "validation failed",
+  }));
+}
+
+/**
+ * Validate raw arguments against the output schema. Throws
+ * `OutputValidationError` on mismatch; returns the parsed value on
+ * success.
+ */
+export function validateOutput(
+  outputSchema: OutputSchema,
+  raw: unknown,
+): unknown {
+  const validator = getValidator();
+  const validate = validator.compile(outputSchema.schema);
+  if (validate(raw)) {
+    return raw;
+  }
+  throw new OutputValidationError(
+    `Structured output for "${outputSchema.name}" failed schema validation.`,
+    raw,
+    ajvErrorsToFlat(validate.errors),
+  );
+}
+
+/**
+ * Pull the synthetic respond tool's call (if any) out of the model's
+ * response. Returns the validated parsed value plus a filtered
+ * `toolCalls` list with the synthetic call removed so the agent loop
+ * does not try to dispatch it.
+ */
+export function extractStructuredOutput(
+  outputSchema: OutputSchema,
+  toolCalls: ReadonlyArray<ToolCall>,
+): { output: unknown; remainingToolCalls: ToolCall[] } | null {
+  const idx = toolCalls.findIndex((c) => c.name === outputSchema.name);
+  if (idx === -1) return null;
+  const call = toolCalls[idx]!;
+  const output = validateOutput(outputSchema, call.input);
+  const remaining = toolCalls.filter((_, i) => i !== idx);
+  return { output, remainingToolCalls: remaining };
+}

--- a/packages/agent-sdk/src/agent/types.ts
+++ b/packages/agent-sdk/src/agent/types.ts
@@ -104,6 +104,13 @@ export interface ModelResponse {
   text: string;
   toolCalls: ToolCall[];
   stopReason: "end_turn" | "tool_use" | "max_tokens";
+  /**
+   * Set when the caller supplied an `outputSchema` and the model
+   * called the synthetic respond tool with arguments matching the
+   * schema. The synthetic tool call is stripped from `toolCalls` so
+   * the agent loop does not try to dispatch it.
+   */
+  output?: unknown;
   usage: {
     inputTokens: number;
     outputTokens: number;
@@ -117,6 +124,47 @@ export interface ModelResponse {
      */
     cachedInputTokens?: number;
   };
+}
+
+/**
+ * Schema for structured-output turns. When passed to `runTurn` or
+ * `ModelClient.chat`, the SDK registers a synthetic tool with this
+ * shape; the model "calling" it delivers a structured answer that the
+ * SDK validates and returns as `ModelResponse.output` /
+ * `runTurn().output`.
+ */
+export interface OutputSchema {
+  /**
+   * Tool-facing name. Must match `^[a-zA-Z0-9_-]{1,64}$` (the tool-name
+   * pattern both providers accept). Pick a descriptive name —
+   * the model sees it.
+   */
+  name: string;
+  /** JSON Schema (draft 2020-12 subset) describing the desired output. */
+  schema: Record<string, unknown>;
+  /** Description shown to the model on the synthetic tool. */
+  description?: string;
+}
+
+/**
+ * Thrown when the model's structured-output call fails JSON Schema
+ * validation. Carries the raw arguments and the validator's error
+ * list so consumers can log, retry, or surface diagnostics.
+ */
+export class OutputValidationError extends Error {
+  readonly raw: unknown;
+  readonly errors: ReadonlyArray<{ path: string; message: string }>;
+
+  constructor(
+    message: string,
+    raw: unknown,
+    errors: ReadonlyArray<{ path: string; message: string }>,
+  ) {
+    super(message);
+    this.name = "OutputValidationError";
+    this.raw = raw;
+    this.errors = errors;
+  }
 }
 
 /** Describes a model available from the provider. */
@@ -143,6 +191,14 @@ export interface ModelClient {
      * invalidated and re-written. Tools are always cacheable separately.
      */
     cacheableSystem?: boolean;
+    /**
+     * When supplied, the client appends a synthetic tool with this
+     * schema to the request. If the model calls that tool, the
+     * arguments are validated against the schema and surfaced via
+     * `ModelResponse.output`; the synthetic call is stripped from
+     * `toolCalls`. A schema mismatch throws `OutputValidationError`.
+     */
+    outputSchema?: OutputSchema;
   }): Promise<ModelResponse>;
 
   /** List models available from the provider. Returns empty array on failure. */

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -6,6 +6,7 @@ export type {
   ModelClient,
   ModelInfo,
   ModelResponse,
+  OutputSchema,
   ReasoningEffort,
   SessionMessage,
   ToolCall,
@@ -15,6 +16,9 @@ export type {
   ToolSchema,
   UserMessage,
 } from "./agent/types.js";
+
+// Structured output
+export { OutputValidationError } from "./agent/types.js";
 
 // Agent runtime
 export {

--- a/packages/agent-sdk/src/model/client.ts
+++ b/packages/agent-sdk/src/model/client.ts
@@ -8,15 +8,42 @@ import type {
   ModelClient,
   ModelInfo,
   ModelResponse,
+  OutputSchema,
   ReasoningEffort,
   SessionMessage,
   ToolCall,
   ToolSchema,
 } from "../agent/types.js";
+import {
+  extractStructuredOutput,
+  synthesizeRespondTool,
+  validateOutputSchema,
+} from "../agent/structured-output.js";
 
 const DEFAULT_MODEL_START_TIMEOUT_SECONDS = 60;
 const RETRY_ATTEMPTS = 3;
 const RETRY_BASE_DELAY_MS = 500;
+
+/**
+ * If the caller supplied an `outputSchema`, look for the synthetic
+ * respond-tool's call in the parsed response, validate it, and surface
+ * it via `ModelResponse.output`. The synthetic call is removed from
+ * `toolCalls` so the agent loop does not try to dispatch it. When the
+ * model didn't call the synthetic tool, the response is unchanged.
+ */
+function applyStructuredOutput(
+  response: ModelResponse,
+  outputSchema: OutputSchema | undefined,
+): ModelResponse {
+  if (!outputSchema) return response;
+  const extracted = extractStructuredOutput(outputSchema, response.toolCalls);
+  if (!extracted) return response;
+  return {
+    ...response,
+    output: extracted.output,
+    toolCalls: extracted.remainingToolCalls,
+  };
+}
 
 function toAnthropicMessages(
   messages: SessionMessage[],
@@ -527,7 +554,17 @@ export class AnthropicModelClient implements ModelClient {
     onStream?: (chunk: string) => void;
     signal?: AbortSignal;
     cacheableSystem?: boolean;
+    outputSchema?: OutputSchema;
   }): Promise<ModelResponse> {
+    // Structured output: append a synthetic respond-tool with the
+    // caller's schema so the model can "call" it with a typed answer.
+    // Validated early to surface name collisions before the request.
+    const effectiveTools = params.tools;
+    const toolsForRequest: ToolSchema[] = (() => {
+      if (!params.outputSchema) return effectiveTools;
+      validateOutputSchema(params.outputSchema, effectiveTools);
+      return [...effectiveTools, synthesizeRespondTool(params.outputSchema)];
+    })();
     // Anthropic prompt caching: mark stable parts of the prefix with
     // `cache_control: { type: "ephemeral" }` so the provider serves
     // them at the cache-read rate (~10% of input cost) on subsequent
@@ -549,14 +586,14 @@ export class AnthropicModelClient implements ModelClient {
         ]
       : params.system;
     const toolsWithCache =
-      params.tools.length > 0
-        ? (params.tools as unknown as Anthropic.Messages.ToolUnion[]).map(
+      toolsForRequest.length > 0
+        ? (toolsForRequest as unknown as Anthropic.Messages.ToolUnion[]).map(
             (tool, i) =>
-              i === params.tools.length - 1
+              i === toolsForRequest.length - 1
                 ? { ...tool, cache_control: { type: "ephemeral" } }
                 : tool,
           )
-        : params.tools;
+        : toolsForRequest;
     const baseParams = {
       model: params.model,
       max_tokens: params.maxTokens,
@@ -605,7 +642,7 @@ export class AnthropicModelClient implements ModelClient {
       });
 
       const finalMessage = await stream.finalMessage();
-      return parseResponse(finalMessage);
+      return applyStructuredOutput(parseResponse(finalMessage), params.outputSchema);
     }, {
       shouldRetry: isRetryableAnthropicError,
     });
@@ -780,7 +817,13 @@ export class OpenAICompatibleModelClient implements ModelClient {
     onStream?: (chunk: string) => void;
     signal?: AbortSignal;
     cacheableSystem?: boolean;
+    outputSchema?: OutputSchema;
   }): Promise<ModelResponse> {
+    const toolsForRequest: ToolSchema[] = (() => {
+      if (!params.outputSchema) return params.tools;
+      validateOutputSchema(params.outputSchema, params.tools);
+      return [...params.tools, synthesizeRespondTool(params.outputSchema)];
+    })();
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
       "HTTP-Referer": "https://minicode.seanholung.com",
@@ -808,7 +851,7 @@ export class OpenAICompatibleModelClient implements ModelClient {
     const requestBody: Record<string, unknown> = {
       model: params.model,
       messages: toOpenAICompatibleMessages(params.system, params.messages),
-      tools: toOpenAICompatibleTools(params.tools),
+      tools: toOpenAICompatibleTools(toolsForRequest),
       tool_choice: "auto",
       max_tokens: params.maxTokens,
       stream: useStream,
@@ -849,15 +892,21 @@ export class OpenAICompatibleModelClient implements ModelClient {
           }
 
           if (useStream && httpResponse.body) {
-            return parseOpenAIStream(
-              httpResponse.body.getReader(),
-              params.onStream,
+            return applyStructuredOutput(
+              await parseOpenAIStream(
+                httpResponse.body.getReader(),
+                params.onStream,
+              ),
+              params.outputSchema,
             );
           }
 
           const payload =
             (await httpResponse.json()) as OpenAICompatibleCompletionResponse;
-          return parseOpenAICompatibleResponse(payload);
+          return applyStructuredOutput(
+            parseOpenAICompatibleResponse(payload),
+            params.outputSchema,
+          );
         }),
       {
         shouldRetry: isRetryableOpenAICompatibleError,

--- a/packages/agent-sdk/tests/model-client-anthropic-structured-output.test.ts
+++ b/packages/agent-sdk/tests/model-client-anthropic-structured-output.test.ts
@@ -1,0 +1,247 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { AnthropicModelClient } from "../src/model/client.js";
+import type { OutputSchema } from "../src/agent/types.js";
+import { OutputValidationError } from "../src/agent/types.js";
+
+const InvoiceSchema: OutputSchema = {
+  name: "Invoice",
+  description: "Extracted invoice fields",
+  schema: {
+    type: "object",
+    properties: {
+      vendor: { type: "string" },
+      total: { type: "number" },
+    },
+    required: ["vendor", "total"],
+    additionalProperties: false,
+  },
+};
+
+interface FakeStreamOpts {
+  finalMessage: unknown;
+  onTextChunks?: string[];
+}
+
+/**
+ * Minimal stand-in for the `MessageStream` returned by
+ * `Anthropic.Messages.stream`. Only implements the surface the
+ * client uses: `.on("text", fn)`, `.emitted("connect")`,
+ * `.finalMessage()`, `.abort()`.
+ */
+function makeFakeStream(opts: FakeStreamOpts) {
+  return {
+    on(event: string, fn: (...args: unknown[]) => void) {
+      if (event === "text" && opts.onTextChunks) {
+        for (const chunk of opts.onTextChunks) {
+          fn(chunk);
+        }
+      }
+      return this;
+    },
+    emitted(): Promise<void> {
+      return Promise.resolve();
+    },
+    finalMessage(): Promise<unknown> {
+      return Promise.resolve(opts.finalMessage);
+    },
+    abort(): void {
+      // no-op
+    },
+  };
+}
+
+interface CapturedRequest {
+  params: Record<string, unknown>;
+}
+
+function makeFakeClient(opts: FakeStreamOpts): {
+  fakeClient: object;
+  captured: CapturedRequest;
+} {
+  const captured: CapturedRequest = { params: {} };
+  const fakeClient = {
+    messages: {
+      stream(params: Record<string, unknown>) {
+        captured.params = params;
+        return makeFakeStream(opts);
+      },
+    },
+  };
+  return { fakeClient, captured };
+}
+
+test("anthropic client appends synthetic respond-tool when outputSchema is set", async () => {
+  const fake = makeFakeClient({
+    finalMessage: {
+      content: [
+        {
+          type: "tool_use",
+          id: "tu_1",
+          name: "Invoice",
+          input: { vendor: "Acme", total: 1234 },
+        },
+      ],
+      stop_reason: "tool_use",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+  });
+
+  const client = new AnthropicModelClient("test-key", {
+    // The fake "client" only implements `messages.stream`, which is all
+    // chat() touches.
+    client: fake.fakeClient as never,
+  });
+
+  const response = await client.chat({
+    model: "claude-test",
+    system: "sys",
+    messages: [{ role: "user", content: "hi" }],
+    tools: [
+      {
+        name: "read_file",
+        description: "read",
+        input_schema: { type: "object", properties: {} },
+      },
+    ],
+    maxTokens: 64,
+    outputSchema: InvoiceSchema,
+  });
+
+  // The synthetic Invoice tool was appended after the real read_file
+  // tool when the request was built.
+  const tools = fake.captured.params.tools as Array<Record<string, unknown>>;
+  assert.equal(tools.length, 2);
+  assert.equal(tools[0]?.name, "read_file");
+  assert.equal(tools[1]?.name, "Invoice");
+  assert.deepEqual(tools[1]?.input_schema, InvoiceSchema.schema);
+
+  // The synthetic tool_use block was extracted into output and stripped
+  // from toolCalls so the agent loop won't try to dispatch it.
+  assert.deepEqual(response.output, { vendor: "Acme", total: 1234 });
+  assert.equal(response.toolCalls.length, 0);
+});
+
+test("anthropic client throws OutputValidationError on schema mismatch", async () => {
+  const fake = makeFakeClient({
+    finalMessage: {
+      content: [
+        {
+          type: "tool_use",
+          id: "tu_1",
+          name: "Invoice",
+          // total should be number; provide string instead
+          input: { vendor: "Acme", total: "oops" },
+        },
+      ],
+      stop_reason: "tool_use",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+  });
+
+  const client = new AnthropicModelClient("test-key", {
+    client: fake.fakeClient as never,
+  });
+
+  await assert.rejects(
+    () =>
+      client.chat({
+        model: "claude-test",
+        system: "sys",
+        messages: [{ role: "user", content: "hi" }],
+        tools: [],
+        maxTokens: 64,
+        outputSchema: InvoiceSchema,
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof OutputValidationError);
+      assert.match(error.message, /Invoice.*failed schema validation/);
+      return true;
+    },
+  );
+});
+
+test("anthropic client passes through unchanged when outputSchema is omitted", async () => {
+  const fake = makeFakeClient({
+    finalMessage: {
+      content: [{ type: "text", text: "hello" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+  });
+
+  const client = new AnthropicModelClient("test-key", {
+    client: fake.fakeClient as never,
+  });
+
+  const response = await client.chat({
+    model: "claude-test",
+    system: "sys",
+    messages: [{ role: "user", content: "hi" }],
+    tools: [
+      {
+        name: "read_file",
+        description: "r",
+        input_schema: { type: "object", properties: {} },
+      },
+    ],
+    maxTokens: 64,
+  });
+
+  const tools = fake.captured.params.tools as Array<Record<string, unknown>>;
+  assert.equal(tools.length, 1);
+  assert.equal(tools[0]?.name, "read_file");
+  assert.equal(response.output, undefined);
+  assert.equal(response.text, "hello");
+});
+
+test("anthropic client extracts synthetic call alongside real tool calls", async () => {
+  // Multi-tool step: model calls a real tool AND the synthetic tool.
+  // The synthetic call should be extracted; the real call should
+  // remain in `toolCalls`.
+  const fake = makeFakeClient({
+    finalMessage: {
+      content: [
+        { type: "text", text: "ok" },
+        {
+          type: "tool_use",
+          id: "tu_1",
+          name: "read_file",
+          input: { path: "x.txt" },
+        },
+        {
+          type: "tool_use",
+          id: "tu_2",
+          name: "Invoice",
+          input: { vendor: "Acme", total: 50 },
+        },
+      ],
+      stop_reason: "tool_use",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+  });
+
+  const client = new AnthropicModelClient("test-key", {
+    client: fake.fakeClient as never,
+  });
+
+  const response = await client.chat({
+    model: "claude-test",
+    system: "sys",
+    messages: [{ role: "user", content: "hi" }],
+    tools: [
+      {
+        name: "read_file",
+        description: "r",
+        input_schema: { type: "object", properties: {} },
+      },
+    ],
+    maxTokens: 64,
+    outputSchema: InvoiceSchema,
+  });
+
+  assert.deepEqual(response.output, { vendor: "Acme", total: 50 });
+  assert.equal(response.toolCalls.length, 1);
+  assert.equal(response.toolCalls[0]?.name, "read_file");
+});

--- a/packages/agent-sdk/tests/model-client-structured-output.test.ts
+++ b/packages/agent-sdk/tests/model-client-structured-output.test.ts
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { OpenAICompatibleModelClient } from "../src/model/client.js";
+import type { OutputSchema } from "../src/agent/types.js";
+import { OutputValidationError } from "../src/agent/types.js";
+
+const InvoiceSchema: OutputSchema = {
+  name: "Invoice",
+  description: "Extracted invoice fields",
+  schema: {
+    type: "object",
+    properties: {
+      vendor: { type: "string" },
+      total: { type: "number" },
+    },
+    required: ["vendor", "total"],
+    additionalProperties: false,
+  },
+};
+
+test("openai-compat client appends synthetic respond-tool when outputSchema is set", async () => {
+  let capturedBody = "";
+
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    capturedBody = String(init?.body ?? "");
+    return new Response(
+      JSON.stringify({
+        choices: [
+          {
+            finish_reason: "tool_calls",
+            message: {
+              content: "",
+              tool_calls: [
+                {
+                  id: "call_1",
+                  type: "function",
+                  function: {
+                    name: "Invoice",
+                    arguments: '{"vendor":"Acme","total":1234}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+
+  const response = await client.chat({
+    model: "test",
+    system: "sys",
+    messages: [{ role: "user", content: "hi" }],
+    tools: [
+      {
+        name: "read_file",
+        description: "read",
+        input_schema: { type: "object", properties: {} },
+      },
+    ],
+    maxTokens: 64,
+    outputSchema: InvoiceSchema,
+  });
+
+  // The synthetic tool was appended to the request alongside read_file.
+  const parsedBody = JSON.parse(capturedBody) as Record<string, unknown>;
+  const tools = parsedBody.tools as Array<Record<string, unknown>>;
+  assert.equal(tools.length, 2);
+  const fns = tools.map((t) => (t.function as Record<string, unknown>).name);
+  assert.deepEqual(fns, ["read_file", "Invoice"]);
+
+  // The synthetic call was extracted into `output` and stripped from
+  // `toolCalls` so the agent loop won't try to dispatch it.
+  assert.deepEqual(response.output, { vendor: "Acme", total: 1234 });
+  assert.equal(response.toolCalls.length, 0);
+});
+
+test("openai-compat client throws OutputValidationError on schema mismatch", async () => {
+  const fetchImpl: typeof fetch = async () =>
+    new Response(
+      JSON.stringify({
+        choices: [
+          {
+            finish_reason: "tool_calls",
+            message: {
+              content: "",
+              tool_calls: [
+                {
+                  id: "call_1",
+                  type: "function",
+                  function: {
+                    name: "Invoice",
+                    // total should be a number — provide string instead
+                    arguments: '{"vendor":"Acme","total":"oops"}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+
+  await assert.rejects(
+    () =>
+      client.chat({
+        model: "test",
+        system: "sys",
+        messages: [{ role: "user", content: "hi" }],
+        tools: [],
+        maxTokens: 64,
+        outputSchema: InvoiceSchema,
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof OutputValidationError);
+      assert.match(error.message, /Invoice.*failed schema validation/);
+      return true;
+    },
+  );
+});
+
+test("openai-compat client passes through unchanged when outputSchema is omitted", async () => {
+  let capturedBody = "";
+
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    capturedBody = String(init?.body ?? "");
+    return new Response(
+      JSON.stringify({
+        choices: [
+          {
+            finish_reason: "stop",
+            message: { content: "ok", tool_calls: [] },
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+
+  const response = await client.chat({
+    model: "test",
+    system: "sys",
+    messages: [{ role: "user", content: "hi" }],
+    tools: [
+      {
+        name: "read_file",
+        description: "r",
+        input_schema: { type: "object", properties: {} },
+      },
+    ],
+    maxTokens: 64,
+  });
+
+  const parsedBody = JSON.parse(capturedBody) as Record<string, unknown>;
+  const tools = parsedBody.tools as Array<Record<string, unknown>>;
+  assert.equal(tools.length, 1);
+  assert.equal(response.output, undefined);
+  assert.equal(response.text, "ok");
+});
+
+test("openai-compat client throws on outputSchema name collision with a real tool", async () => {
+  const fetchImpl: typeof fetch = async () => new Response("{}");
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+  await assert.rejects(
+    () =>
+      client.chat({
+        model: "test",
+        system: "sys",
+        messages: [{ role: "user", content: "hi" }],
+        tools: [
+          {
+            name: "Invoice",
+            description: "real tool with the same name",
+            input_schema: { type: "object" },
+          },
+        ],
+        maxTokens: 64,
+        outputSchema: InvoiceSchema,
+      }),
+    /collides with a registered tool/,
+  );
+});

--- a/packages/agent-sdk/tests/structured-output.test.ts
+++ b/packages/agent-sdk/tests/structured-output.test.ts
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { CodingAgent } from "../src/agent/agent.js";
+import {
+  extractStructuredOutput,
+  synthesizeRespondTool,
+  validateOutput,
+  validateOutputSchema,
+} from "../src/agent/structured-output.js";
+import type {
+  ModelClient,
+  ModelResponse,
+  OutputSchema,
+  SessionMessage,
+  ToolDefinition,
+  ToolSchema,
+} from "../src/agent/types.js";
+import { OutputValidationError } from "../src/agent/types.js";
+import { ToolRegistry } from "../src/tools/registry.js";
+import { createTestAgentConfig } from "./test-utils.js";
+
+const InvoiceSchema: OutputSchema = {
+  name: "Invoice",
+  description: "Extracted invoice data",
+  schema: {
+    type: "object",
+    properties: {
+      vendor: { type: "string" },
+      total: { type: "number" },
+    },
+    required: ["vendor", "total"],
+    additionalProperties: false,
+  },
+};
+
+// ─── Helper module ───────────────────────────────────────────────────────────
+
+test("synthesizeRespondTool builds a ToolSchema with the supplied schema", () => {
+  const tool = synthesizeRespondTool(InvoiceSchema);
+  assert.equal(tool.name, "Invoice");
+  assert.equal(tool.description, "Extracted invoice data");
+  assert.deepEqual(tool.input_schema, InvoiceSchema.schema);
+});
+
+test("synthesizeRespondTool falls back to a default description", () => {
+  const noDesc: OutputSchema = {
+    name: "Foo",
+    schema: { type: "object", properties: {}, additionalProperties: false },
+  };
+  const tool = synthesizeRespondTool(noDesc);
+  assert.match(tool.description, /Call this/);
+});
+
+test("validateOutputSchema rejects bad names and collisions", () => {
+  assert.throws(
+    () => validateOutputSchema({ name: "bad name", schema: {} }, []),
+    /must match/,
+  );
+  assert.throws(
+    () => validateOutputSchema({ name: "ok", schema: null as unknown as Record<string, unknown> }, []),
+    /JSON Schema object/,
+  );
+  const realTool: ToolSchema = {
+    name: "Invoice",
+    description: "x",
+    input_schema: { type: "object" },
+  };
+  assert.throws(
+    () => validateOutputSchema(InvoiceSchema, [realTool]),
+    /collides with a registered tool/,
+  );
+});
+
+test("validateOutput returns the value when it matches the schema", () => {
+  const value = { vendor: "Acme", total: 1234 };
+  const out = validateOutput(InvoiceSchema, value);
+  assert.deepEqual(out, value);
+});
+
+test("validateOutput throws OutputValidationError with diagnostic info on mismatch", () => {
+  try {
+    validateOutput(InvoiceSchema, { vendor: 5 });
+    assert.fail("expected throw");
+  } catch (error) {
+    assert.ok(error instanceof OutputValidationError);
+    assert.match(error.message, /Invoice.*failed schema validation/);
+    assert.ok(error.errors.length > 0);
+    assert.deepEqual(error.raw, { vendor: 5 });
+  }
+});
+
+test("extractStructuredOutput pulls the synthetic call out and leaves real tool calls", () => {
+  const result = extractStructuredOutput(InvoiceSchema, [
+    { id: "1", name: "read_file", input: { path: "x.txt" } },
+    { id: "2", name: "Invoice", input: { vendor: "Acme", total: 100 } },
+    { id: "3", name: "write_file", input: { path: "y.txt", content: "ok" } },
+  ]);
+  assert.ok(result, "extractStructuredOutput should find the call");
+  assert.deepEqual(result.output, { vendor: "Acme", total: 100 });
+  assert.equal(result.remainingToolCalls.length, 2);
+  assert.deepEqual(
+    result.remainingToolCalls.map((c) => c.name),
+    ["read_file", "write_file"],
+  );
+});
+
+test("extractStructuredOutput returns null when the model didn't call the synthetic tool", () => {
+  const result = extractStructuredOutput(InvoiceSchema, [
+    { id: "1", name: "read_file", input: { path: "x.txt" } },
+  ]);
+  assert.equal(result, null);
+});
+
+// ─── Agent integration ───────────────────────────────────────────────────────
+
+class CapturingClient implements ModelClient {
+  toolsLastSeen: ToolSchema[] = [];
+  outputSchemaLastSeen: OutputSchema | undefined = undefined;
+  private readonly responses: ModelResponse[];
+
+  constructor(responses: ModelResponse[]) {
+    this.responses = [...responses];
+  }
+
+  async chat(params: {
+    model: string;
+    system: string;
+    messages: SessionMessage[];
+    tools: ToolSchema[];
+    maxTokens: number;
+    outputSchema?: OutputSchema;
+  }): Promise<ModelResponse> {
+    this.toolsLastSeen = params.tools;
+    this.outputSchemaLastSeen = params.outputSchema;
+    const next = this.responses.shift();
+    if (!next) throw new Error("No queued response.");
+    return next;
+  }
+}
+
+function buildAgentWithRegistry(
+  client: ModelClient,
+  tools: ToolDefinition[] = [],
+): CodingAgent {
+  return new CodingAgent({
+    config: createTestAgentConfig("/tmp/structured-test"),
+    modelClient: client,
+    toolRegistry: new ToolRegistry(tools),
+  });
+}
+
+function makeEchoTool(): ToolDefinition {
+  return {
+    name: "echo_tool",
+    description: "echo",
+    inputSchema: {
+      type: "object",
+      properties: { value: { type: "string" } },
+      required: ["value"],
+    },
+    execute: async (input) => `echo:${String(input.value)}`,
+  };
+}
+
+test("runTurn forwards outputSchema to the model client", async () => {
+  // The client is responsible for appending the synthetic tool — but
+  // when this test uses a fake client, we just verify the schema was
+  // forwarded so the real clients (covered by their own tests) can do
+  // their job.
+  const client = new CapturingClient([
+    {
+      text: "",
+      toolCalls: [
+        { id: "1", name: "Invoice", input: { vendor: "Acme", total: 99 } },
+      ],
+      stopReason: "tool_use",
+      // The fake client emulates what a real client does: extract the
+      // synthetic call and surface it as `output`.
+      output: { vendor: "Acme", total: 99 },
+      usage: { inputTokens: 5, outputTokens: 5 },
+    },
+  ]);
+  const agent = buildAgentWithRegistry(client);
+  const result = await agent.runTurn("hi", { outputSchema: InvoiceSchema });
+  assert.equal(client.outputSchemaLastSeen, InvoiceSchema);
+  assert.deepEqual(result.output, { vendor: "Acme", total: 99 });
+});
+
+test("runTurn terminates on structured output even mid-loop", async () => {
+  // Step 1: model calls a real tool. Step 2: model calls the synthetic
+  // respond tool. The agent should execute the real tool and then
+  // terminate on the structured output.
+  const client = new CapturingClient([
+    {
+      text: "Let me check first.",
+      toolCalls: [
+        { id: "1", name: "echo_tool", input: { value: "ping" } },
+      ],
+      stopReason: "tool_use",
+      usage: { inputTokens: 5, outputTokens: 5 },
+    },
+    {
+      text: "",
+      toolCalls: [],
+      stopReason: "end_turn",
+      output: { vendor: "Acme", total: 42 },
+      usage: { inputTokens: 5, outputTokens: 5 },
+    },
+  ]);
+  const agent = buildAgentWithRegistry(client, [makeEchoTool()]);
+  const result = await agent.runTurn("extract this", {
+    outputSchema: InvoiceSchema,
+  });
+  assert.deepEqual(result.output, { vendor: "Acme", total: 42 });
+  assert.equal(result.text, "");
+});
+
+test("runTurn returns no output when the model never calls the synthetic tool", async () => {
+  const client = new CapturingClient([
+    {
+      text: "Hello there.",
+      toolCalls: [],
+      stopReason: "end_turn",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    },
+  ]);
+  const agent = buildAgentWithRegistry(client);
+  const result = await agent.runTurn("hi", { outputSchema: InvoiceSchema });
+  assert.equal(result.output, undefined);
+  assert.equal(result.text, "Hello there.");
+});
+
+test("runTurn ignores extra real-tool calls when output is set in the same step", async () => {
+  // Some providers emit multi-tool steps. When the model commits to a
+  // structured answer, side-effects in the same step are dropped
+  // rather than executed in a way the model can't see the result of.
+  let echoCalls = 0;
+  const echoTool: ToolDefinition = {
+    name: "echo_tool",
+    description: "echo",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    execute: async () => {
+      echoCalls += 1;
+      return "echoed";
+    },
+  };
+  const client = new CapturingClient([
+    {
+      text: "",
+      // The synthetic call has been stripped already; the real client's
+      // extractor leaves only the side-effect call here. The agent
+      // should NOT dispatch it because output is set.
+      toolCalls: [{ id: "1", name: "echo_tool", input: {} }],
+      stopReason: "tool_use",
+      output: { vendor: "Acme", total: 10 },
+      usage: { inputTokens: 1, outputTokens: 1 },
+    },
+  ]);
+  const agent = buildAgentWithRegistry(client, [echoTool]);
+  const result = await agent.runTurn("hi", { outputSchema: InvoiceSchema });
+  assert.deepEqual(result.output, { vendor: "Acme", total: 10 });
+  assert.equal(echoCalls, 0, "echo tool must not be executed once output is set");
+});


### PR DESCRIPTION
## Summary

Closes #171. Adds `runTurn(msg, { outputSchema })` — a turn that returns parsed-and-validated JSON instead of free-form text. Works against both Anthropic and any OpenAI-compatible backend through one uniform code path.

```typescript
const InvoiceSchema: OutputSchema = {
  name: "Invoice",
  description: "Call this with the extracted invoice once you've finished reading.",
  schema: {
    type: "object",
    properties: {
      vendor: { type: "string" },
      total: { type: "number" },
    },
    required: ["vendor", "total"],
  },
};

const result = await agent.runTurn(invoiceText, { outputSchema: InvoiceSchema });
// result.output === { vendor: "Acme", total: 1234 } — validated.
```

### How it works (synthetic-tool design)

When the caller supplies `outputSchema`, the SDK appends a synthetic tool with that input shape to the model's tool list. The model decides to "call" it the same way it'd call any other tool. The SDK intercepts the call, validates the arguments with ajv, and surfaces them as `ModelResponse.output`. Real tools and the synthetic tool coexist — the model can run real tools first to gather data, then deliver the structured answer via the synthetic tool.

Why this design beats trying to use OpenAI's native `response_format` + Anthropic emulation:
- One mechanism for both providers
- No "is this the terminal call?" detection problem — the model's choice between calling a real tool vs the synthetic one *is* the loop terminator
- No extra round trips
- Anthropic's own structured-output guide describes this exact pattern

### Behavior

- **Schema mismatch throws `OutputValidationError`** with diagnostic info (raw value + ajv error path list). Loud failure beats silent garbage.
- **Loop terminates** as soon as the model calls the synthetic tool. If real-tool calls and the synthetic call arrive in the same step, the structured answer wins; side-effect calls in that step are ignored (we don't execute work whose results we can't fold back into context).
- **Tool-name collisions** (a real tool with the same name as the schema) throw at the boundary.
- **Backward compatible**: existing callers without `outputSchema` see no behavior change.

### Implementation

- New `packages/agent-sdk/src/agent/structured-output.ts` holds the synthesizer + ajv validator + extractor; both clients share it via an `applyStructuredOutput` helper
- `ajv@^8` added as a direct dep of agent-sdk (it was reachable transitively via the MCP SDK, but root resolution hit ajv@6 which lacks draft-2020-12). Same playbook as adding `@modelcontextprotocol/sdk` in #170.
- New types `OutputSchema` and `OutputValidationError` exported from `@minicode/agent-sdk`

### Out of scope (per #171)

- Streaming partial JSON
- Schema → TS type inference (consumers cast or run their own type guard)
- Native `response_format` for OpenAI (synthetic tool covers both providers uniformly)

## Test plan

- [x] 15 new tests pass (helper module + OpenAI-compat client wiring + agent integration)
- [x] Helper module: synthesize, validate, extract, `OutputValidationError`
- [x] OpenAI-compat client wiring: synthetic tool appended to request, `output` extracted from response, validation error on mismatch, no-op when `outputSchema` omitted, collision detection
- [x] Agent loop: `outputSchema` forwarded to client; loop terminates mid-turn on `output`; no-output case preserved (free-form text fallback); side-effect calls in the same step as `output` are dropped
- [x] Full root build clean (`npm run build`)
- [x] Full root lint clean (`npm run lint`)
- [x] Full test suite: 678/682 pass — the 4 failures (`workspace-changes.test.ts`) are pre-existing on main, unrelated to this PR (`git commit` failing because the test env has no git user configured)

This closes the SDK-consumability push that started with #168 and shipped #169 (configurable system prompt + narrow tool factories) and #170 (external MCP servers). With these four landed, `@minicode/agent-sdk` is genuinely embeddable for non-coding-agent use cases — extraction, classification, review bots, planners.

https://claude.ai/code/session_012ajRQHucZRbcE39L9E75nw

---
_Generated by [Claude Code](https://claude.ai/code/session_012ajRQHucZRbcE39L9E75nw)_