### PR TITLE
Copilot-inspired tool descriptions: parallel-call hints + efficiency block

### DIFF
--- a/packages/agent-sdk/src/prompt/system-prompt.ts
+++ b/packages/agent-sdk/src/prompt/system-prompt.ts
@@ -156,6 +156,11 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
     "",
     ...toolGuidelines,
     "",
+    "[Tool Efficiency]",
+    "- When you need multiple independent operations, make ALL the tool calls in a SINGLE response — they execute in parallel. Reading three files? Issue three tool calls in one turn, not three sequential turns.",
+    "- This is about batching work per turn, not about skipping investigation. Take as many turns as you need to understand the problem; just don't waste turns on independent work that could happen together.",
+    "- For shell work, chain related commands with && in a single run_command rather than issuing them one by one.",
+    "",
     "[Code Reading Strategy]",
     "- Start with entry points (e.g. index.ts, main) and follow the flow.",
     ...(hasSpecializedTools

--- a/packages/agent-sdk/src/tools/read-file.ts
+++ b/packages/agent-sdk/src/tools/read-file.ts
@@ -59,7 +59,10 @@ export function createReadFileTool(options: ReadFileToolOptions): ToolDefinition
   return {
     name: "read_file",
     description:
-      "Read file contents with line numbers. Use for config files, non-code files, or when symbol name is unknown. For large files, use offset and limit.",
+      "Read file contents with line numbers. Use for config files, non-code files, or when the symbol name is unknown. " +
+      "For files you expect to be large, pass `offset` and `limit` to avoid a wasted round-trip on truncated output. " +
+      "When reading multiple files (or multiple sections of one file), call read_file multiple times in the same response — they run in parallel. " +
+      "Example: to compare two configs, issue two read_file calls in one turn rather than two sequential turns.",
     inputSchema: {
       type: "object",
       properties: {

--- a/packages/agent-sdk/src/tools/search.ts
+++ b/packages/agent-sdk/src/tools/search.ts
@@ -123,7 +123,8 @@ export function createSearchTool(options: SearchToolOptions): ToolDefinition {
   return {
     name: "search",
     description:
-      "Search file contents using ripgrep. Use when you don't know the symbol name.",
+      "Search file contents using ripgrep. Use when you don't know the symbol name. " +
+      "When grepping for several patterns or under several paths, issue all the search calls in one response — they run in parallel.",
     inputSchema: {
       type: "object",
       properties: {

--- a/src/tools/read-symbol.ts
+++ b/src/tools/read-symbol.ts
@@ -26,7 +26,8 @@ export function createReadSymbolTool(
       "Read a specific function, class, or type definition by name. " +
       "Returns the symbol's source code, referenced types, callers, and callees. " +
       "If a bare name matches multiple symbols, returns disambiguation candidates. " +
-      "PREFER this over read_file for .ts/.tsx/.js/.jsx — use the code map to find symbol names.",
+      "PREFER this over read_file for .ts/.tsx/.js/.jsx — use the code map to find symbol names. " +
+      "When inspecting several symbols, call read_symbol multiple times in the same response — they run in parallel.",
     inputSchema: {
       type: "object",
       properties: {


### PR DESCRIPTION
## Summary

Copilot-inspired change to nudge models — especially small ones — toward batched parallel tool calls. Three pieces:

1. **New `[Tool Efficiency]` block in the default system prompt.** Explicit guidance: "make multiple tool calls in a SINGLE response when independent", "this is about batching, not skipping investigation", "chain shell commands with `&&`".

2. **`read_file` description** carries a parallel-call hint with a worked example ("to compare two configs, issue two read_file calls in one turn rather than two sequential turns"). Also calls out the wasted-round-trip-on-truncation case for large files.

3. **`read_symbol` and `search` descriptions** add the parallel-call hint. Both are common tools where small models tend to round-trip on independent work.

## Why

From the Copilot CLI source inspection (see PR #185 thread / Experiment 4 doc): Copilot's tool descriptions ship with worked examples and parallelism hints inline. The hypothesis is that gemma-class models benefit disproportionately from worked examples vs. abstract specs. The original ablation pattern in `RESULTS-GEMMA-4.md` showed editing-category pass rate flat at 40% — a suspiciously low floor that this change is most plausibly positioned to lift, since editing tasks usually involve `locate → read multiple files → propose change`.

This is the cheapest of three sequenced Copilot-inspired experiments. Sequencing rationale lives in the planning thread; in short: validate variance regime first, then `<plan>` mode (#2), then explore sub-loop (#1) only if needed.

## Caveats

- **Not yet measured.** Plan is to run n=3 on `benchmarks/tasks/` with `gemma-4-26b-a4b-it` against the post-#185 baseline (61.3% → 68.0%), with provider pinning enabled (env var from PR #186) for variance control. This PR ships the change; the experiment write-up follows.
- **No new tests for the description strings themselves** — they're prose and the existing tests assert structural shape only. The system-prompt test passes against the new block.
- `src/tools/read-symbol.ts` had inconsistent CRLF/LF line endings in the original; this PR normalizes to LF, making the diff look larger than it is. Semantic change is one description string.

## Test plan
- [x] `npm test` — 714 pass / 2 pre-existing failures unrelated to this branch
- [ ] n=3 internal-task benchmark with provider pinned to Novita (separate experiment, results to be appended to `RESULTS-GEMMA-4.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)