### PR TITLE
Verification nudge + head/tail run_command truncation (CCBench failure modes)

### DIFF
--- a/packages/agent-sdk/src/agent/agent.ts
+++ b/packages/agent-sdk/src/agent/agent.ts
@@ -112,7 +112,10 @@ const PROGRESS_THINKING_MAX = 200;
  * Content-aware truncation for tool outputs.
  * Different tools benefit from different truncation strategies:
  * - read_file: No truncation — the model needs exact text for edits
- * - run_command: Keep tail (errors/results are at the end)
+ * - run_command: Keep head + tail (50/50). Errors live at the end of
+ *   normal failures, but pathological cases (infinite loops, runaway
+ *   recursion, excessive logging) reveal themselves at the start. A
+ *   tail-heavy split hides the diagnostic bytes for the runaway case.
  * - search: Keep head with a match count footer
  * - default: Keep head (existing behavior)
  */
@@ -133,12 +136,22 @@ export function truncateToolOutput(
   const totalLen = output.length;
 
   if (toolName === "run_command") {
-    // Keep tail — errors and results are usually at the end
-    const tailChars = Math.floor(maxChars * 0.8);
-    const headChars = maxChars - tailChars;
+    // Balanced head + tail. See doc comment above for the runaway-output
+    // rationale: with a tail-heavy split, an infinite-loop trace gets
+    // truncated such that both the visible head AND tail are inside the
+    // loop pattern, so the model can't see the start that would reveal
+    // the bug. 50/50 surfaces enough of both ends to spot either errors
+    // at the tail OR pathological patterns at the head.
+    const headChars = Math.floor(maxChars / 2);
+    const tailChars = maxChars - headChars;
     const head = output.slice(0, headChars);
     const tail = output.slice(totalLen - tailChars);
-    return `${head}\n\n[... agent-level truncation: ${totalLen - headChars - tailChars} chars omitted from middle of run_command output to keep head + tail.]\n\n${tail}`;
+    const omitted = totalLen - headChars - tailChars;
+    const ratioHint =
+      omitted > 10 * maxChars
+        ? " The omitted region is unusually large — suspect runaway output (infinite loop, recursion, excessive logging) and examine the head, not just the tail."
+        : "";
+    return `${head}\n\n[... agent-level truncation: ${omitted} chars omitted from middle of run_command output to keep head + tail.${ratioHint}]\n\n${tail}`;
   }
 
   if (toolName === "search") {

--- a/packages/agent-sdk/src/prompt/system-prompt.ts
+++ b/packages/agent-sdk/src/prompt/system-prompt.ts
@@ -178,6 +178,8 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
     "- If you cannot complete the task, explain what is blocking you.",
     "- Do not respond with empty text. Always provide a summary or explanation.",
     "- Do not continue exploring once the task is done.",
+    "- If the task involves implementing features against an existing test suite (test files in the workspace, package.json test scripts, Makefile test targets, etc.), run the tests before declaring complete. Treat \"tests passed\" as requiring an explicit success signal — non-error output, placeholder logs, or program output that merely \"looks plausible\" are NOT confirmation of success.",
+    "- When you see an agent-level truncation marker in tool output (e.g. \"... agent-level truncation: N chars omitted ...\"), the elided region may hide failure signals. If the omitted count is large relative to what's shown, suspect a problem in the program (infinite loop, runaway logging) and examine the head of the output, not just the tail.",
     "",
     "[Safety Rules]",
     "- Never modify files outside the workspace directory.",

--- a/packages/agent-sdk/tests/system-prompt.test.ts
+++ b/packages/agent-sdk/tests/system-prompt.test.ts
@@ -67,6 +67,27 @@ test("system prompt includes safety rules", () => {
   assert.ok(prompt.includes("Never modify files outside the workspace"));
 });
 
+test("system prompt nudges test verification before declaring complete", () => {
+  // Mechanism-grounded nudge added after the 2026-05-13 CCBench
+  // investigation showed gemini-3-flash's dominant failure mode was
+  // declaring "I have implemented..." without running tests, OR
+  // running tests but misreading huge/repetitive output as success.
+  const config = createTestAgentConfig("/tmp");
+  const prompt = buildSystemPrompt({ config, tools: [] });
+  assert.ok(
+    /run the tests before declaring complete/i.test(prompt),
+    "should instruct the model to run tests before declaring complete",
+  );
+  assert.ok(
+    /explicit success signal/i.test(prompt),
+    "should warn that non-error output is not the same as test pass",
+  );
+  assert.ok(
+    /agent-level truncation marker/i.test(prompt),
+    "should warn that truncated output may hide failure signals",
+  );
+});
+
 test("system prompt includes specialized tool guidance when present", () => {
   const config = createTestAgentConfig("/tmp");
   const tools = [

--- a/packages/agent-sdk/tests/truncate-tool-output.test.ts
+++ b/packages/agent-sdk/tests/truncate-tool-output.test.ts
@@ -23,14 +23,39 @@ test("truncateToolOutput never truncates read_file even over maxChars", () => {
   assert.equal(out, big);
 });
 
-test("truncateToolOutput run_command keeps tail with self-identifying footer", () => {
+test("truncateToolOutput run_command keeps both head and tail with self-identifying footer", () => {
   const lines = Array.from({ length: 200 }, (_, i) => `line ${i + 1}`).join("\n");
   const out = truncateToolOutput("run_command", lines, 200);
-  // Tail is preserved (errors/results live there).
+  // Tail is preserved (errors/results live there for normal failures).
   assert.match(out, /line 200$/);
+  // Head is ALSO preserved — for runaway outputs (infinite loops etc),
+  // the diagnostic pattern lives at the start. A tail-only split hides
+  // it. See the failure-mode analysis from the 2026-05-13 CCBench
+  // investigation: gemini-3-flash's Lox interpreter wrote an infinite
+  // loop, the program emitted 4.3 MB of integers, and a tail-heavy
+  // truncation showed the model only "more integers" — never the start.
+  assert.match(out, /^line 1\n/);
   // Footer identifies the layer and the tool.
   assert.match(out, /agent-level truncation/);
   assert.match(out, /run_command/);
+});
+
+test("truncateToolOutput run_command flags pathologically large omissions", () => {
+  // Output that's >10× the budget gets an extra hint that runaway
+  // output is a likely cause. The model should be steered to examine
+  // the head, not just trust the tail.
+  const huge = "x".repeat(50_000);
+  const out = truncateToolOutput("run_command", huge, 1000);
+  assert.match(out, /runaway output|infinite loop|recursion|excessive logging/);
+});
+
+test("truncateToolOutput run_command does NOT flag normal-sized omissions", () => {
+  // Output only slightly over the budget gets the plain truncation
+  // footer — no runaway hint, since "small overrun" is the common case
+  // (a normal command with a long-but-bounded output).
+  const modest = "y".repeat(1500);
+  const out = truncateToolOutput("run_command", modest, 1000);
+  assert.doesNotMatch(out, /runaway output/);
 });
 
 test("truncateToolOutput search keeps head with line count and remediation hint", () => {


### PR DESCRIPTION
## Summary

Two small fixes for distinct small-model failure modes surfaced while running gemini-3-flash-preview on CCBench (see [`RESULTS-GEMMA-4.md`](benchmarks/RESULTS-GEMMA-4.md) for the trace-level failure-mode investigation when this is documented).

### Fix 1 — Verification nudge in Termination Policy

**Premature completion** was the dominant failure mode (~13 of 17 graded tasks on the JS/TS + Python subset). Pattern: model writes plausible-looking code, declares "I have implemented the requested features...", stops, and the verifier disagrees because **no tests were ever run**.

Adds two lines to the system prompt's Termination Policy:
1. If the task involves implementing against an existing test suite, run the tests before declaring complete. Treat "tests passed" as requiring an explicit success signal — non-error output or placeholder logs are NOT confirmation.
2. When you see an agent-level truncation marker, the elided region may hide failure signals. Examine the head, not just the tail.

Both are mechanism-grounded against observed failures, not preemptive prompt-copying from competitor harnesses. Scoped to test-driven contexts so it doesn't drag personality toward robot-mode on conversational tasks.

### Fix 2 — Head + tail truncation for `run_command`

`run_command` used an 80% tail / 20% head split. For pathological output (e.g. an infinite loop emitting 4.3 MB of integers, observed in an `interpreter-control-flow-python` trace), the model saw only the tail — which was still mid-loop — and concluded "tests passed." It never saw the start of the output where the bug pattern was visible.

Switch to 50/50 head + tail. Add a runaway-output hint to the truncation footer when the omitted region is unusually large (>10× the budget), prompting the model to suspect infinite loops / runaway logging instead of trusting the tail.

## Test plan

- [x] `packages/agent-sdk/tests/truncate-tool-output.test.ts`: existing tail-keep test extended to assert head presence too; two new tests cover the runaway-output hint firing on large omissions and NOT firing on small overruns.
- [x] `packages/agent-sdk/tests/system-prompt.test.ts`: new test asserts the three pieces of the verification nudge are present.
- [x] Full agent-sdk suite passes (17 tests in the touched files, all green).
- [x] `npm run lint` clean.
- [x] `npm run build` succeeds.
- [ ] CCBench validation re-run after publishing 0.4.2 (pending merge + publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)