### PR TITLE
ContextBench driver: name trajectory file by instance_id

### DIFF
--- a/benchmarks/contextbench/README.md
+++ b/benchmarks/contextbench/README.md
@@ -36,14 +36,16 @@ tasks by reusing the SWE-bench Docker images each task ships with.
      --limit 3
    ```
 
-3. Score the trajectories with ContextBench's evaluator:
+3. Score the trajectories with ContextBench's evaluator. The evaluator
+   extracts `instance_id` from the trajectory filename (`<id>.traj.json`),
+   so make sure the file is named with the full instance id:
 
    ```bash
-   for traj in /tmp/minicode-contextbench-smoke/*/trajectory.traj.json; do
+   for traj in /tmp/minicode-contextbench-smoke/*/*.traj.json; do
      PYTHONPATH=/tmp/ContextBench python3 -m contextbench.evaluate \
        --gold /tmp/ContextBench/data/contextbench_verified.parquet \
        --pred "$traj" \
-       --out "${traj%/trajectory.traj.json}/score.jsonl"
+       --out "$(dirname "$traj")/score.jsonl"
    done
    ```
 

--- a/benchmarks/contextbench/run_minicode.py
+++ b/benchmarks/contextbench/run_minicode.py
@@ -176,15 +176,16 @@ minicode benchmark run \\
   --model "{args.model}" \\
   --out /out/result.json \\
   --diff-out /out/minicode.patch \\
-  --contextbench-trajectory /out/trajectory.traj.json \\
+  --contextbench-trajectory "/out/{task.instance_id}.traj.json" \\
   --contextbench-image "{task.image}" \\
   --prompt-file /tmp/problem_statement.txt 2>&1 | tee /out/minicode.stdout
 """
 
 
 def write_task_outputs(out_dir: Path, task: Task, container_result: subprocess.CompletedProcess) -> None:
-    """Surface container stdout/stderr to the host. result.json, trajectory.traj.json,
-    and minicode.patch are already on the host via the volume mount.
+    """Surface container stdout/stderr to the host. result.json,
+    <instance_id>.traj.json, and minicode.patch are already on the host via
+    the volume mount.
     """
     (out_dir / "container.stdout").write_text(container_result.stdout or "")
     (out_dir / "container.stderr").write_text(container_result.stderr or "")
@@ -250,9 +251,9 @@ def run_task(task: Task, args: argparse.Namespace, out_root: Path) -> tuple[bool
 
     if result.returncode != 0:
         return False, f"container exit {result.returncode}; see container.stderr"
-    trajectory = out_dir / "trajectory.traj.json"
+    trajectory = out_dir / f"{task.instance_id}.traj.json"
     if not trajectory.exists():
-        return False, "container produced no trajectory.traj.json"
+        return False, f"container produced no {task.instance_id}.traj.json"
     return True, str(trajectory)
 
 


### PR DESCRIPTION
## Summary
- ContextBench's evaluator extracts the `instance_id` from the trajectory filename (`<id>.traj.json`). The driver was writing `trajectory.traj.json` uniformly, so every prediction got keyed as `"trajectory"` and the GoldLoader reported `missing_gold` instead of doing real scoring.
- Fix: write `<instance_id>.traj.json`. README documents the rule so future agent wiring catches it before hitting the same error.

## Context
Caught during Stage 2 of the ContextBench wiring work — three SWE-bench Verified astropy tasks ran cleanly end-to-end but landed on the missing_gold path until trajectories were manually renamed. With the fix, the evaluator produces real per-instance metrics for file / symbol / span / line coverage + editloc precision/recall.

## Test plan
- [x] Generated bash script confirmed to write `--contextbench-trajectory /out/<instance_id>.traj.json` for a sample task
- [x] No new tests — single string-substitution change in the embedded bash script

🤖 Generated with [Claude Code](https://claude.com/claude-code)