### PR TITLE
Fix two prefer-const errors + extend CI lint to workspaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
       - name: Run lint
         run: npm run lint
 
+      # Workspaces have their own lint scripts that cover packages/*/src
+      # and packages/*/tests, which the root's lint script doesn't reach.
+      # Without this, lint errors inside packages/ hide until they hit
+      # the publish workflow.
+      - name: Run workspace lints
+        run: npm run lint --workspaces --if-present
+
       - name: Run tests
         run: npm test
 

--- a/packages/agent-sdk/src/model/client.ts
+++ b/packages/agent-sdk/src/model/client.ts
@@ -249,6 +249,8 @@ function createTimeoutSignal(timeoutSeconds: number, parentSignal?: AbortSignal)
 } {
   const controller = new AbortController();
   let timedOut = false;
+  // Forward-declared because the returned `cleanup` closure references
+  // it before the setTimeout call below assigns the handle.
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeoutMs = timeoutSeconds * 1000;
 
@@ -262,6 +264,7 @@ function createTimeoutSignal(timeoutSeconds: number, parentSignal?: AbortSignal)
     parentSignal.addEventListener("abort", handleParentAbort, { once: true });
   }
 
+  // eslint-disable-next-line prefer-const -- forward-declared above
   timeoutHandle = setTimeout(() => {
     timedOut = true;
     controller.abort(new ModelStartTimeoutError(timeoutSeconds));

--- a/packages/agent-sdk/src/tools/run-command.ts
+++ b/packages/agent-sdk/src/tools/run-command.ts
@@ -48,6 +48,9 @@ function executeBashCommand(
     let stderr = "";
     let timedOut = false;
     let settled = false;
+    // Forward-declared because the `cleanup` closure below reads it
+    // before the setTimeout call lower in the function assigns it.
+    // eslint-disable-next-line prefer-const -- reassigned in setTimeout call below; declared early so cleanup() closure can reference it
     let timeout: ReturnType<typeof setTimeout> | undefined;
     let forceKillTimeout: ReturnType<typeof setTimeout> | undefined;
     let forceResolveTimeout: ReturnType<typeof setTimeout> | undefined;


### PR DESCRIPTION
## Summary

The `publish-sdk` workflow you just ran failed because it executes the SDK package's own lint script, which has wider scope than the root's `npm run lint` (root only lints `src/**` and `tests/**` — it doesn't reach `packages/*/src`). Two pre-existing `prefer-const` errors have been hiding inside the agent-sdk:

```
packages/agent-sdk/src/model/client.ts:265   'timeoutHandle' is never reassigned
packages/agent-sdk/src/tools/run-command.ts:51 'timeout' is never reassigned
```

Both are forward-declared because cleanup closures reference them before the `setTimeout` call lower in the function assigns the handle. Restructuring to `const`-with-init would mean reordering each cleanup closure relative to its timeout declaration — fiddly, and risks subtle ordering bugs for marginal gain. Suppressing the rule with a one-line justification is the cheaper and clearer fix.

(ESLint reported each error at a different line — declaration site for `run-command.ts`, assignment site for `client.ts`. The `eslint-disable-next-line` directives are placed accordingly in each file.)

## Also: extend root CI lint scope to workspaces

Per your request — added `npm run lint --workspaces --if-present` to `.github/workflows/ci.yml`, right after the existing `npm run lint`. Without it, lint regressions inside `packages/*` only surface when someone triggers the publish workflow, which is too late. This catches future drift on every PR.

## Test plan

- [x] `npm run lint` (root) clean
- [x] `npm run lint --workspaces --if-present` clean for both `agent-sdk` and `minicode-plugin-python`
- [x] Full test suite: 697/701 pass (4 pre-existing `workspace-changes` `git commit` env failures, unrelated)
- [x] Build clean

After this merges, you should be able to re-run the publish-sdk workflow and have it get past the lint step.

https://claude.ai/code/session_012ajRQHucZRbcE39L9E75nw

---
_Generated by [Claude Code](https://claude.ai/code/session_012ajRQHucZRbcE39L9E75nw)_