### PR TITLE
Soft loop guard: skip + nudge instead of terminate-on-fire

### DIFF
--- a/packages/agent-sdk/src/agent/agent.ts
+++ b/packages/agent-sdk/src/agent/agent.ts
@@ -94,6 +94,34 @@ function clearStateSensitiveFingerprints(fingerprints: string[]): void {
   }
 }
 
+function clearFingerprint(fingerprints: string[], target: string): void {
+  for (let index = fingerprints.length - 1; index >= 0; index -= 1) {
+    if (fingerprints[index] === target) {
+      fingerprints.splice(index, 1);
+    }
+  }
+}
+
+/**
+ * Maximum number of loop-guard fires per turn before the agent hard-stops.
+ * A single fire surfaces a nudge to the model and continues — the model
+ * usually adjusts. Three fires across one turn signal the model isn't
+ * finding a productive path, so the safety valve kicks in.
+ */
+const MAX_LOOP_GUARD_FIRES_PER_TURN = 3;
+
+const LOOP_GUARD_HARD_STOP_MESSAGE =
+  "Stopped due to repeated identical tool calls. The model triggered the loop guard 3 times in this turn without finding a productive path forward.";
+
+function loopGuardNudge(repeatedCalls: number, fireNumber: number): string {
+  return (
+    `[loop guard: suppressed an identical call after ${repeatedCalls} repeats in a small window. ` +
+    `Try a different approach — read a different file or region, search for a more specific pattern, ` +
+    `run a command to inspect state, or use find_references / get_dependencies / read_symbol to navigate by structure. ` +
+    `This is loop-guard fire ${fireNumber}/${MAX_LOOP_GUARD_FIRES_PER_TURN} for this turn; after the ${MAX_LOOP_GUARD_FIRES_PER_TURN}th the turn will hard-stop.]`
+  );
+}
+
 /**
  * Extract the symbol name from a tool call input if the tool is symbol-aware.
  */
@@ -414,6 +442,7 @@ export class CodingAgent {
     let totalOutputTokens = 0;
     let totalCachedInputTokens = 0;
     let totalReasoningTokens = 0;
+    let loopGuardFires = 0;
 
     for (let step = 0; step < this.config.maxSteps; step += 1) {
       ensureStepWithinLimit(step, this.config.maxSteps);
@@ -658,34 +687,57 @@ export class CodingAgent {
           (value) => value === fingerprint,
         ).length;
         if (repeatedCalls >= getRepeatThreshold(toolCall.name)) {
-          const loopMessage =
-            "Stopped due to repeated identical tool calls. Please refine the prompt or provide additional constraints.";
-          for (const skippedToolCall of response.toolCalls.slice(toolCallIndex)) {
+          loopGuardFires += 1;
+          if (loopGuardFires >= MAX_LOOP_GUARD_FIRES_PER_TURN) {
+            // Safety valve: the model has triggered the guard three times
+            // in this turn without redirecting. Skip the offending call,
+            // hard-terminate the turn, and surface the stop reason.
             this.session.addMessage({
               role: "tool",
-              toolCallId: skippedToolCall.id,
-              toolName: skippedToolCall.name,
-              content: `Tool skipped: ${loopMessage}`,
+              toolCallId: toolCall.id,
+              toolName: toolCall.name,
+              content: `Tool skipped: ${LOOP_GUARD_HARD_STOP_MESSAGE}`,
             });
+            for (const skippedToolCall of response.toolCalls.slice(toolCallIndex + 1)) {
+              this.session.addMessage({
+                role: "tool",
+                toolCallId: skippedToolCall.id,
+                toolName: skippedToolCall.name,
+                content: `Tool skipped: ${LOOP_GUARD_HARD_STOP_MESSAGE}`,
+              });
+            }
+            this.session.addMessage({
+              role: "assistant",
+              content: LOOP_GUARD_HARD_STOP_MESSAGE,
+            });
+            return {
+              text: LOOP_GUARD_HARD_STOP_MESSAGE,
+              usage: {
+                inputTokens: totalInputTokens,
+                outputTokens: totalOutputTokens,
+                ...(totalCachedInputTokens > 0
+                  ? { cachedInputTokens: totalCachedInputTokens }
+                  : {}),
+                ...(totalReasoningTokens > 0
+                  ? { reasoningTokens: totalReasoningTokens }
+                  : {}),
+              },
+              streamed: false,
+            };
           }
+
+          // Soft path: skip this single call, inject an actionable nudge
+          // as its tool result, clear this fingerprint from the window
+          // (so the next unrelated call doesn't re-trip), and continue
+          // processing remaining calls in the batch.
           this.session.addMessage({
-            role: "assistant",
-            content: loopMessage,
+            role: "tool",
+            toolCallId: toolCall.id,
+            toolName: toolCall.name,
+            content: loopGuardNudge(repeatedCalls, loopGuardFires),
           });
-          return {
-            text: loopMessage,
-            usage: {
-            inputTokens: totalInputTokens,
-            outputTokens: totalOutputTokens,
-            ...(totalCachedInputTokens > 0
-              ? { cachedInputTokens: totalCachedInputTokens }
-              : {}),
-            ...(totalReasoningTokens > 0
-              ? { reasoningTokens: totalReasoningTokens }
-              : {}),
-          },
-            streamed: false,
-          };
+          clearFingerprint(recentToolCallFingerprints, fingerprint);
+          continue;
         }
 
         // Track symbol focus from symbol-aware tool calls

--- a/packages/agent-sdk/tests/agent.test.ts
+++ b/packages/agent-sdk/tests/agent.test.ts
@@ -112,11 +112,75 @@ test("agent stops on repeated identical tool calls", async () => {
   assert.match(text, /repeated identical tool calls/);
 });
 
+test("soft loop guard lets the model recover after a single nudge", async () => {
+  // Three identical echo calls trip the guard once (skip + nudge + reset
+  // the offending fingerprint), the model redirects on the next turn,
+  // and the turn completes normally. Regression check against the prior
+  // terminate-on-first-fire behavior, which would have hard-stopped the
+  // turn before the redirect message could land.
+  const responses: ModelResponse[] = [
+    {
+      text: "first call",
+      toolCalls: [{ id: "echo-1", name: "echo_tool", input: { value: "same" } }],
+      stopReason: "tool_use",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    },
+    {
+      text: "second call",
+      toolCalls: [{ id: "echo-2", name: "echo_tool", input: { value: "same" } }],
+      stopReason: "tool_use",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    },
+    {
+      text: "third call (will be nudged)",
+      toolCalls: [{ id: "echo-3", name: "echo_tool", input: { value: "same" } }],
+      stopReason: "tool_use",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    },
+    {
+      text: "redirect after nudge",
+      toolCalls: [{ id: "echo-4", name: "echo_tool", input: { value: "different" } }],
+      stopReason: "tool_use",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    },
+    {
+      text: "Done.",
+      toolCalls: [],
+      stopReason: "end_turn",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    },
+  ];
+
+  const agent = new CodingAgent({
+    config: createTestAgentConfig("/tmp"),
+    modelClient: new SequenceModelClient(responses),
+    toolRegistry: new ToolRegistry([createEchoTool()]),
+  });
+
+  const { text } = await agent.runTurn("Do something");
+  assert.equal(text, "Done.");
+
+  const toolMessages = agent
+    .getSession()
+    .getMessages()
+    .filter((m) => m.role === "tool");
+  const nudges = toolMessages.filter(
+    (m) => typeof m.content === "string" && m.content.includes("loop guard"),
+  );
+  assert.equal(nudges.length, 1, "exactly one loop-guard nudge should fire");
+  assert.equal(
+    toolMessages.length,
+    4,
+    "the 3rd echo should be suppressed (nudge) and the 4th should execute normally",
+  );
+});
+
 test("agent tolerates 3 identical search calls before tripping loop guard", async () => {
   // search has a relaxed threshold of 4 (vs 3 for other tools) — regex
   // exploration legitimately emits pattern variants and may revisit one
-  // before converging. Verify the agent gets to the 4th repeat before
-  // tripping, and that the underlying tool actually executed 3 times.
+  // before converging. Verify the agent executes the underlying tool 3
+  // times before the 4th repeat triggers the soft guard (skip + nudge),
+  // and that the nudge surfaces as the suppressed call's tool result.
   let searchCallCount = 0;
   const searchTool: ToolDefinition = {
     name: "search",
@@ -155,12 +219,25 @@ test("agent tolerates 3 identical search calls before tripping loop guard", asyn
     toolRegistry: new ToolRegistry([searchTool]),
   });
 
-  const { text } = await agent.runTurn("Do something");
-  assert.match(text, /repeated identical tool calls/);
+  await agent.runTurn("Do something");
+  // Find the first loop-guard nudge in the transcript and count search
+  // executions that happened before it. Threshold = 4 means the search
+  // tool should have run 3 times before the 4th repeat was suppressed.
+  // If search had used the default threshold of 3, we would see only 2
+  // executions before the first nudge.
+  const messages = agent.getSession().getMessages();
+  const firstNudgeIndex = messages.findIndex(
+    (m) => m.role === "tool" && typeof m.content === "string" && m.content.includes("loop guard"),
+  );
+  assert.ok(firstNudgeIndex >= 0, "soft loop guard should inject at least one nudge tool result");
+  const executionsBeforeFirstNudge = messages
+    .slice(0, firstNudgeIndex)
+    .filter((m) => m.role === "tool" && typeof m.content === "string" && m.content.includes("no matches"))
+    .length;
   assert.equal(
-    searchCallCount,
+    executionsBeforeFirstNudge,
     3,
-    "search should execute 3 times before the 4th repeat trips the guard",
+    "search threshold = 4 should let the tool run 3 times before the 4th repeat trips the guard",
   );
 });
 

--- a/packages/agent-sdk/tests/agent.test.ts
+++ b/packages/agent-sdk/tests/agent.test.ts
@@ -181,7 +181,6 @@ test("agent tolerates 3 identical search calls before tripping loop guard", asyn
   // before converging. Verify the agent executes the underlying tool 3
   // times before the 4th repeat triggers the soft guard (skip + nudge),
   // and that the nudge surfaces as the suppressed call's tool result.
-  let searchCallCount = 0;
   const searchTool: ToolDefinition = {
     name: "search",
     description: "Search the workspace",
@@ -190,10 +189,7 @@ test("agent tolerates 3 identical search calls before tripping loop guard", asyn
       properties: { pattern: { type: "string" } },
       required: ["pattern"],
     },
-    execute: async () => {
-      searchCallCount += 1;
-      return "no matches";
-    },
+    execute: async () => "no matches",
   };
 
   class RepeatingSearchClient implements ModelClient {

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -246,30 +246,26 @@ test("agent does not treat repeated validation commands after edits as a loop", 
 });
 
 test("agent still stops on repeated identical mutations", async () => {
-  const responses: ModelResponse[] = [
-    {
-      text: "first edit",
-      toolCalls: [{ id: "edit-1", name: "edit_file", input: { path: "app.ts", content: "same" } }],
-      stopReason: "tool_use",
-      usage: { inputTokens: 1, outputTokens: 1 },
-    },
-    {
-      text: "second edit",
-      toolCalls: [{ id: "edit-2", name: "edit_file", input: { path: "app.ts", content: "same" } }],
-      stopReason: "tool_use",
-      usage: { inputTokens: 1, outputTokens: 1 },
-    },
-    {
-      text: "third edit",
-      toolCalls: [{ id: "edit-3", name: "edit_file", input: { path: "app.ts", content: "same" } }],
-      stopReason: "tool_use",
-      usage: { inputTokens: 1, outputTokens: 1 },
-    },
-  ];
+  // A model that keeps emitting the same edit_file forever should be
+  // hard-stopped after the soft guard has fired 3 times in the turn.
+  class RepeatingEditClient implements ModelClient {
+    private idx = 0;
+    async chat(): Promise<ModelResponse> {
+      this.idx += 1;
+      return {
+        text: "edit",
+        toolCalls: [
+          { id: `edit-${this.idx}`, name: "edit_file", input: { path: "app.ts", content: "same" } },
+        ],
+        stopReason: "tool_use",
+        usage: { inputTokens: 1, outputTokens: 1 },
+      };
+    }
+  }
 
   const agent = new CodingAgent({
     config: createTestAgentConfig("/tmp"),
-    modelClient: new SequenceModelClient(responses),
+    modelClient: new RepeatingEditClient(),
     toolRegistry: new ToolRegistry([createEditTool()]),
   });
 


### PR DESCRIPTION
## Summary
- Loop guard no longer terminates the turn on the first fire. It skips the offending call, injects an actionable nudge as the tool result, clears that fingerprint from the rolling window, and lets the turn continue.
- After 3 loop-guard fires in one turn, the hard-stop path still triggers so a runaway model still terminates.
- The previous behavior killed CCBench tasks during their orientation phase — 3 of 8 Python failures in the recent discrimination-zone run died this way (including the only task that had successfully invoked `read_symbol`). The model would cross-reference a file it just read, hit the guard on the 3rd read, and be sent home with "I give up."

## Test plan
- [x] `packages/agent-sdk/tests/agent.test.ts` — new "soft loop guard lets the model recover after a single nudge" test asserts the model continues past a single fire and completes normally
- [x] Existing "agent stops on repeated identical tool calls" test still passes (with the soft path, RepeatingModelClient now hits the hard-stop at fire #3 instead of fire #1)
- [x] "agent still stops on repeated identical mutations" rewritten to use a repeating client; verifies the hard-stop still fires on mutations
- [x] "agent tolerates 3 identical search calls before tripping loop guard" updated to verify the first nudge appears after 3 underlying executions (search threshold = 4)
- [x] Full test suite: 735/737 pass (2 pre-existing failures from real `OPENAI_API_KEY` in shell env leaking into `tests/config-integration.test.ts`)

Next: rerun the Python CCBench subset as a single-variable A/B against the prior 20% baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)