### PR TITLE
OpenRouter provider pinning for benchmark variance control

### DIFF
--- a/packages/agent-sdk/src/model/client.ts
+++ b/packages/agent-sdk/src/model/client.ts
@@ -876,6 +876,27 @@ export class OpenAICompatibleModelClient implements ModelClient {
       requestBody.cache_control = { type: "ephemeral" };
     }
 
+    // OpenRouter provider pinning (variance control). When
+    // `OPENROUTER_PROVIDER_ORDER` is set, requests are routed to the
+    // listed providers in order. Default is `allow_fallbacks: false`
+    // so an unavailable pinned provider fails loudly rather than
+    // silently routing elsewhere — which would defeat the variance
+    // control. Only injected when targeting OpenRouter.
+    if (this.baseUrl.includes("openrouter")) {
+      const providerOrderRaw = process.env.OPENROUTER_PROVIDER_ORDER;
+      if (providerOrderRaw && providerOrderRaw.trim().length > 0) {
+        const order = providerOrderRaw
+          .split(",")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0);
+        if (order.length > 0) {
+          const allowFallbacks =
+            process.env.OPENROUTER_PROVIDER_ALLOW_FALLBACKS === "true";
+          requestBody.provider = { order, allow_fallbacks: allowFallbacks };
+        }
+      }
+    }
+
     const response = await withRetry(
       () =>
         withResponseStartTimeout(this.timeoutSeconds, params.signal, async (signal) => {

--- a/packages/agent-sdk/tests/model-client-openai.test.ts
+++ b/packages/agent-sdk/tests/model-client-openai.test.ts
@@ -424,3 +424,127 @@ test("createModelClient returns openai-compatible client", () => {
   const client = createModelClient(config);
   assert.ok(client instanceof OpenAICompatibleModelClient);
 });
+
+// ─── OpenRouter provider pinning (variance control) ─────────────────────
+
+function captureRequestBody(): {
+  fetchImpl: typeof fetch;
+  getBody: () => Record<string, unknown>;
+} {
+  let captured = "";
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    captured = String(init?.body ?? "");
+    return new Response(
+      JSON.stringify({
+        choices: [{ finish_reason: "stop", message: { content: "ok" } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+  return {
+    fetchImpl,
+    getBody: () => JSON.parse(captured) as Record<string, unknown>,
+  };
+}
+
+async function runChatStub(
+  fetchImpl: typeof fetch,
+  baseUrl: string,
+): Promise<void> {
+  const client = new OpenAICompatibleModelClient({
+    baseUrl,
+    apiKey: "sk-or-v1-test",
+    fetchImpl,
+  });
+  await client.chat({
+    model: "google/gemma-4-26b-a4b-it",
+    system: "sys",
+    messages: [{ role: "user", content: "hi" }],
+    tools: [],
+    maxTokens: 8,
+  });
+}
+
+test("OPENROUTER_PROVIDER_ORDER injects provider block when targeting OpenRouter", async () => {
+  const { fetchImpl, getBody } = captureRequestBody();
+  const original = process.env.OPENROUTER_PROVIDER_ORDER;
+  process.env.OPENROUTER_PROVIDER_ORDER = "Novita";
+  try {
+    await runChatStub(fetchImpl, "https://openrouter.ai/api/v1");
+    const body = getBody();
+    assert.deepEqual(body.provider, {
+      order: ["Novita"],
+      allow_fallbacks: false,
+    });
+  } finally {
+    if (original === undefined) delete process.env.OPENROUTER_PROVIDER_ORDER;
+    else process.env.OPENROUTER_PROVIDER_ORDER = original;
+  }
+});
+
+test("OPENROUTER_PROVIDER_ORDER accepts comma-separated lists", async () => {
+  const { fetchImpl, getBody } = captureRequestBody();
+  const original = process.env.OPENROUTER_PROVIDER_ORDER;
+  process.env.OPENROUTER_PROVIDER_ORDER = "Novita, DeepInfra ,Fireworks";
+  try {
+    await runChatStub(fetchImpl, "https://openrouter.ai/api/v1");
+    const body = getBody();
+    assert.deepEqual(body.provider, {
+      order: ["Novita", "DeepInfra", "Fireworks"],
+      allow_fallbacks: false,
+    });
+  } finally {
+    if (original === undefined) delete process.env.OPENROUTER_PROVIDER_ORDER;
+    else process.env.OPENROUTER_PROVIDER_ORDER = original;
+  }
+});
+
+test("OPENROUTER_PROVIDER_ALLOW_FALLBACKS=true opts back into fallbacks", async () => {
+  const { fetchImpl, getBody } = captureRequestBody();
+  const orderOrig = process.env.OPENROUTER_PROVIDER_ORDER;
+  const fallOrig = process.env.OPENROUTER_PROVIDER_ALLOW_FALLBACKS;
+  process.env.OPENROUTER_PROVIDER_ORDER = "Novita";
+  process.env.OPENROUTER_PROVIDER_ALLOW_FALLBACKS = "true";
+  try {
+    await runChatStub(fetchImpl, "https://openrouter.ai/api/v1");
+    const body = getBody();
+    assert.deepEqual(body.provider, {
+      order: ["Novita"],
+      allow_fallbacks: true,
+    });
+  } finally {
+    if (orderOrig === undefined) delete process.env.OPENROUTER_PROVIDER_ORDER;
+    else process.env.OPENROUTER_PROVIDER_ORDER = orderOrig;
+    if (fallOrig === undefined)
+      delete process.env.OPENROUTER_PROVIDER_ALLOW_FALLBACKS;
+    else process.env.OPENROUTER_PROVIDER_ALLOW_FALLBACKS = fallOrig;
+  }
+});
+
+test("provider block is NOT injected when baseUrl is not OpenRouter", async () => {
+  const { fetchImpl, getBody } = captureRequestBody();
+  const original = process.env.OPENROUTER_PROVIDER_ORDER;
+  process.env.OPENROUTER_PROVIDER_ORDER = "Novita";
+  try {
+    await runChatStub(fetchImpl, "http://localhost:1234/v1");
+    const body = getBody();
+    assert.equal(body.provider, undefined);
+  } finally {
+    if (original === undefined) delete process.env.OPENROUTER_PROVIDER_ORDER;
+    else process.env.OPENROUTER_PROVIDER_ORDER = original;
+  }
+});
+
+test("provider block is NOT injected when env var is unset", async () => {
+  const { fetchImpl, getBody } = captureRequestBody();
+  const original = process.env.OPENROUTER_PROVIDER_ORDER;
+  delete process.env.OPENROUTER_PROVIDER_ORDER;
+  try {
+    await runChatStub(fetchImpl, "https://openrouter.ai/api/v1");
+    const body = getBody();
+    assert.equal(body.provider, undefined);
+  } finally {
+    if (original !== undefined) process.env.OPENROUTER_PROVIDER_ORDER = original;
+  }
+});


### PR DESCRIPTION
## Summary
- Adds `OPENROUTER_PROVIDER_ORDER` env var that pins OpenRouter requests to a specific provider (or ordered preference list)
- Default `allow_fallbacks: false` so an unavailable provider fails loudly with a 404 rather than silently routing elsewhere — silent fallback would defeat variance control
- Optional `OPENROUTER_PROVIDER_ALLOW_FALLBACKS=true` opts back into soft-pinning for non-experimental use
- Only injected when targeting OpenRouter; invisible to local LM Studio / generic OpenAI flows

## Motivation

The n=3 internal-task benchmark on `gemma-4-26b-a4b-it` shows ±8 pp run-to-run variance, much of which is OpenRouter routing across DeepInfra, Fireworks, Novita, etc. — each running a slightly different quantization. The two zero-tool-call refusal failures in `after-fixes-r2` (PR #185) almost certainly came from a provider that mangled the tool-call response shape.

Pinning collapses that source of variance so experimental deltas worth +3 pp can be read with confidence at lower n. For the upcoming Copilot-inspired prompt experiments, this is a prerequisite.

## Usage

```bash
# Pin to Novita (bf16 quantization for Gemma 4)
export OPENROUTER_PROVIDER_ORDER=Novita
npm run benchmark -- --variant pinned ...
```

Comma-separated lists work for ordered preference (`"Novita, DeepInfra, Fireworks"`).

## Verification
- [x] Smoke test with `OPENROUTER_PROVIDER_ORDER=Novita` against `find-symbol-definition`: PASS in 1 tool call, 8.3s
- [x] Negative test with fake provider name + `allow_fallbacks=false`: 404 "No endpoints found" — confirms loud-fail behavior
- [x] 5 unit tests covering: single provider, comma-list, allow_fallbacks=true, non-OpenRouter URL no-op, unset env no-op
- [x] All 16 model-client tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)