### PR TITLE
Post-edit tsc diagnostic feedback (Experiment 10)

### DIFF
--- a/benchmarks/RESULTS-GEMMA-4.md
+++ b/benchmarks/RESULTS-GEMMA-4.md
@@ -1330,3 +1330,85 @@ done
 ```
 
 Artifacts: `/tmp/minicode-bench-logs/internal-tasks-postmerge/trim-r{1,2,3}.{json,log}`.
+
+# Experiment 10: post-edit diagnostic feedback (opencode-style LSP echo)
+
+**Status: mechanism works (verified end-to-end), aggregate +6.7 pp at n=3, but editing — the only category the mechanism can touch — was flat. Net signal at this n: probably null but downside is bounded. Shipped on the basis that the mechanism is sound and the activation rate is the limiting factor, not the design.**
+
+## Change
+
+After a successful `edit_file`, run `tsc --noEmit --incremental -p <nearest tsconfig>` against the workspace, filter the parsed diagnostics to errors in the touched file, and append an opencode-style block to the tool's result string when there's anything to report:
+
+```
+Updated "src/indexer/code-map.ts" successfully.
+
+<diagnostics file="src/indexer/code-map.ts">
+ERROR [123:7] Block-scoped variable 'totalCount' used before its declaration.
+ERROR [123:7] Variable 'totalCount' is used before being assigned.
+</diagnostics>
+```
+
+The model sees this on the next turn and can correct the bad edit before continuing.
+
+Implementation lives at `src/tools/post-edit-diagnostics.ts` (app layer — depends on workspace tsconfig). The SDK's `EditFileHooks.afterEdit` was widened to allow returning a string that gets appended to the success message. `tsc` is resolved via `require.resolve("typescript/bin/tsc")` so it works in temp workspaces the benchmark runner creates (no `node_modules`). Runs are serialized per-tsconfig to avoid `.tsbuildinfo` races; cache lives under `~/.minicode/cache/<workspace-hash>/diagnostics/`. Timeout 15s, graceful degrade to no-diagnostic on any failure. Gated off with `MINICODE_DISABLE_POST_EDIT_DIAGNOSTICS=1`.
+
+Mirrors opencode's pattern (`packages/opencode/src/tool/edit.ts:192-197`), which calls into the language server after every edit and emits a `<diagnostics file="...">` block when errors are present. opencode uses LSP for full-fidelity diagnostics; we run `tsc` because we don't have an LSP layer.
+
+## Results (n=3, unpinned)
+
+| Cell | aggregate | dbg | edit | nav | plan | refac |
+| --- | --- | --- | --- | --- | --- | --- |
+| trim baseline (Exp 9, n=3 unpinned) | 80.0% | 73.3% | 86.7% | 100% | 86.7% | 53.3% |
+| **diagnostic n=3 (this PR)** | **86.7%** | 93.3% | **86.7%** | 100% | 80.0% | 73.3% |
+| Δ | +6.7 | +20 | **flat** | flat | -6.7 | +20 |
+
+Per-run: 76, 88, 96. The 20 pp run-to-run swing is the standard unpinned variance band — typical of provider routing lottery on refactor-heavy categories.
+
+## Mechanism evidence vs. aggregate signal
+
+The diagnostic is **mechanistically valid** but **rarely activated** on this benchmark:
+
+- **75 task-runs · 9 total `edit_file` calls** (0.12 edits/task). Most tasks are comprehension; few mutate files.
+- **3 of 9 edits triggered a diagnostic block** — all on `editing/fix-small-bug`. The other 6 edits produced clean output (no errors).
+- In runs r1 and r2 the model's first edit had a TS error (`totalCount` used-before-declaration); the model then issued a second `edit_file` that was clean, and the task passed. That's the loop we wanted to enable.
+- In run r3 the task passed on the first edit (no diagnostic surfaced). Same passing outcome, no diagnostic dependency.
+
+The aggregate +6.7 pp lives in categories where the diagnostic **can't fire** (debugging, refactors — most of those tasks never call `edit_file`). So the headline is provider variance, not the change.
+
+Editing — the one category the diagnostic mechanism touches — is **flat at 86.7%** vs the trim baseline's 86.7%. The model already had editing working at this rate before the diagnostic.
+
+## Why ship it anyway
+
+- **No measured regression.** No task failed because of a diagnostic block (verified across all 10 failing tasks in n=3). The model never got confused by the appended block.
+- **Cost is bounded and gated.** Only fires on `edit_file` for `.ts/.tsx/.js/.jsx/.mts/.cts` files, only when a tsconfig is reachable. ~2-4s per fire. Roughly 3 fires per 25-task run on this lane. Disable knob is `MINICODE_DISABLE_POST_EDIT_DIAGNOSTICS=1`.
+- **Mechanism is right** by the heuristic. Surfacing existing system feedback to the model is a nudge that helps failing edits, not a restriction. Frontier models will benefit too — they already know how to read TS errors.
+- **Activation rate is the bottleneck, not the design.** The benchmark suite has few edits per task. On a real codebase or a more edit-heavy benchmark, the rate of diagnostic-triggered self-correction would be higher.
+
+## Why this isn't a clean win
+
+Honest framing per the variance-rules-out heuristic:
+
+- The diagnostic only ever runs on `edit_file`'s success path. It cannot have caused changes in dbg/refactor outcomes on tasks that never edit a file. Those wins are routing variance.
+- Editing is the only category where the diagnostic could have moved the needle, and editing is flat.
+- A clean signal would require either (a) pinned n=3 to remove variance, (b) tasks where the model's first edit is more likely to be broken (bigger surface area), or (c) a metric narrower than pass/fail (e.g. "edits-per-passing-task").
+
+## Caveats
+
+- **Per-task cold `tsc`.** The benchmark runner copies each task into a fresh tempdir without `node_modules`, so the `.tsbuildinfo` cache is empty per task. Cold tsc is ~4s; warm (subsequent edits in the same task) is ~2s. On a real session against a single workspace the warm path dominates.
+- **TS-only.** Other plugins (Python, etc.) would need their own diagnostic shim.
+- **Whole-project check per edit.** We don't isolate to the touched file's reverse-dependency set. Catches more errors but pays the full project cost.
+
+## Reproducibility
+
+```bash
+for r in 1 2 3; do
+  MODEL_PROVIDER=openai-compatible \
+    MODEL=google/gemma-4-26b-a4b-it \
+    OPENAI_BASE_URL=https://openrouter.ai/api/v1 \
+    OPENROUTER_API_KEY=... \
+    npm run benchmark -- --variant diagnostic-r${r} \
+      --out /tmp/minicode-bench-logs/internal-tasks-postmerge/diagnostic-r${r}.json
+done
+```
+
+Artifacts: `/tmp/minicode-bench-logs/internal-tasks-postmerge/diagnostic-r{1,2,3}.{json,log}`.

--- a/packages/agent-sdk/src/tools/edit-file.ts
+++ b/packages/agent-sdk/src/tools/edit-file.ts
@@ -22,8 +22,17 @@ function expectString(input: Record<string, unknown>, key: string): string {
 }
 
 export interface EditFileHooks {
+  /**
+   * Called after a successful edit. If the hook returns a non-empty string,
+   * it is appended to the tool's success message — used to surface post-edit
+   * diagnostics (e.g. type-check errors) so the model can fix bad edits on
+   * the next turn.
+   */
   afterEdit?:
-    | ((filePath: string, content: string) => void | Promise<void>)
+    | ((
+        filePath: string,
+        content: string,
+      ) => void | string | Promise<void | string>)
     | undefined;
 }
 
@@ -72,11 +81,15 @@ export function createEditFileTool(
 
       await writeFile(filePath, updated, "utf8");
 
+      let suffix = "";
       if (hooks?.afterEdit) {
-        await hooks.afterEdit(filePath, updated);
+        const result = await hooks.afterEdit(filePath, updated);
+        if (typeof result === "string" && result.length > 0) {
+          suffix = `\n\n${result}`;
+        }
       }
 
-      return `Updated "${requestedPath}" successfully.`;
+      return `Updated "${requestedPath}" successfully.${suffix}`;
     },
   };
 }

--- a/src/tools/post-edit-diagnostics.ts
+++ b/src/tools/post-edit-diagnostics.ts
@@ -1,0 +1,234 @@
+import { spawn } from "node:child_process";
+import { mkdir, stat } from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+import { getWorkspaceCacheDir } from "../indexer/cache.js";
+
+const require = createRequire(import.meta.url);
+
+let cachedTscPath: string | null | undefined;
+function resolveTscPath(): string | null {
+  if (cachedTscPath !== undefined) return cachedTscPath;
+  try {
+    cachedTscPath = require.resolve("typescript/bin/tsc");
+  } catch {
+    cachedTscPath = null;
+  }
+  return cachedTscPath;
+}
+
+const TS_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".mts", ".cts"]);
+const MAX_PER_FILE = 20;
+const TSC_TIMEOUT_MS = 15_000;
+const DISABLE_ENV = "MINICODE_DISABLE_POST_EDIT_DIAGNOSTICS";
+
+interface ParsedDiagnostic {
+  file: string;
+  line: number;
+  col: number;
+  severity: "error" | "warning";
+  code: string;
+  message: string;
+}
+
+/**
+ * Walk up from `startDir` looking for the nearest tsconfig.json. Stops at
+ * `workspaceRoot` (inclusive). Returns null if none found.
+ */
+async function findNearestTsconfig(
+  startDir: string,
+  workspaceRoot: string,
+): Promise<string | null> {
+  const root = path.resolve(workspaceRoot);
+  let dir = path.resolve(startDir);
+  while (true) {
+    const candidate = path.join(dir, "tsconfig.json");
+    try {
+      const s = await stat(candidate);
+      if (s.isFile()) return candidate;
+    } catch {
+      // not present, keep walking
+    }
+    if (dir === root) return null;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+const TSC_LINE_RE =
+  /^(.+?)\((\d+),(\d+)\):\s+(error|warning)\s+(TS\d+):\s*(.*)$/;
+
+function parseTscOutput(output: string, projectDir: string): ParsedDiagnostic[] {
+  const lines = output.split(/\r?\n/);
+  const out: ParsedDiagnostic[] = [];
+  for (const line of lines) {
+    const m = line.match(TSC_LINE_RE);
+    if (!m) continue;
+    const [, rawFile, ln, col, sev, code, msg] = m;
+    if (!rawFile || !ln || !col || !sev || !code || msg === undefined) continue;
+    const absFile = path.isAbsolute(rawFile)
+      ? rawFile
+      : path.resolve(projectDir, rawFile);
+    out.push({
+      file: absFile,
+      line: Number(ln),
+      col: Number(col),
+      severity: sev === "error" ? "error" : "warning",
+      code,
+      message: msg.trim(),
+    });
+  }
+  return out;
+}
+
+interface RunResult {
+  diagnostics: ParsedDiagnostic[];
+}
+
+async function runTsc(
+  tsconfigPath: string,
+  workspaceRoot: string,
+): Promise<RunResult | null> {
+  const cacheDir = path.join(
+    getWorkspaceCacheDir(workspaceRoot),
+    "diagnostics",
+  );
+  await mkdir(cacheDir, { recursive: true });
+  const tsbuildinfo = path.join(
+    cacheDir,
+    `${path.basename(path.dirname(tsconfigPath))}.tsbuildinfo`,
+  );
+
+  const tscPath = resolveTscPath();
+  if (!tscPath) return null;
+
+  return await new Promise<RunResult | null>((resolve) => {
+    const child = spawn(
+      process.execPath,
+      [
+        tscPath,
+        "--noEmit",
+        "--pretty",
+        "false",
+        "--incremental",
+        "--tsBuildInfoFile",
+        tsbuildinfo,
+        "-p",
+        tsconfigPath,
+      ],
+      {
+        cwd: workspaceRoot,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: process.env,
+      },
+    );
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      resolve(null);
+    }, TSC_TIMEOUT_MS);
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(null);
+    });
+    child.on("close", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      const combined = stdout + (stderr ? `\n${stderr}` : "");
+      resolve({
+        diagnostics: parseTscOutput(combined, path.dirname(tsconfigPath)),
+      });
+    });
+  });
+}
+
+function formatDiagnostics(
+  filePath: string,
+  diags: ParsedDiagnostic[],
+): string | undefined {
+  const errors = diags.filter((d) => d.severity === "error");
+  if (errors.length === 0) return undefined;
+  const limited = errors.slice(0, MAX_PER_FILE);
+  const more = errors.length - MAX_PER_FILE;
+  const suffix = more > 0 ? `\n... and ${more} more` : "";
+  const body = limited
+    .map((d) => `ERROR [${d.line}:${d.col}] ${d.message}`)
+    .join("\n");
+  return `<diagnostics file="${filePath}">\n${body}${suffix}\n</diagnostics>`;
+}
+
+/**
+ * Serialize diagnostic runs per workspace+tsconfig so concurrent edits don't
+ * trigger overlapping tsc processes that fight over the same .tsbuildinfo.
+ */
+const inflightByKey = new Map<string, Promise<RunResult | null>>();
+
+function serializedRun(
+  tsconfigPath: string,
+  workspaceRoot: string,
+): Promise<RunResult | null> {
+  const key = `${workspaceRoot}::${tsconfigPath}`;
+  const prev = inflightByKey.get(key) ?? Promise.resolve(null);
+  const next = prev.then(() => runTsc(tsconfigPath, workspaceRoot));
+  inflightByKey.set(
+    key,
+    next.finally(() => {
+      if (inflightByKey.get(key) === next) inflightByKey.delete(key);
+    }),
+  );
+  return next;
+}
+
+/**
+ * Run tsc against the nearest tsconfig and return an opencode-style
+ * `<diagnostics file="...">` block listing errors in the touched file. Returns
+ * undefined when there are no errors, when the file is not a TypeScript-family
+ * file, when no tsconfig is found, or when the run fails. Never throws.
+ */
+export async function buildPostEditDiagnostic(
+  filePath: string,
+  workspaceRoot: string,
+): Promise<string | undefined> {
+  if (process.env[DISABLE_ENV] === "1") return undefined;
+
+  const ext = path.extname(filePath).toLowerCase();
+  if (!TS_EXTENSIONS.has(ext)) return undefined;
+
+  try {
+    const tsconfig = await findNearestTsconfig(
+      path.dirname(filePath),
+      workspaceRoot,
+    );
+    if (!tsconfig) return undefined;
+
+    const result = await serializedRun(tsconfig, workspaceRoot);
+    if (!result) return undefined;
+
+    const absTouched = path.resolve(filePath);
+    const forFile = result.diagnostics.filter(
+      (d) => path.resolve(d.file) === absTouched,
+    );
+    const displayPath = path.relative(workspaceRoot, absTouched) || filePath;
+    return formatDiagnostics(displayPath, forFile);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import {
   ToolRegistry,
   createReadFileTool,
@@ -14,6 +16,7 @@ import { createGetDependenciesTool } from "./get-dependencies.js";
 import { createReadSymbolTool } from "./read-symbol.js";
 import { createFindPathTool } from "./find-path.js";
 import { createSearchCodeMapTool } from "./search-code-map.js";
+import { buildPostEditDiagnostic } from "./post-edit-diagnostics.js";
 
 export { ToolRegistry };
 
@@ -48,8 +51,14 @@ export function createToolRegistry(
     ? {
         afterWrite: (relPath: string, content: string) =>
           reindexBestEffort(projectIndex, relPath, content),
-        afterEdit: (relPath: string, content: string) =>
-          reindexBestEffort(projectIndex, relPath, content),
+        afterEdit: async (
+          absPath: string,
+          content: string,
+        ): Promise<string | undefined> => {
+          const relPath = path.relative(config.workspaceRoot, absPath);
+          await reindexBestEffort(projectIndex, relPath, content);
+          return await buildPostEditDiagnostic(absPath, config.workspaceRoot);
+        },
         afterCommand: async () => {
           await projectIndex.refreshFromWorkspace();
         },


### PR DESCRIPTION
## Summary

- After a successful `edit_file`, run `tsc --noEmit` against the touched workspace and surface any errors in the touched file as an opencode-style `<diagnostics file="...">` block appended to the tool's result message — so the model can fix bad edits on the next turn.
- TS-only (`.ts/.tsx/.js/.jsx/.mts/.cts`), gated off with `MINICODE_DISABLE_POST_EDIT_DIAGNOSTICS=1`, ~2-4s per fire, serialized per-tsconfig.
- Full write-up: `benchmarks/RESULTS-GEMMA-4.md` (Experiment 10).

## Results (n=3, unpinned)

| Cell | aggregate | dbg | edit | nav | plan | refac |
| --- | --- | --- | --- | --- | --- | --- |
| trim baseline (Exp 9) | 80.0% | 73.3% | 86.7% | 100% | 86.7% | 53.3% |
| **diagnostic (this)** | **86.7%** | 93.3% | **86.7%** | 100% | 80.0% | 73.3% |
| Δ | +6.7 | +20 | **flat** | flat | -6.7 | +20 |

Per-run swing 76 → 88 → 96 is the standard unpinned variance band. Editing — the only category the mechanism can touch — is flat. Aggregate delta is debugging/refactor provider variance.

Mechanism evidence is real but rare on this benchmark: 9 total `edit_file` calls across 75 task-runs (0.12 edits/task), 3 surfaced a diagnostic block (all on `editing/fix-small-bug`), and on r1+r2 the model's first edit had a TS error and the second edit was clean — exactly the loop the change is supposed to enable.

## Why ship anyway

- No regression: no failing task across n=3 was attributable to a diagnostic block confusing the model.
- Cost is bounded and disable-able: only fires on `edit_file` for TS files when a tsconfig is reachable.
- Mechanism is right: surfaces existing system feedback rather than adding new restrictions. Frontier models benefit equally.
- The activation rate (not the design) is the bottleneck on this benchmark suite. Real workloads have more edits per task.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean (--max-warnings=0)
- [x] SDK file-tools tests pass (`node --test --import tsx packages/agent-sdk/tests/file-tools.test.ts` — 18/18)
- [x] End-to-end integration test in a temp workspace: edit introduces TS error → diagnostic block appears in result
- [x] Clean edit + non-TS file → no diagnostic block, no errors
- [x] n=3 unpinned benchmark — artifacts at `/tmp/minicode-bench-logs/internal-tasks-postmerge/diagnostic-r{1,2,3}.{json,log}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)