### PR TITLE
Iteration discipline block — +10.7 pp on internal-tasks (gemma-4-26b)

### DIFF
--- a/benchmarks/RESULTS-GEMMA-4.md
+++ b/benchmarks/RESULTS-GEMMA-4.md
@@ -815,3 +815,118 @@ done
 ```
 
 Artifacts: `/tmp/minicode-bench-logs/internal-tasks/after-fixes-r{1,2,3}.{json,log}`.
+
+# Experiment 5: Copilot-inspired tool descriptions (negative result)
+
+**Status: null result on correctness. The hypothesis (gemma-4-26b benefits disproportionately from worked examples + parallel-call hints in tool descriptions) does not hold at our power level. Two real secondary findings worth documenting: provider pinning collapsed run-to-run variance from ~16 pp to ~4 pp, and the parallel-batching mechanism fired (-9% tokens, -7% duration), it just didn't move correctness.**
+
+## Background
+
+After inspecting the GitHub Copilot CLI source (closed-source agent loop ships as a minified bundle but un-minified prompts and tool descriptions are recoverable from `~/.nvm/.../@github/copilot/app.js` + `definitions/*.agent.yaml`), three techniques looked transferable:
+
+1. Tool descriptions with worked examples + parallelism hints
+2. `<plan>` tag protocol with question-intent classification
+3. Read-only "explore" sub-loop with hard "stop when answered" termination
+
+Sequenced cheapest-first to validate the post-pinning variance regime before stacking experiments. This experiment is #1.
+
+## Changes shipped (on `experiment/copilot-tool-descriptions`)
+
+- **New `[Tool Efficiency]` block** in the default system prompt: explicit "make multiple tool calls in a SINGLE response when independent", "this is about batching, not skipping investigation", "chain shell commands with `&&`".
+- **`read_file`, `read_symbol`, and `search` descriptions** now carry parallel-call hints with worked examples (e.g. "to compare two configs, issue two read_file calls in one turn rather than two sequential turns").
+
+## Methodology
+
+Two cells, both pinned to Novita (bf16) via `OPENROUTER_PROVIDER_ORDER=Novita` (env knob from `experiment/openrouter-provider-pinning`), n=3 each, sequential:
+
+- **pinned-baseline**: post-#185 main + provider pinning (no description changes)
+- **copilot-desc**: pinned-baseline + the description changes above
+
+The pinned-baseline cell exists specifically to disambiguate "did the description change help" from "did pinning to a single good provider help" — the prior 61.3% n=3 mean was on the unpinned OpenRouter routing lottery, so absolute deltas across that boundary would be confounded.
+
+Worktree at `/tmp/minicode-pinned-baseline` keeps each cell's SDK build isolated so concurrent runs don't clobber each other's `dist/`.
+
+## Headline (n=3 mean)
+
+| Cell | r1 | r2 | r3 | mean / 25 | pass rate | tokens (avg) | duration (avg) |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| pinned-baseline | 17 | 17 | 18 | 17.33 | **69.3%** | 58.6K | 33.2s |
+| **copilot-desc** | 17 | 18 | 18 | 17.67 | **70.7%** | 53.2K | 31.0s |
+| Δ | | | | +0.33 | **+1.4 pp** | -9.3% | -6.6% |
+
+**Net per-task delta: +1 pass across all 75 trials.** Inside the variance band. Not credibly distinguishable from noise.
+
+## Per-category (n=3 mean pass rate)
+
+| Category | pinned-baseline | copilot-desc | Δ |
+| --- | --- | --- | --- |
+| navigation | 86.7% | 100.0% | +13.3 pp |
+| debugging | 73.3% | 80.0% | +6.7 pp |
+| planning | 66.7% | 73.3% | +6.7 pp |
+| editing | 46.7% | 40.0% | -6.7 pp |
+| refactors | 73.3% | 60.0% | -13.3 pp |
+
+The category-level deltas look more dramatic than the aggregate suggests, but each is dominated by 1–2 single-task swings at the variance boundary:
+
+- **navigation +13.3 pp**: `explain-feature-flow` and `find-all-references` each move 2/3 → 3/3. Both already trending toward the ceiling — the description change isn't unlocking new capability, just smoothing the last 1/3.
+- **refactors -13.3 pp**: dominated by `consolidate-duplicates` going 3/3 → 0/3. Same task that bailed with zero-tool-call refusals in earlier OpenRouter-routing-roulette runs. Even with Novita pinned, this task systematically fails under the description change. Possibly real, possibly variance — needs a larger n to call.
+- **editing -6.7 pp**: `add-validation` flips 1/3 → 0/3. One task at the margin.
+
+Editing floor (40%) and refactor mid-tier are exactly where the real product gap sits, and the description change does not move them. That's the load-bearing finding: parallel-call hints don't help with the kinds of failures that actually limit gemma-4-26b on this lane.
+
+## What did fire: token economy and batching
+
+- **Tokens per task: 58.6K → 53.2K (-9.3%)**
+- **Duration per task: 33.2s → 31.0s (-6.6%)**
+
+Both consistent with the parallel-batching hypothesis actually working as intended — the agent issues more tool calls per turn, the loop runs fewer turns total. The mechanism is doing what we asked it to. It just doesn't translate to correctness on these tasks.
+
+This is a useful piece of evidence: it tells us "the model is following the new instructions" rather than "the new instructions are being ignored." The wrong layer to attack our remaining failures.
+
+## Methodology finding: provider pinning collapsed variance
+
+The unpinned `after-fixes` n=3 from Experiment 4 spanned **60.0% → 76.0% (16 pp)**. The pinned cells here span:
+
+- pinned-baseline: 68% / 68% / 72% (4 pp)
+- copilot-desc: 68% / 72% / 72% (4 pp)
+
+**Variance band shrunk roughly 4×** by pinning to Novita with `allow_fallbacks: false`. This is more important than the experiment's null result — it means future experiments worth +3 pp can be read at n=3, where unpinned they'd have been drowned by routing noise.
+
+Recommend `experiment/openrouter-provider-pinning` (PR #186) merges regardless of the (3) outcome — its value is measurement infrastructure, not a product gain.
+
+## What this means for the thesis
+
+1. **Tool-description rewrites are not the right lever for gemma-4-26b on this lane.** The mechanism fires (tokens down, duration down) but correctness doesn't move. Either the parallel-call hints solve a problem we don't have on these tasks, or the model needs a stronger architectural intervention than prompt nudges.
+2. **Editing/refactor floor is where the real correctness gap lives** (40-60%) and is unmoved by this change. That's where the next experiment should aim.
+3. **Don't merge this PR's description changes** as a product change. The token savings are nice but not worth the description-string maintenance burden if correctness doesn't track. Keep the work in `experiment/copilot-tool-descriptions` (PR #187) as a documented null result.
+
+## Implications for the next experiment
+
+The Copilot technique that's most directly aligned with our actual failure modes is the `<plan>` mode discipline — specifically the "gather context fully before proposing changes" rule for implement-class tasks. Editing tasks on this lane fail when the model writes code before understanding the surrounding API; that's a different failure shape than parallel-call efficiency.
+
+The third candidate (read-only explore sub-loop on a smaller cheap model) is a heavier architectural lift; conditional on (2) being insufficient.
+
+## Reproducibility
+
+```bash
+# pinned-baseline (worktree) and copilot-desc (main repo) run in parallel,
+# both on Novita via OPENROUTER_PROVIDER_ORDER. n=3 each.
+
+# Pinned-baseline cell (run from /tmp/minicode-pinned-baseline worktree)
+git worktree add /tmp/minicode-pinned-baseline main
+cd /tmp/minicode-pinned-baseline
+git checkout -b experiment/pinned-baseline
+git cherry-pick <pinning-commit>
+npm install && npm run build --workspace=packages/agent-sdk
+
+# Then for r1..r3:
+OPENROUTER_PROVIDER_ORDER=Novita \
+  MODEL_PROVIDER=openai-compatible \
+  MODEL=google/gemma-4-26b-a4b-it \
+  OPENAI_BASE_URL=https://openrouter.ai/api/v1 \
+  OPENROUTER_API_KEY=... \
+  npm run benchmark -- --variant pinned-baseline-r${r} \
+    --out /tmp/minicode-bench-logs/internal-tasks-pinned/pinned-baseline-r${r}.json
+```
+
+Artifacts: `/tmp/minicode-bench-logs/internal-tasks-pinned/{pinned-baseline,copilot-desc}-r{1,2,3}.{json,log}`.

--- a/benchmarks/RESULTS-GEMMA-4.md
+++ b/benchmarks/RESULTS-GEMMA-4.md
@@ -930,3 +930,110 @@ OPENROUTER_PROVIDER_ORDER=Novita \
 ```
 
 Artifacts: `/tmp/minicode-bench-logs/internal-tasks-pinned/{pinned-baseline,copilot-desc}-r{1,2,3}.{json,log}`.
+
+# Experiment 6: iteration-discipline block in the system prompt
+
+**Status: positive and clean. n=3 mean lifts 69.3% → 80.0% (+10.7 pp). The win concentrates exactly where the failure-mode analysis predicted (loop-guard failures in refactors and planning), with no regressions on previously-passing tasks. This is the keeper from the Copilot-inspired round.**
+
+## Why this experiment instead of `<plan>` mode
+
+Originally Experiment 6 was going to port Copilot's `<plan>` mode discipline ("gather all context first, then act"). Failure-mode analysis on the Experiment 5 traces flipped that plan:
+
+| Failure mode (across 3 runs of failing tasks) | Count |
+| --- | --- |
+| **Loop guard tripped** ("repeated identical tool calls") | **11** |
+| Empty output (model emitted tool calls but no final text) | 5 |
+| 0-tool confidently-wrong answer | 3 |
+| Malformed tool-call syntax | 1 |
+| Off-topic but readable | 2 |
+
+The dominant mode is the *opposite* of what `<plan>` mode addresses. The model is investigating exhaustively (`editing/fix-small-bug` 13/7/11 calls before tripping the guard, `editing/add-validation` 17/11/9, `refactors/consolidate-duplicates` 14/13/10) and never committing to an answer or edit. Copilot's explore agent has the matching discipline: *"Stop searching as soon as you can answer the question. Do not be exhaustive."*
+
+## Change shipped (`experiment/iteration-discipline`)
+
+A new `[Iteration Discipline]` block in the default system prompt, inserted before `[Termination Policy]`:
+
+```
+[Iteration Discipline]
+Looping on tool calls is the most common cause of task failure. To avoid it:
+- Stop investigating as soon as you have enough to answer or act. Do not be exhaustive.
+- If you have made 3 or more similar read/search calls without making forward progress, STOP and either commit to the best answer you can support with what you have, or acknowledge what you cannot determine.
+- Do not repeat a tool call with identical or near-identical arguments. If the result was useful, move on. If it was not, change your approach (different pattern, different path, different tool) rather than retrying.
+- Target: gather context in 3–5 read/search calls, then answer or edit.
+```
+
+Five lines, no architectural change, ships behind the same provider-pinning regime as Experiment 5.
+
+## Headline (n=3 mean)
+
+| Cell | r1 | r2 | r3 | mean / 25 | pass rate | tokens (avg) | duration (avg) |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| pinned-baseline | 17 | 17 | 18 | 17.33 | **69.3%** | 58.6K | 33.2s |
+| **iter-discipline** | 21 | 19 | 20 | 20.00 | **80.0%** | 54.6K | 30.5s |
+| Δ | | | | +2.67 | **+10.7 pp** | -6.8% | -8.1% |
+
+Net per-task delta: **+8 passes across 75 trials**. The variance band (8 pp; 76–84%) is slightly wider than the pinned-baseline (4 pp) but doesn't materially affect the read on a +10.7 pp delta.
+
+## Per-category (n=3 mean pass rate)
+
+| Category | pinned-baseline | iter-discipline | Δ |
+| --- | --- | --- | --- |
+| navigation | 86.7% | **100.0%** | +13.3 pp |
+| **planning** | 66.7% | **86.7%** | **+20.0 pp** |
+| **refactors** | 73.3% | **93.3%** | **+20.0 pp** |
+| debugging | 73.3% | 73.3% | 0 pp |
+| editing | 46.7% | 46.7% | 0 pp |
+
+The +20 pp categories are exactly where loop-guard failures concentrated in the Experiment 5 traces. Both moved cleanly. The unmoved categories are also predicted by the failure-mode analysis:
+
+- **debugging unchanged**: the failing task is `diagnose-type-error` (0/3 → 0/3), which is the *opposite* failure shape — 0-tool calls, hallucinated answer from training-data knowledge. The discipline can't help a model that never called a tool.
+- **editing flat**: `fix-small-bug` 0/3→1/3 (loop-guard win) and `add-validation` 1/3→0/3 (variance-edge wash) net zero. The remaining editing failures (`add-logging`, `add-validation`) are empty-output or malformed-tool-call modes — separate mechanism, separate fix.
+
+## Per-task wins concentrated on the predicted shapes
+
+The +8 net delta breaks down as:
+
+- **Loop-guard tasks recovered** (+4): `refactors/extract-helper` 0/3→2/3 (was guard-trip on 9/_/6 calls), `planning/identify-serve-codepath` 2/3→3/3, `editing/fix-small-bug` 0/3→1/3 (was guard-trip on 13/7/11), `planning/plan-new-tool` 0/3→1/3.
+- **Variance-edge tasks tipped to ceiling** (+4): `navigation/explain-feature-flow` 2/3→3/3, `navigation/find-all-references` 2/3→3/3, `planning/explain-context-trimming` 2/3→3/3, `refactors/move-logic-to-helper` 2/3→3/3. Already trending toward 3/3; the discipline likely just removed the spurious investigation that was costing the third trial.
+- **One regression at the variance edge** (-1): `editing/add-validation` 1/3→0/3. Single task, was already noisy, not a previously-stable result.
+
+Crucially, **no previously-3/3 tasks regressed.** Every task at the ceiling stayed there. The discipline didn't introduce new failure modes; it suppressed the dominant existing one.
+
+## Token economy
+
+Tokens dropped from 58.6K → 54.6K per task (-6.8%); duration 33.2s → 30.5s (-8.1%). These are not the headline win — the correctness improvement is — but they're consistent: fewer wasted tool calls means less inference overall.
+
+## What this means
+
+1. **The right Copilot technique to port for gemma-class models on this lane is the explore-agent stopping rule, not the `<plan>` mode discipline.** This was a flipped hypothesis; the failure-mode analysis got us there.
+
+2. **Loop-guard trips are a load-bearing failure mode** that the system prompt can directly address. Before this change, four categories of tasks were systematically losing trials to over-investigation; after, they recover cleanly.
+
+3. **The remaining failure modes are mechanically distinct** and need separate fixes:
+   - Empty output / malformed tool-call: likely a model-format issue (provider-side or in our request shape). Not a prompting problem.
+   - 0-tool hallucinated answers (`diagnose-type-error`): the *opposite* of loop-guard. Probably needs an "investigate before answering" rule, but only for questions the model can't answer from system-prompt context. Tricky to scope without re-introducing the looping problem.
+
+4. **PR worth merging.** Unlike Experiment 5, this change is product-level and not just measurement infrastructure. Recommend merging after PR #186 (provider pinning) lands.
+
+## Reproducibility
+
+```bash
+# Same setup as Experiment 5, just with the iter-discipline branch
+git checkout experiment/iteration-discipline
+git cherry-pick <pinning-commit>  # for the experiment run only
+npm install && npm run build --workspace=packages/agent-sdk
+
+for r in 1 2 3; do
+  OPENROUTER_PROVIDER_ORDER=Novita \
+    MODEL_PROVIDER=openai-compatible \
+    MODEL=google/gemma-4-26b-a4b-it \
+    OPENAI_BASE_URL=https://openrouter.ai/api/v1 \
+    OPENROUTER_API_KEY=... \
+    npm run benchmark -- --variant iter-disc-r${r} \
+      --out /tmp/minicode-bench-logs/internal-tasks-pinned/iter-disc-r${r}.json
+done
+```
+
+Pinned-baseline data is reused from Experiment 5 (`/tmp/minicode-bench-logs/internal-tasks-pinned/pinned-baseline-r{1,2,3}.json`).
+
+Artifacts: `/tmp/minicode-bench-logs/internal-tasks-pinned/iter-disc-r{1,2,3}.{json,log}`.

--- a/packages/agent-sdk/src/prompt/system-prompt.ts
+++ b/packages/agent-sdk/src/prompt/system-prompt.ts
@@ -165,6 +165,13 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
         ]
       : ["- Use search to locate relevant code, then read_file to inspect it."]),
     "",
+    "[Iteration Discipline]",
+    "Looping on tool calls is the most common cause of task failure. To avoid it:",
+    "- Stop investigating as soon as you have enough to answer or act. Do not be exhaustive.",
+    "- If you have made 3 or more similar read/search calls without making forward progress, STOP and either commit to the best answer you can support with what you have, or acknowledge what you cannot determine.",
+    "- Do not repeat a tool call with identical or near-identical arguments. If the result was useful, move on. If it was not, change your approach (different pattern, different path, different tool) rather than retrying.",
+    "- Target: gather context in 3–5 read/search calls, then answer or edit.",
+    "",
     "[Termination Policy]",
     "- When the user asks you to do something (edit code, search, run commands, etc.), you MUST use the appropriate tools first. Do not conclude until you have actually performed the work.",
     "- When the task is complete, respond with a concise summary of what you changed.",


### PR DESCRIPTION
## Summary

Adds a 5-line `[Iteration Discipline]` block to the default system prompt that tells the agent to stop investigating when it has enough context, target 3-5 read/search calls, and avoid identical/near-identical retries. Adapted from GitHub Copilot CLI's explore-agent stopping rule (*"Stop searching as soon as you can answer the question. Do not be exhaustive."*) after failure-mode analysis showed loop-guard trips were the dominant failure on `gemma-4-26b-a4b-it`.

## Result

| Cell | r1 | r2 | r3 | mean | pass rate |
| --- | --- | --- | --- | --- | --- |
| pinned-baseline (Exp 5) | 17 | 17 | 18 | 17.33 | 69.3% |
| **iter-discipline** | 21 | 19 | 20 | **20.00** | **80.0%** |
| **Δ** | | | | +2.67 | **+10.7 pp** |

- Net per-task delta: **+8 passes across 75 trials**
- **Refactors +20 pp** (73.3% → 93.3%) — `extract-helper` 0/3→2/3, `move-logic-to-helper` 2/3→3/3
- **Planning +20 pp** (66.7% → 86.7%) — `identify-serve-codepath`, `explain-context-trimming`, `plan-new-tool` all moved
- **Navigation +13.3 pp** to 100% mean
- **No regressions on previously-3/3 tasks**
- Tokens -6.8%, duration -8.1% as side effects

Categories that didn't move (debugging, editing) are *predicted* by the failure analysis: their dominant failure modes are 0-tool hallucinated answers and empty-output / malformed-tool-call, neither of which this change targets.

## Why this experiment, not the original `<plan>` mode

Failure-mode analysis on Experiment 5 traces showed 11/22 failing-task occurrences were the loop-guard tripping — the *opposite* of what `<plan>` mode addresses. Detail in `benchmarks/RESULTS-GEMMA-4.md` Experiment 6 section.

## Includes

This PR also includes the Experiment 5 doc (Copilot tool-description null result) since that experiment's PR (#188) is doc-only and the two pieces of evidence make more sense merged together. If #188 is preferred separately, this PR can be rebased.

## Test plan
- [x] `npm test` — 714 pass / 2 pre-existing failures unrelated to this branch
- [x] n=3 internal-task benchmark with Novita pinned: 84%/76%/80%, mean 80.0%
- [x] Per-task and per-category deltas align with the predicted failure-mode targeting
- [x] No regressions on previously-3/3 tasks across all 25 tasks
- [x] Variance band tracked, +10.7 pp clearly outside it

## Recommended merge order
1. PR #186 (provider pinning) — measurement infrastructure
2. This PR — first product change validated against the pinned regime

🤖 Generated with [Claude Code](https://claude.com/claude-code)