### PR TITLE
Iteration discipline + maxTokens default: align prompts with task shape

### DIFF
--- a/packages/agent-sdk/src/prompt/system-prompt.ts
+++ b/packages/agent-sdk/src/prompt/system-prompt.ts
@@ -170,7 +170,7 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
     "- Stop investigating as soon as you have enough to answer or act. Do not be exhaustive.",
     "- If you have made 3 or more similar read/search calls without making forward progress, STOP and either commit to the best answer you can support with what you have, or acknowledge what you cannot determine.",
     "- Do not repeat a tool call with identical or near-identical arguments. If the result was useful, move on. If it was not, change your approach (different pattern, different path, different tool) rather than retrying.",
-    "- Target: gather context in 3–5 read/search calls, then answer or edit.",
+    "- Match investigation depth to task type. Exploratory questions (\"what does X do?\", \"where is Y used?\") usually need only a few reads before you can answer. Tasks with an existing test suite (bug fixes, feature implementation, refactors) typically need iterate-test-fix cycles — keep iterating until tests pass or you can articulate a concrete blocker. Do not bail early on iterative tasks simply because you have made a few reads.",
     "",
     "[Termination Policy]",
     "- When the user asks you to do something (edit code, search, run commands, etc.), you MUST use the appropriate tools first. Do not conclude until you have actually performed the work.",

--- a/packages/agent-sdk/tests/system-prompt.test.ts
+++ b/packages/agent-sdk/tests/system-prompt.test.ts
@@ -67,6 +67,32 @@ test("system prompt includes safety rules", () => {
   assert.ok(prompt.includes("Never modify files outside the workspace"));
 });
 
+test("iteration discipline matches investigation depth to task type", () => {
+  // Reframed after CCBench showed the prior "Target: gather context in
+  // 3-5 read/search calls, then answer or edit" target was driving
+  // premature completion on tasks that genuinely require iterate-test-fix
+  // cycles. The anti-looping rules above are kept — those are universal
+  // good advice — but the hard call-count target was harmful for any
+  // task that involves a test suite.
+  const config = createTestAgentConfig("/tmp");
+  const prompt = buildSystemPrompt({ config, tools: [] });
+  assert.match(
+    prompt,
+    /Match investigation depth to task type/,
+    "should frame iteration depth by task type instead of a fixed call-count target",
+  );
+  assert.match(
+    prompt,
+    /iterate-test-fix cycles/,
+    "should set the expectation that iterative tasks involve multiple test runs",
+  );
+  assert.doesNotMatch(
+    prompt,
+    /Target:?\s*gather context in 3.5/i,
+    "the harmful '3-5 calls then answer' target should be removed",
+  );
+});
+
 test("system prompt nudges test verification before declaring complete", () => {
   // Mechanism-grounded nudge added after the 2026-05-13 CCBench
   // investigation showed gemini-3-flash's dominant failure mode was

--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -347,7 +347,7 @@ export async function loadAgentConfig(
     ),
     maxTokens: parseNumber(
       env.MAX_TOKENS,
-      4096,
+      16000,
     ),
     modelTimeoutSeconds: parseNumber(
       env.MODEL_TIMEOUT_SECONDS,

--- a/src/benchmark/config.ts
+++ b/src/benchmark/config.ts
@@ -246,7 +246,7 @@ export async function buildBenchmarkAgentConfig(
     ),
     maxTokens: parseNumber(
       resolvedEnv.values.MAX_TOKENS ?? fileConfig.maxTokens,
-      4096,
+      16000,
     ),
     modelTimeoutSeconds: parseNumber(
       resolvedEnv.values.MODEL_TIMEOUT_SECONDS ?? fileConfig.modelTimeoutSeconds,

--- a/src/cli/benchmark-run.ts
+++ b/src/cli/benchmark-run.ts
@@ -87,12 +87,17 @@ export interface BenchmarkToolUsageSummary {
 }
 
 const BENCHMARK_SYSTEM_PROMPT_SUFFIX = [
-  "[Benchmark Execution Mode]",
-  "- This task is running in a non-interactive benchmark harness.",
-  "- The task is already approved. Do not ask for confirmation, permission, or whether you should proceed.",
+  "[Execution Mode]",
+  "- This task is running in a non-interactive harness. The task is already approved.",
+  "- Do not ask for confirmation, permission, or whether you should proceed.",
   "- If the task requires code changes, make them immediately using the available tools.",
   "- Do not stop after presenting a plan. Either complete the task or explain a concrete blocker.",
-  "- When validation is part of the task, run the required command once after making changes.",
+  "",
+  "[Long-form Task Discipline]",
+  "- Non-trivial coding tasks routinely require 30+ tool-call iterate-test-fix cycles. Persistent iteration against the test suite is expected; do not bail early because you have read a few files.",
+  "- Iterate against the canonical test runner (the test command shipped with the task) until it passes. Treat the runner's output as the source of truth — not your own assessment of whether the code looks correct, and not ad-hoc verification scripts you write yourself.",
+  "- Before declaring the task complete: run the FULL existing test suite, not just tests targeting the new feature. Many tasks modify code that other features depend on — verify you did not break previously-passing functionality. Regression failures on stages you were not asked to modify still count as failures.",
+  "- \"I have implemented X\" is not the same as \"tests pass.\" Do not declare completion without observing an explicit green signal (exit code 0, all-pass marker) from the canonical test runner over the full suite.",
 ].join("\n");
 
 const BENCHMARK_RETRY_REMINDER = [

--- a/tests/benchmark-run.test.ts
+++ b/tests/benchmark-run.test.ts
@@ -13,9 +13,39 @@ import type { SessionMessage } from "@sean.holung/minicode-sdk";
 test("benchmark system prompt suffix clearly disables approval-seeking behavior", () => {
   const suffix = getBenchmarkSystemPromptSuffix();
 
-  assert.match(suffix, /non-interactive benchmark harness/i);
+  assert.match(suffix, /non-interactive harness/i);
   assert.match(suffix, /already approved/i);
   assert.match(suffix, /do not ask for confirmation/i);
+});
+
+test("benchmark system prompt suffix overrides iteration discipline for long-form tasks", () => {
+  // Added after observing on CCBench that the base [Iteration Discipline]
+  // "3-5 calls then commit" guidance was driving premature completion on
+  // benchmark tasks that genuinely require 30+ iterate-test-fix cycles.
+  // Both gemini-3-flash and haiku-4.5 declared "I have implemented" before
+  // verifying their changes against the canonical test suite.
+  const suffix = getBenchmarkSystemPromptSuffix();
+
+  assert.match(
+    suffix,
+    /persistent iteration|30\+ tool-call/i,
+    "should set the expectation that persistent iteration is normal",
+  );
+  assert.match(
+    suffix,
+    /canonical test runner/i,
+    "should direct the model to the canonical test runner, not ad-hoc tests",
+  );
+  assert.match(
+    suffix,
+    /full existing test suite/i,
+    "should require running the full suite to catch regressions",
+  );
+  assert.match(
+    suffix,
+    /explicit green signal/i,
+    "should require an observed pass signal, not self-assessed completion",
+  );
 });
 
 test("benchmark system prompt suffix omits runtime budget knobs", () => {


### PR DESCRIPTION
## Summary

Two coupled fixes identified during CCBench investigation on gemini-3-flash and claude-haiku-4.5:

1. **Reframed `[Iteration Discipline]`** in the base system prompt — removed the hard target *"gather context in 3–5 read/search calls, then answer or edit."* That guidance is right for exploratory questions but drives premature completion on tasks that require iterate-test-fix cycles. Replaced with task-shape-aware framing (exploratory vs. test-suite-driven). Anti-looping rules retained.

2. **Added `[Long-form Task Discipline]`** to the benchmark prompt suffix — specifies canonical test runner as source of truth, requires running the FULL existing test suite (not just new-feature tests), and frames "I have implemented X" as not the same as "tests pass."

3. **Bumped SDK `maxTokens` default from 4096 → 16000.** The old default truncated tool-call JSON mid-arguments for `write_file` with substantial content; diagnosed cleanly on a haiku-4.5 single-task test where the cap was producing empty `{}` tool arguments and triggering the loop guard.

## Why

CCBench A/B (single-variable comparison, `gemini-3-flash + reasoning_effort=high + maxTokens=32k`, same 9-task JS/TS subset):

| Run | Prompt | Pass rate |
|---|---|---|
| Prior baseline | Old | 2/9 = 22.2% |
| **This change** | New | **4/9 = 44.4%** (+22pp, doubled) |

Cross-model confirmation (`claude-haiku-4.5` via OpenRouter, same JS/TS subset): 3/9 = 33.3%.

Python directional signal: ~0/N with old prompt (per prior trace investigation) → 2/10 = 20% with new prompt. Confounded across several variables (prompt, budget, reasoning, default bump) but the direction is consistent. Lower Python ceiling likely reflects the thinner Python plugin index, not prompt design.

## Test plan

- [x] `npm test` in `packages/agent-sdk` — 154/154 pass (includes new `iteration discipline matches investigation depth to task type` test)
- [x] `npm test` (root) — 734/736 pass; 2 pre-existing failures are env-leak from real `OPENAI_API_KEY` in shell and unrelated to this change
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Validated via three independent CCBench runs (single-variable A/B + cross-model + Python directional)

## Follow-ups (separate work)

- Python plugin index richness audit — lower Python ceiling (20% vs 44% JS/TS) suggests symbol-graph tools provide less value when fewer symbols/edges are extracted
- `maxSteps=300` experiment — three failing tasks hit the 150-step cap mid-iteration on the haiku run
- Concrete test-output verification language (have the model paste literal final test runner output before declaring complete)