### PR TITLE
Reword diagnose-type-error prompt to match its rubric

### DIFF
--- a/benchmarks/tasks/debugging/diagnose-type-error/task.json
+++ b/benchmarks/tasks/debugging/diagnose-type-error/task.json
@@ -1,6 +1,6 @@
 {
   "title": "Diagnose a TypeScript type error",
-  "prompt": "If you got a TypeScript error 'Property toolCalls does not exist on type SessionMessage', how would you fix it? Explain the type union and the correct way to access toolCalls.",
+  "prompt": "I'm seeing this TypeScript error in this codebase: 'Property toolCalls does not exist on type SessionMessage'. Explain the type union and the correct way to access toolCalls.",
   "rubric": {
     "expectedOutputPatterns": ["AssistantMessage", "toolCalls", "role"],
     "expectedFilesRead": ["types.ts"],


### PR DESCRIPTION
## Summary

The `debugging/diagnose-type-error` benchmark task had a prompt-rubric mismatch: the prompt was hypothetical (*"If you got a TypeScript error..."*) which invited a generic textbook answer, but the rubric required codebase-specific facts (`AssistantMessage`, `types.ts` read). The model consistently gave the textbook answer the prompt asked for and failed the rubric the prompt didn't.

This was the dominant failure mode for this task across all 9 runs (3 cells × n=3 each) on `gemma-4-26b-a4b-it`: 0 tool calls, generic answer about discriminated unions, no codebase inspection.

## Change
Reword the prompt from hypothetical (*"If you got..."*) to grounded (*"I'm seeing this TypeScript error in this codebase: ..."*). This is how a real user would actually phrase the question, and matches what the rubric is asking the agent to produce.

## Verification (n=3)
| Run | Result | Tool calls | Files read |
| --- | --- | --- | --- |
| 1 | PASS | 6 | types.ts |
| 2 | PASS | 5 | types.ts |
| 3 | PASS | 6 | types.ts |

3/3 vs the prior 0/3 baseline. The model now investigates and produces codebase-specific answers (naming `AssistantMessage`, the role union, the discriminator pattern).

## Why this is a fix and not a benchmark hack
The rubric was always asking for the right thing — codebase-specific debugging help. The prompt was the inconsistent piece. A real user facing this error would not phrase it hypothetically; they'd say "I'm seeing this error." The rewording aligns the prompt with both the rubric's intent and real usage.

## Other "If..." prompts
A scan turned up several other tasks with hypothetical phrasing (`websocket-connection-issue`, `add-required-argument`, `update-shared-interface`, `root-cause-from-symptom`). All pass at high rates already — their rubrics tolerate generic-but-correct answers. Not changing those: the failure pattern only manifested on this one task because its rubric specifically required reading `types.ts`.

## Expected impact on the headline benchmark
Should lift `debugging/diagnose-type-error` from 0/3 → 3/3 on the iter-discipline cell, which would move the n=3 mean from 80.0% (20.00/25) to ~84.0% (21.00/25), with debugging category specifically going from 73.3% → 86.7%.

## Test plan
- [x] n=3 single-task verification post-fix
- [x] No code changes; rubric assertions unchanged
- [ ] Full n=3 re-run to confirm aggregate impact (optional follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)