### PR TITLE
Benchmark: narrow symlink of node_modules/@types into temp workspace

### DIFF
--- a/src/benchmark/runner.ts
+++ b/src/benchmark/runner.ts
@@ -6,7 +6,7 @@
  */
 
 import { execSync } from "node:child_process";
-import { cp, mkdtemp, rm } from "node:fs/promises";
+import { cp, mkdir, mkdtemp, rm, symlink, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -35,6 +35,25 @@ const COPY_SKIP_NAMES = new Set([
   "build",
   "coverage",
 ]);
+
+/**
+ * Narrow symlinks (relative to the source workspace) injected into the
+ * isolated workspace after the bulk copy. Goal: make `tsc --noEmit`
+ * resolve types for the post-edit diagnostic, *without* enabling the
+ * full test runner.
+ *
+ * - `node_modules/@types` lets tsc resolve `@types/node` etc. (the
+ *   typescript binary itself runs from the source workspace and finds
+ *   its lib files relative to its own install location, so we don't
+ *   need to symlink it into the temp tree.)
+ *
+ * We intentionally do NOT symlink `node_modules/.bin` or general deps,
+ * so commands like `npm test` fail fast with "tsc: not found" rather
+ * than running the full pretest+test suite and burning per-task
+ * tool-call budget on infrastructure noise. See benchmarks/RESULTS for
+ * the symlink scope conversation.
+ */
+const SYMLINK_FROM_SOURCE: ReadonlyArray<string> = ["node_modules/@types"];
 
 export interface RunnerOptions {
   /** Model client to use. */
@@ -97,6 +116,32 @@ function shouldCopyPath(src: string): boolean {
   return !COPY_SKIP_NAMES.has(name);
 }
 
+async function linkSharedDirs(
+  sourceRoot: string,
+  workspaceRoot: string,
+): Promise<void> {
+  for (const rel of SYMLINK_FROM_SOURCE) {
+    const sourcePath = path.join(sourceRoot, rel);
+    try {
+      const s = await stat(sourcePath);
+      if (!s.isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    const linkPath = path.join(workspaceRoot, rel);
+    // Ensure parent dir exists — e.g. `node_modules/@types` requires
+    // `node_modules/` to be created first (we don't bulk-copy it).
+    await mkdir(path.dirname(linkPath), { recursive: true });
+    try {
+      await symlink(sourcePath, linkPath, "dir");
+    } catch {
+      // Best-effort: a parent path may not exist or the link target
+      // already does. Skip silently — tools that need these resolve
+      // to a useful error if missing.
+    }
+  }
+}
+
 async function prepareTaskWorkspace(
   task: BenchmarkTask,
   options: RunnerOptions,
@@ -116,6 +161,8 @@ async function prepareTaskWorkspace(
     recursive: true,
     filter: shouldCopyPath,
   });
+
+  await linkSharedDirs(sourceWorkspaceRoot, isolatedWorkspaceRoot);
 
   return {
     sourceWorkspaceRoot,


### PR DESCRIPTION
## Summary

Methodology fix. The benchmark runner excludes `node_modules` from the per-task workspace copy. Without it, `tsc --noEmit` can't resolve type definitions and silently fails — which was rendering the post-edit diagnostic from #194 a near-no-op on the benchmark suite (it only fired the few times the model ran `npm install` first).

Symlinking just `node_modules/@types` solves it without enabling the test runner:

- ✅ tsc finds `@types/node` etc. → post-edit diagnostic actually fires
- ✅ `npm test` still fails fast (~1-2s, "tsc: not found" via PATH) because we don't symlink `.bin` or general deps
- ✅ Verified end-to-end: broken edit to `code-map.ts` surfaces a `<diagnostics file="...">` block with the expected TS18004 errors. Without the symlink the helper returned undefined silently.

## Why narrow vs. full

A full `node_modules` symlink was the first attempt, but it made `npm test` actually run the pretest+test suite (~30s timeouts, 50KB output) and burned per-task tool-call budget on infrastructure noise. The narrow scope (just `node_modules/@types`) gives tsc what it needs and nothing else.

## Framing

This is a methodology fix, not a designed experiment. n=3 on a bad routing evening (22/25 failures across the 3 runs were provider-side issues — empty responses and `<|tool_call>` markup leakage) gave 76/64/48% which is unusable as a measurement. The mechanism is verified in smoke; macro impact will be measurable next time provider routing is calm or via a pinned run.

## Test plan

- [x] `npm run build` clean
- [x] Smoke (single-task `editing/fix-small-bug`): passes, npm test fails fast (~2.5s)
- [x] End-to-end diagnostic verification: broken edit → `<diagnostics>` block fires with real TS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)