### PR TITLE
Defensive recovery for leaked gemma tool-call markup (Experiment 14)

### DIFF
--- a/benchmarks/RESULTS-GEMMA-4.md
+++ b/benchmarks/RESULTS-GEMMA-4.md
@@ -1673,3 +1673,88 @@ done
 ```
 
 Artifacts: `/tmp/minicode-bench-logs/internal-tasks-postmerge/fresh-r{1,2,3}.{json,log}`.
+
+# Experiment 14: defensive recovery of leaked gemma tool-call markup
+
+**Status: mechanism verified by unit tests, runtime path not exercised on this n=3 (routing didn't produce any leakages). Aggregate landed at 89.3% mean — top of variance band — but can't be attributed to the change. Shipped as defensive correctness for real-world users on bad-routing windows.**
+
+## The failure mode
+
+Some upstream OpenAI-compatible providers (Novita observed most often) fail to extract gemma's internal channel-format tool calls and leak the raw markup into the `content` field with empty `tool_calls`:
+
+```
+content: '<|tool_call>call:search{pattern:<|"|>typescriptPlugin<|"|>}<tool_call|>'
+tool_calls: []
+```
+
+Cataloged across all archived benchmark runs: **17 instances across 9 different result files**, all single-call, with two consistent shapes:
+
+- `<|tool_call>call:NAME{...}<tool_call|>` (full channel markup)
+- `call:NAME{...}<tool_call|>` (opening marker stripped by partial provider parsing)
+
+Argument format is consistent: `KEY:<|"|>VALUE<|"|>` separated by `,`, with multi-line values supported (observed in an `edit_file` leakage with newline-containing `new_string` / `old_string` values). `<|tool_call>`, `<|"|>`, and `<tool_call|>` are gemma channel tokens that should never appear in normal model text.
+
+Pre-fix, these leakages surfaced as "model returned no tool calls" failures (~1/run on calm routing, several/run on bad evenings) because the agent loop saw empty `toolCalls` and exited the turn.
+
+## Change
+
+`packages/agent-sdk/src/model/client.ts` — add a defensive recovery step at the end of both `parseOpenAICompatibleResponse` (non-streaming) and the streaming aggregator. When structured `tool_calls` is empty AND `content` matches the strict anchored leakage pattern, extract the call into a synthetic `ToolCall` with id `"leaked-tool-call"` and clear the text:
+
+```ts
+function tryRecoverLeakedToolCall(content: string): ToolCall | null {
+  // strip optional <|tool_call> prefix
+  // match anchored: ^call:(\w+)\{(.*)\}<tool_call\|>\s*$
+  // parse args: (\w+):<|"|>(.*?)<|"|>(?:,|$)
+}
+
+function applyLeakedToolCallRecovery(response: ModelResponse): ModelResponse {
+  if (response.toolCalls.length > 0) return response;
+  const recovered = tryRecoverLeakedToolCall(response.text);
+  if (!recovered) return response;
+  return { ...response, text: "", toolCalls: [recovered], stopReason: "tool_use" };
+}
+```
+
+Three unit tests:
+1. Single-arg leakage (`search { pattern: "typescriptPlugin" }`) → recovered
+2. Multi-arg multi-line leakage (`edit_file` with newline-containing values) → recovered
+3. Regular text that mentions the literal pattern in prose → passes through untouched
+
+The third test is the false-positive guard. Channel-marker presence (`<|"|>`) plus the strict anchor (must end with `<tool_call|>` at end-of-string) makes accidental triggering extremely unlikely.
+
+## Results (n=3, unpinned)
+
+| Cell | aggregate | dbg | edit | nav | plan | refac |
+| --- | --- | --- | --- | --- | --- | --- |
+| fresh (Exp 13) | 85.3% | 100 | 80.0 | 100 | 80.0 | 66.7 |
+| **leakage (this)** | **89.3%** | 100 | 80.0 | 100 | 93.3 | 73.3 |
+
+Per-run: 92, 92, 84. Variance band ±4 pp. The 89.3% mean is at the top of the band but cannot honestly be attributed to the change — **across all 75 task results, zero leakages occurred** in this n=3, so the recovery mechanism had no opportunity to fire. The lift is most plausibly upstream-routing fluctuation (e.g. fewer Novita routes today than on Exp 13).
+
+## Why ship anyway
+
+- **Mechanism verified** via unit tests against real leakage patterns from archived traces.
+- **No regression observed** — aggregate beats prior baselines by 4 pp, within variance band.
+- **Real-world value is the point.** Users hitting bad-routing windows where Novita gets multiple consecutive routes will silently see tool calls disappear; this catches them.
+- **False-positive risk is bounded** by strict anchor + channel-marker requirement + the third unit test.
+
+This is the same shape as the post-edit diagnostic (Exp 10): mechanism works, activation rate on this benchmark is bounded by upstream conditions, the feature ships defensively for real users.
+
+## What this closes in the failure taxonomy
+
+The "Malformed tool-call leakage" category in `project_failure_mode_taxonomy.md` is now **defensively addressed**. We didn't fix the upstream provider parsing, but we recover when it happens. Future occurrences should appear in traces as successful tool calls with id `"leaked-tool-call"` instead of as "model returned no response" failures.
+
+## Reproducibility
+
+```bash
+for r in 1 2 3; do
+  MODEL_PROVIDER=openai-compatible \
+    MODEL=google/gemma-4-26b-a4b-it \
+    OPENAI_BASE_URL=https://openrouter.ai/api/v1 \
+    OPENROUTER_API_KEY=... \
+    npm run benchmark -- --variant leakage-r${r} \
+      --out /tmp/minicode-bench-logs/internal-tasks-postmerge/leakage-r${r}.json
+done
+```
+
+Artifacts: `/tmp/minicode-bench-logs/internal-tasks-postmerge/leakage-r{1,2,3}.{json,log}`.

--- a/packages/agent-sdk/src/model/client.ts
+++ b/packages/agent-sdk/src/model/client.ts
@@ -462,6 +462,69 @@ function parseOpenAICompatibleToolArguments(
   return {};
 }
 
+/**
+ * Some upstream OpenAI-compatible providers (Novita observed most often)
+ * fail to extract tool calls from gemma's internal channel format and
+ * leak the raw markup into the `content` field instead — e.g.
+ *
+ *   <|tool_call>call:search{pattern:<|"|>typescriptPlugin<|"|>}<tool_call|>
+ *
+ * Without recovery, the agent sees zero tool calls and exits the turn,
+ * which surfaces as "model returned no tool calls" failures (~1/run on
+ * calm routing, several/run on bad days). When the structured tool_calls
+ * field is empty but content matches this exact format, we extract the
+ * call and convert it to a synthetic structured tool call.
+ *
+ * Strict, anchored matching — must start with `<|tool_call>` or `call:`
+ * and end with `<tool_call|>`. Channel markers do not appear in normal
+ * model text, so false-positive risk is low. Returns null if the input
+ * does not match.
+ */
+function tryRecoverLeakedToolCall(content: string): ToolCall | null {
+  const trimmed = content.trim();
+  if (trimmed.length === 0) return null;
+
+  const stripped = trimmed.startsWith("<|tool_call>")
+    ? trimmed.slice("<|tool_call>".length)
+    : trimmed;
+
+  const shellMatch = stripped.match(/^call:(\w+)\{([\s\S]*)\}<tool_call\|>\s*$/);
+  if (!shellMatch) return null;
+  const [, name, argsBody] = shellMatch;
+  if (!name || argsBody === undefined) return null;
+
+  const argRegex = /(\w+):<\|"\|>([\s\S]*?)<\|"\|>(?:,|$)/g;
+  const input: Record<string, unknown> = {};
+  let matched = false;
+  let m: RegExpExecArray | null;
+  while ((m = argRegex.exec(argsBody)) !== null) {
+    const key = m[1];
+    const value = m[2];
+    if (key === undefined || value === undefined) continue;
+    input[key] = value;
+    matched = true;
+  }
+  if (!matched) return null;
+
+  return {
+    id: "leaked-tool-call",
+    name,
+    input,
+  };
+}
+
+function applyLeakedToolCallRecovery(response: ModelResponse): ModelResponse {
+  if (response.toolCalls.length > 0) return response;
+  const recovered = tryRecoverLeakedToolCall(response.text);
+  if (!recovered) return response;
+  return {
+    ...response,
+    text: "",
+    toolCalls: [recovered],
+    stopReason: "tool_use",
+  };
+}
+
 function parseOpenAICompatibleResponse(
   response: OpenAICompatibleCompletionResponse,
 ): ModelResponse {
@@ -490,7 +553,7 @@ function parseOpenAICompatibleResponse(
 
   const cachedTokens = response.usage?.prompt_tokens_details?.cached_tokens;
 
-  return {
+  return applyLeakedToolCallRecovery({
     text: (message.content ?? "").trim(),
     toolCalls,
     stopReason,
@@ -501,7 +564,7 @@ function parseOpenAICompatibleResponse(
         ? { cachedInputTokens: cachedTokens }
         : {}),
     },
-  };
+  });
 }
 
 function normalizeBaseUrl(baseUrl: string): string {
@@ -771,7 +834,7 @@ async function parseOpenAIStream(
           ? "tool_use"
           : "end_turn";
 
-  return {
+  return applyLeakedToolCallRecovery({
     text: content.trim(),
     toolCalls,
     stopReason,
@@ -782,7 +845,7 @@ async function parseOpenAIStream(
         ? { cachedInputTokens: usage.cached_tokens }
         : {}),
     },
-  };
+  });
 }
 
 export class OpenAICompatibleModelClient implements ModelClient {

--- a/packages/agent-sdk/tests/model-client-openai.test.ts
+++ b/packages/agent-sdk/tests/model-client-openai.test.ts
@@ -424,3 +424,129 @@ test("createModelClient returns openai-compatible client", () => {
   const client = createModelClient(config);
   assert.ok(client instanceof OpenAICompatibleModelClient);
 });
+
+test("openai-compatible client recovers leaked gemma tool-call markup", async () => {
+  // Some upstream providers (Novita observed most often) fail to extract
+  // gemma's internal channel-format tool calls from the model output and
+  // leak the raw markup into `content` with an empty `tool_calls` array.
+  // The parser should detect this and recover a structured call.
+  const leaked =
+    '<|tool_call>call:search{pattern:<|"|>typescriptPlugin<|"|>}<tool_call|>';
+
+  const fetchImpl: typeof fetch = async () =>
+    new Response(
+      JSON.stringify({
+        choices: [
+          {
+            finish_reason: "stop",
+            message: { content: leaked, tool_calls: [] },
+          },
+        ],
+        usage: { prompt_tokens: 12, completion_tokens: 8 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+
+  const response = await client.chat({
+    model: "google/gemma-4-26b-a4b-it",
+    system: "",
+    messages: [{ role: "user", content: "find typescriptPlugin" }],
+    tools: [],
+    maxTokens: 64,
+  });
+
+  assert.equal(response.stopReason, "tool_use");
+  assert.equal(response.text, "");
+  assert.equal(response.toolCalls.length, 1);
+  assert.equal(response.toolCalls[0]?.name, "search");
+  assert.deepEqual(response.toolCalls[0]?.input, { pattern: "typescriptPlugin" });
+});
+
+test("openai-compatible client recovers multi-arg leaked tool-call markup", async () => {
+  // Multi-arg leakage with multi-line values — the edit_file shape seen in
+  // copilot-desc-r3's editing/add-logging trace.
+  const leaked = [
+    "call:edit_file{new_string:<|\"|>line a\nline b<|\"|>",
+    ",old_string:<|\"|>old line a\nold line b<|\"|>",
+    ",path:<|\"|>src/foo.ts<|\"|>}<tool_call|>",
+  ].join("");
+
+  const fetchImpl: typeof fetch = async () =>
+    new Response(
+      JSON.stringify({
+        choices: [
+          {
+            finish_reason: "stop",
+            message: { content: leaked, tool_calls: [] },
+          },
+        ],
+        usage: { prompt_tokens: 20, completion_tokens: 30 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+
+  const response = await client.chat({
+    model: "google/gemma-4-26b-a4b-it",
+    system: "",
+    messages: [{ role: "user", content: "edit foo.ts" }],
+    tools: [],
+    maxTokens: 64,
+  });
+
+  assert.equal(response.toolCalls.length, 1);
+  assert.equal(response.toolCalls[0]?.name, "edit_file");
+  assert.deepEqual(response.toolCalls[0]?.input, {
+    new_string: "line a\nline b",
+    old_string: "old line a\nold line b",
+    path: "src/foo.ts",
+  });
+});
+
+test("openai-compatible client does not mistake regular text for a leaked tool call", async () => {
+  // Strict anchor check: text that mentions tool-call syntax but isn't
+  // a leak should pass through untouched.
+  const fetchImpl: typeof fetch = async () =>
+    new Response(
+      JSON.stringify({
+        choices: [
+          {
+            finish_reason: "stop",
+            message: {
+              content:
+                'To call the tool, the model would emit something like `call:search{pattern:"x"}`.',
+              tool_calls: [],
+            },
+          },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 5 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+
+  const response = await client.chat({
+    model: "google/gemma-4-26b-a4b-it",
+    system: "",
+    messages: [{ role: "user", content: "explain tool calls" }],
+    tools: [],
+    maxTokens: 64,
+  });
+
+  assert.equal(response.stopReason, "end_turn");
+  assert.equal(response.toolCalls.length, 0);
+  assert.match(response.text, /To call the tool/);
+});


### PR DESCRIPTION
## Summary

Some upstream OpenAI-compatible providers (Novita most often) fail to extract gemma's internal channel-format tool calls and leak the raw markup into the `content` field with empty `tool_calls`. Without recovery, these silently became "model returned no tool calls" failures (~1/run on calm routing, several/run on bad-routing evenings).

Cataloged 17 leakage instances across 9 benchmark archives. All single-call, consistent format. Added a defensive parser that runs at the end of both parse paths (non-streaming + streaming) and converts leakage into a structured tool call.

## Trigger conditions

- Structured `tool_calls` is empty
- Content matches the strict anchored pattern (channel markers `<|tool_call>`, `<|"|>`, `<tool_call|>` plus end-of-string anchor)

Channel markers don't appear in normal model text. The third unit test confirms regular prose mentioning the syntax does not trip the recovery.

## Results (n=3, unpinned)

| Cell | aggregate | dbg | edit | nav | plan | refac |
| --- | --- | --- | --- | --- | --- | --- |
| fresh baseline (Exp 13) | 85.3% | 100 | 80.0 | 100 | 80.0 | 66.7 |
| **leakage (this)** | **89.3%** | 100 | 80.0 | 100 | 93.3 | 73.3 |

Per-run: 92, 92, 84.

**Caveat with teeth**: across all 75 task results this run, **zero leakages occurred** — the routing pool today didn't hit Novita. The recovery mechanism had no runtime activation. The +4 pp lift is within variance band and is not attributable to this change. The change is shipped on:

- Mechanism verified by unit tests against real leakage patterns from archived traces
- Bounded false-positive risk (strict anchor + channel-marker requirement + explicit guard test)
- Real-world value for users hitting bad-routing windows

Same shape as Experiment 10 (post-edit diagnostic): feature ships defensively, benchmark activation will surface in future runs.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean (--max-warnings=0)
- [x] All 147 SDK tests pass (3 new: single-arg recovery, multi-arg multi-line recovery, false-positive guard)
- [x] n=3 unpinned benchmark — artifacts at `/tmp/minicode-bench-logs/internal-tasks-postmerge/leakage-r{1,2,3}.{json,log}`

## What this closes

The "Malformed tool-call leakage" category in our internal failure taxonomy is now defensively addressed. Future occurrences should appear in traces as successful tool calls with id `"leaked-tool-call"` instead of "model returned no response" failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)