### PR TITLE
Disable dynamic prompts by default (real fix) — finish PR #138

### DIFF
--- a/packages/agent-sdk/src/agent/agent.ts
+++ b/packages/agent-sdk/src/agent/agent.ts
@@ -450,7 +450,12 @@ export class CodingAgent {
       // with the latest focus set so the code map dynamically adapts.
       // By default this stays false, so we build once and cache to keep the
       // prompt prefix stable across turns and improve KV cache hit rates.
-      const dynamicPrompt = this.config.enableDynamicPrompt !== false;
+      // NB: explicit `=== true` so that an absent field (undefined) routes
+      // to false, matching the documented default. PR #138 flipped the CLI
+      // loader's parseBoolean fallback to false but missed this line, which
+      // left every SDK consumer that didn't explicitly set the field
+      // running with dynamic prompts on.
+      const dynamicPrompt = this.config.enableDynamicPrompt === true;
       let systemPrompt: string;
       if (dynamicPrompt || !this.cachedSystemPrompt) {
         const codeMap = this.getCodeMap?.(dynamicPrompt ? this.getFocusSet() : undefined);

--- a/packages/agent-sdk/tests/agent.test.ts
+++ b/packages/agent-sdk/tests/agent.test.ts
@@ -517,6 +517,69 @@ test("agent passes cacheableSystem: true by default and accumulates cachedInputT
   assert.equal(result.usage?.inputTokens, 210);
 });
 
+test("agent uses static prompt when enableDynamicPrompt is absent from config", async () => {
+  // Regression test for PR #138's incomplete fix. The CLI's loadAgentConfig
+  // explicitly sets enableDynamicPrompt: false, but external SDK consumers
+  // and the benchmark script were leaving the field undefined. Previously
+  // the agent used `!== false` semantics for the dynamic check, which
+  // routed `undefined` to `true` — so any consumer relying on the
+  // documented default (off) silently got dynamic prompts on.
+  //
+  // After fix: an absent field must route to static prompts (built once,
+  // reused across steps), matching what the CLI/serve callers already do.
+  const buildSystemPromptCalls: number[] = [];
+  let callIndex = 0;
+
+  const stepResponses = [
+    {
+      text: "Step 1",
+      toolCalls: [{ id: "t1", name: "echo_tool", input: { value: "a" } }],
+      stopReason: "tool_use" as const,
+      usage: { inputTokens: 100, outputTokens: 10 },
+    },
+    {
+      text: "Step 2",
+      toolCalls: [{ id: "t2", name: "echo_tool", input: { value: "b" } }],
+      stopReason: "tool_use" as const,
+      usage: { inputTokens: 100, outputTokens: 10 },
+    },
+    {
+      text: "Final",
+      toolCalls: [],
+      stopReason: "end_turn" as const,
+      usage: { inputTokens: 100, outputTokens: 10 },
+    },
+  ];
+
+  const client: ModelClient = {
+    async chat() {
+      const next = stepResponses[callIndex++];
+      if (!next) throw new Error("ran out of queued responses");
+      return next;
+    },
+  };
+
+  // createTestAgentConfig deliberately does NOT set enableDynamicPrompt,
+  // mirroring the benchmark + external-consumer code path.
+  const agent = new CodingAgent({
+    config: createTestAgentConfig("/tmp"),
+    modelClient: client,
+    toolRegistry: new ToolRegistry([createEchoTool()]),
+    buildSystemPrompt: () => {
+      buildSystemPromptCalls.push(callIndex);
+      return "STATIC PROMPT";
+    },
+  });
+
+  await agent.runTurn("Hello");
+
+  assert.equal(
+    buildSystemPromptCalls.length,
+    1,
+    "absent enableDynamicPrompt should default to static — buildSystemPrompt must run exactly once across multiple steps, not on every turn",
+  );
+});
+
 test("agent passes cacheableSystem: false when enableDynamicPrompt is enabled", async () => {
   const cacheableSystemFlags: Array<boolean | undefined> = [];
   const client: ModelClient = {

--- a/scripts/run-benchmarks.ts
+++ b/scripts/run-benchmarks.ts
@@ -180,6 +180,12 @@ export function buildConfig(options: BuildBenchmarkConfigOptions = {}): AgentCon
     maxToolOutputChars: getNumberSetting(getShellOverride("MAX_TOOL_OUTPUT_CHARS"), fileConfig.maxToolOutputChars, 8000),
     openAiBaseUrl,
     ...(openAiApiKey ? { openAiApiKey } : {}),
+    // Explicit match to the loadAgentConfig default so benchmark runs see
+    // the same static-system-prompt behavior that real CLI/serve users
+    // get. Omitting this routes through the SDK fallback in agent.ts and,
+    // depending on its semantics, may flip behavior unintentionally — see
+    // PR #138 follow-up for the original issue.
+    enableDynamicPrompt: false,
   };
 }
 


### PR DESCRIPTION
## Summary

PR #138 documented and renamed the default, but missed the actual SDK fallback in `packages/agent-sdk/src/agent/agent.ts`. The line

```ts
const dynamicPrompt = this.config.enableDynamicPrompt !== false;
```

was unchanged. When the field is `undefined`, `undefined !== false` is `true`, so any consumer that didn't explicitly set the field silently got dynamic prompts ON — contradicting the documented default. This PR finishes #138.

## Impact map (who was affected)

- **CLI / Ink UI / serve**: ✅ correct. `loadAgentConfig` explicitly sets `enableDynamicPrompt: false`. OpenRouter cache hits work, prompt prefix is stable across turns. Confirmed in production.
- **`npm run benchmark`**: ❌ broken. `scripts/run-benchmarks.ts buildConfig` never set the field, so the SDK fallback kicked in. Every benchmark in `RESULTS-GEMMA-4.md` (Experiments 1–14) was measured with dynamic prompts on.
- **External SDK consumers** who construct `AgentConfig` directly without setting `enableDynamicPrompt`: ❌ same as benchmark.

## Smoking-gun evidence

Inside `agent.ts`, the agent already inconsistently treated `undefined`:

- Line 453 (dynamicPrompt flag): `!== false` → `undefined` ⇒ `true` (rebuild every step)
- Line 496 (cacheableSystem hint): `!this.config.enableDynamicPrompt` → `undefined` ⇒ `true` (tell provider to cache)

So with `enableDynamicPrompt: undefined`, the agent was rebuilding the system prompt every step **and** telling the model client it was cacheable. The provider saw different prompts each turn and the cache writes never paid off. This PR aligns both lines on the same answer.

## Changes

- **`packages/agent-sdk/src/agent/agent.ts`**: flip `!== false` to `=== true` so absent field defaults to off.
- **`scripts/run-benchmarks.ts` `buildConfig`**: explicitly set `enableDynamicPrompt: false` (defense in depth; matches what `loadAgentConfig` and `buildBenchmarkAgentConfig` already do).
- **`packages/agent-sdk/tests/agent.test.ts`**: regression test that exercises the SDK fallback specifically. `createTestAgentConfig` deliberately omits the field, so this test would have caught the PR #138 gap.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean (`--max-warnings=0`)
- [x] All 168 SDK + script tests pass; new regression test verifies absent-field → static prompt
- [ ] Re-baseline n=3 benchmark with the fix in (will surface as a separate follow-up — every prior number was measured under the contaminated default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)