### PR TITLE
Surface reasoning tokens + raise maxTokens cap for reasoning runs

### DIFF
--- a/benchmarks/benchmark.config.json
+++ b/benchmarks/benchmark.config.json
@@ -3,7 +3,7 @@
   "model": "google/gemini-3-flash-preview",
   "openAiBaseUrl": "https://openrouter.ai/api/v1",
   "maxSteps": 50,
-  "maxTokens": 4096,
+  "maxTokens": 32000,
   "modelTimeoutSeconds": 120,
   "maxContextTokens": 100000,
   "commandTimeoutMs": 30000,

--- a/benchmarks/harbor/minicode_agent.py
+++ b/benchmarks/harbor/minicode_agent.py
@@ -51,6 +51,7 @@ class MinicodeAgent(BaseInstalledAgent):
         command_timeout_ms: int | None = None,
         model_timeout_seconds: int | None = None,
         max_tool_output_chars: int | None = None,
+        max_tokens: int | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
@@ -70,6 +71,7 @@ class MinicodeAgent(BaseInstalledAgent):
             "COMMAND_TIMEOUT_MS": command_timeout_ms,
             "MODEL_TIMEOUT_SECONDS": model_timeout_seconds,
             "MAX_TOOL_OUTPUT_CHARS": max_tool_output_chars,
+            "MAX_TOKENS": max_tokens,
         }
 
     def version(self) -> str | None:
@@ -254,6 +256,7 @@ class MinicodeAgent(BaseInstalledAgent):
             ("MINICODE_BENCHMARK_COMMAND_TIMEOUT_MS", "COMMAND_TIMEOUT_MS"),
             ("MINICODE_BENCHMARK_MODEL_TIMEOUT_SECONDS", "MODEL_TIMEOUT_SECONDS"),
             ("MINICODE_BENCHMARK_MAX_TOOL_OUTPUT_CHARS", "MAX_TOOL_OUTPUT_CHARS"),
+            ("MINICODE_BENCHMARK_MAX_TOKENS", "MAX_TOKENS"),
             ("MINICODE_BENCHMARK_REASONING_EFFORT", "REASONING_EFFORT"),
             ("MINICODE_BENCHMARK_ENABLE_DYNAMIC_PROMPT", "ENABLE_DYNAMIC_PROMPT"),
             ("MINICODE_BENCHMARK_KEEP_RECENT_MESSAGES", "KEEP_RECENT_MESSAGES"),

--- a/packages/agent-sdk/src/agent/agent.ts
+++ b/packages/agent-sdk/src/agent/agent.ts
@@ -399,6 +399,7 @@ export class CodingAgent {
       inputTokens: number;
       outputTokens: number;
       cachedInputTokens?: number;
+      reasoningTokens?: number;
     };
     streamed?: boolean;
   }> {
@@ -412,6 +413,7 @@ export class CodingAgent {
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
     let totalCachedInputTokens = 0;
+    let totalReasoningTokens = 0;
 
     for (let step = 0; step < this.config.maxSteps; step += 1) {
       ensureStepWithinLimit(step, this.config.maxSteps);
@@ -538,6 +540,7 @@ export class CodingAgent {
       totalInputTokens += response.usage.inputTokens;
       totalOutputTokens += response.usage.outputTokens;
       totalCachedInputTokens += response.usage.cachedInputTokens ?? 0;
+      totalReasoningTokens += response.usage.reasoningTokens ?? 0;
 
       if (this.verbose) {
         this.verboseLog(`\n${VERBOSE_SEP}`);
@@ -577,6 +580,9 @@ export class CodingAgent {
             ...(totalCachedInputTokens > 0
               ? { cachedInputTokens: totalCachedInputTokens }
               : {}),
+            ...(totalReasoningTokens > 0
+              ? { reasoningTokens: totalReasoningTokens }
+              : {}),
           },
           streamed,
         };
@@ -600,6 +606,9 @@ export class CodingAgent {
             outputTokens: totalOutputTokens,
             ...(totalCachedInputTokens > 0
               ? { cachedInputTokens: totalCachedInputTokens }
+              : {}),
+            ...(totalReasoningTokens > 0
+              ? { reasoningTokens: totalReasoningTokens }
               : {}),
           },
           streamed,
@@ -670,6 +679,9 @@ export class CodingAgent {
             outputTokens: totalOutputTokens,
             ...(totalCachedInputTokens > 0
               ? { cachedInputTokens: totalCachedInputTokens }
+              : {}),
+            ...(totalReasoningTokens > 0
+              ? { reasoningTokens: totalReasoningTokens }
               : {}),
           },
             streamed: false,
@@ -771,6 +783,9 @@ export class CodingAgent {
             outputTokens: totalOutputTokens,
             ...(totalCachedInputTokens > 0
               ? { cachedInputTokens: totalCachedInputTokens }
+              : {}),
+            ...(totalReasoningTokens > 0
+              ? { reasoningTokens: totalReasoningTokens }
               : {}),
           },
       streamed: false,

--- a/packages/agent-sdk/src/agent/types.ts
+++ b/packages/agent-sdk/src/agent/types.ts
@@ -123,6 +123,14 @@ export interface ModelResponse {
      * provider-specific shape.
      */
     cachedInputTokens?: number;
+    /**
+     * Reasoning ("thinking") tokens reported by reasoning-capable models.
+     * For OpenAI-compatible providers these are nested under
+     * `completion_tokens_details.reasoning_tokens` and ARE included in
+     * the total `completion_tokens`, so they count against `max_tokens`.
+     * Surfaced here so traces can show whether reasoning is firing.
+     */
+    reasoningTokens?: number;
   };
 }
 

--- a/packages/agent-sdk/src/model/client.ts
+++ b/packages/agent-sdk/src/model/client.ts
@@ -333,6 +333,15 @@ interface OpenAICompatibleCompletionResponse {
     prompt_tokens_details?: {
       cached_tokens?: number;
     };
+    /**
+     * Reasoning-token stats from reasoning-capable models (OpenAI o-series,
+     * Gemini via OpenRouter, etc.). Reasoning tokens are included in
+     * `completion_tokens` and count against `max_tokens`, so surfacing
+     * them helps explain why max_tokens budgets get tight on hard tasks.
+     */
+    completion_tokens_details?: {
+      reasoning_tokens?: number;
+    };
   };
 }
 
@@ -552,6 +561,8 @@ function parseOpenAICompatibleResponse(
           : "end_turn";
 
   const cachedTokens = response.usage?.prompt_tokens_details?.cached_tokens;
+  const reasoningTokens =
+    response.usage?.completion_tokens_details?.reasoning_tokens;
 
   return applyLeakedToolCallRecovery({
     text: (message.content ?? "").trim(),
@@ -562,6 +573,9 @@ function parseOpenAICompatibleResponse(
       outputTokens: response.usage?.completion_tokens ?? 0,
       ...(cachedTokens !== undefined && cachedTokens > 0
         ? { cachedInputTokens: cachedTokens }
+        : {}),
+      ...(reasoningTokens !== undefined && reasoningTokens > 0
+        ? { reasoningTokens }
         : {}),
     },
   });
@@ -746,6 +760,9 @@ interface OpenAIStreamChunk {
     prompt_tokens_details?: {
       cached_tokens?: number;
     };
+    completion_tokens_details?: {
+      reasoning_tokens?: number;
+    };
   };
 }
 
@@ -757,7 +774,12 @@ async function parseOpenAIStream(
   let buffer = "";
   let content = "";
   const toolCallsAcc: Array<{ id: string; name: string; arguments: string }> = [];
-  const usage = { prompt_tokens: 0, completion_tokens: 0, cached_tokens: 0 };
+  const usage = {
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    cached_tokens: 0,
+    reasoning_tokens: 0,
+  };
   let finishReason: string | null = null;
 
   const processLines = (lines: string[]) => {
@@ -796,6 +818,8 @@ async function parseOpenAIStream(
           usage.completion_tokens = chunk.usage.completion_tokens ?? 0;
           usage.cached_tokens =
             chunk.usage.prompt_tokens_details?.cached_tokens ?? 0;
+          usage.reasoning_tokens =
+            chunk.usage.completion_tokens_details?.reasoning_tokens ?? 0;
         }
       } catch {
         // skip malformed chunks
@@ -843,6 +867,9 @@ async function parseOpenAIStream(
       outputTokens: usage.completion_tokens,
       ...(usage.cached_tokens > 0
         ? { cachedInputTokens: usage.cached_tokens }
+        : {}),
+      ...(usage.reasoning_tokens > 0
+        ? { reasoningTokens: usage.reasoning_tokens }
         : {}),
     },
   });

--- a/packages/agent-sdk/tests/model-client-openai.test.ts
+++ b/packages/agent-sdk/tests/model-client-openai.test.ts
@@ -414,6 +414,71 @@ test("openai-compatible client omits cachedInputTokens when zero or absent", asy
   );
 });
 
+test("openai-compatible client surfaces reasoning_tokens via completion_tokens_details", async () => {
+  // Reasoning-capable models (Gemini-3, OpenAI o-series) report their
+  // thinking budget under completion_tokens_details.reasoning_tokens.
+  // These count against max_tokens, so callers need visibility into
+  // them when tuning the budget — without this signal, a model that
+  // burns its cap on reasoning looks indistinguishable from one that
+  // never reasoned at all.
+  const fetchImpl: typeof fetch = async () =>
+    new Response(
+      JSON.stringify({
+        choices: [{ finish_reason: "stop", message: { content: "hi" } }],
+        usage: {
+          prompt_tokens: 40,
+          completion_tokens: 535,
+          completion_tokens_details: { reasoning_tokens: 339 },
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+  const response = await client.chat({
+    model: "test-model",
+    system: "Test",
+    messages: [{ role: "user", content: "Hi" }],
+    tools: [],
+    maxTokens: 64,
+  });
+
+  assert.equal(response.usage.outputTokens, 535);
+  assert.equal(response.usage.reasoningTokens, 339);
+});
+
+test("openai-compatible client omits reasoningTokens when zero or absent", async () => {
+  const fetchImpl: typeof fetch = async () =>
+    new Response(
+      JSON.stringify({
+        choices: [{ finish_reason: "stop", message: { content: "hi" } }],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+  const response = await client.chat({
+    model: "test-model",
+    system: "Test",
+    messages: [{ role: "user", content: "Hi" }],
+    tools: [],
+    maxTokens: 64,
+  });
+
+  assert.equal(
+    response.usage.reasoningTokens,
+    undefined,
+    "absent reasoning_tokens should not surface as 0 or noise",
+  );
+});
+
 test("createModelClient returns openai-compatible client", () => {
   const config = {
     ...createTestAgentConfig("/tmp"),

--- a/src/cli/benchmark-run.ts
+++ b/src/cli/benchmark-run.ts
@@ -41,6 +41,8 @@ export interface BenchmarkRunResult {
   usage: {
     inputTokens: number;
     outputTokens: number;
+    cachedInputTokens?: number;
+    reasoningTokens?: number;
   } | null;
   durationMs: number;
   startedAt: string;
@@ -132,6 +134,8 @@ interface BenchmarkAttemptResult {
   usage?: {
     inputTokens: number;
     outputTokens: number;
+    cachedInputTokens?: number;
+    reasoningTokens?: number;
   };
   streamed?: boolean;
   messages: SessionMessage[];


### PR DESCRIPTION
## Summary

- Parse `completion_tokens_details.reasoning_tokens` in the OpenAI-compatible model client (non-streaming + streaming paths) and plumb the field through `ModelResponse.usage` → agent loop accumulator → `BenchmarkRunResult.usage`. Reasoning-capable providers (OpenRouter forwarding to Gemini-3, OpenAI o-series) were already producing these tokens, but they were invisible end-to-end.
- Raise `benchmarks/benchmark.config.json maxTokens` from 4096 → 32000 and add `MAX_TOKENS` passthrough in the Harbor adapter (`max_tokens` agent-kwarg + `MINICODE_BENCHMARK_MAX_TOKENS` env). Reasoning tokens count against `max_tokens`, so the 4k cap was being consumed entirely by reasoning on harder CCBench tasks, leaving zero room for visible content.

## Why

Audit on a CCBench JS/TS run with `reasoning_effort=high`:

- 3/9 tasks failed with `outputTokens` pinned at the cap and empty visible responses — reasoning was eating the entire budget
- Curl diagnostic against OpenRouter confirmed the upstream returns `reasoning` + `reasoning_details` + `completion_tokens_details.reasoning_tokens` as sibling fields; our parser silently dropped them

After the bump to 32k + parser fix, the same JS/TS subset showed `reasoningTokens` ranging 1.6k–82k per task in result.json, and the empty-response cluster shrank from 3/9 → 1/9. Pass rate held at 2/9 = 22.2% — the remaining failures are model-discipline issues (premature completion, low test-invocation count) rather than budget squeezes, which is the next experiment.

## Test plan

- [x] `npm test` in `packages/agent-sdk` (154/154 pass) — includes 2 new tests covering reasoning_tokens parse + omit-when-absent
- [x] `npm run lint` (root) — clean
- [x] `npm run build` (root + workspaces) — clean
- [x] Validated via CCBench JS/TS run with local-tarball install: reasoningTokens now visible in `minicode-result.json`, empty-response failure cluster reduced