### PR TITLE
ContextBench driver: fix node-gyp python + env var passthrough

### DIFF
--- a/benchmarks/contextbench/run_minicode.py
+++ b/benchmarks/contextbench/run_minicode.py
@@ -166,8 +166,24 @@ if ! command -v node >/dev/null 2>&1 \\
   DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs >/dev/null
 fi
 
-echo "Installing minicode from {args.tarball_url}"
-npm install -g "{args.tarball_url}" >/dev/null 2>&1
+# Many SWE-bench images (especially django ones) activate a conda env whose
+# `python` is 3.6, which breaks node-gyp's tree-sitter build because gyp's
+# python source uses walrus operator (3.8+). Point npm at the system python
+# 3.10 if available — it's present on every SWE-bench image we've seen so far.
+NPM_PY=""
+for cand in /usr/bin/python3.10 /usr/bin/python3.11 /usr/bin/python3.12 /usr/bin/python3.9; do
+  if [ -x "$cand" ]; then NPM_PY="$cand"; break; fi
+done
+
+echo "Installing minicode from {args.tarball_url} (npm_config_python=$NPM_PY)"
+# Capture full npm output to /out/npm-install.log so failures (tree-sitter
+# native build, etc.) are inspectable from the host without re-running.
+if ! npm_config_python="$NPM_PY" npm install -g "{args.tarball_url}" \
+    > /out/npm-install.log 2>&1; then
+  echo "npm install failed — see /out/npm-install.log (tail below):"
+  tail -40 /out/npm-install.log
+  exit 1
+fi
 
 minicode benchmark run \\
   --workspace-root "$WS" \\
@@ -210,11 +226,15 @@ def run_task(task: Task, args: argparse.Namespace, out_root: Path) -> tuple[bool
     if not pull_image(task.image):
         return False, "image pull failed"
 
+    # minicode reads bare env names (MODEL_TIMEOUT_SECONDS etc.) — the
+    # MINICODE_BENCHMARK_* prefix only applies inside harbor's adapter,
+    # which has its own translation step. Pass through the unprefixed
+    # names directly.
     env = {
-        "MINICODE_BENCHMARK_MAX_STEPS": str(args.max_steps),
-        "MINICODE_BENCHMARK_MAX_TOKENS": str(args.max_tokens),
-        "MINICODE_BENCHMARK_MAX_CONTEXT_TOKENS": str(args.max_context_tokens),
-        "MINICODE_BENCHMARK_MODEL_TIMEOUT_SECONDS": str(args.model_timeout_seconds),
+        "MAX_STEPS": str(args.max_steps),
+        "MAX_TOKENS": str(args.max_tokens),
+        "MAX_CONTEXT_TOKENS": str(args.max_context_tokens),
+        "MODEL_TIMEOUT_SECONDS": str(args.model_timeout_seconds),
         "CONFIRM_DESTRUCTIVE": "false",
     }
     for key in ("OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):


### PR DESCRIPTION
## Summary
Three small fixes to the ContextBench docker driver, caught during the Stage 2.5 Gemini 2.5 Pro run (6/10 tasks failed at container exit before model invocation):

1. **`npm_config_python`** — SWE-bench django (and some astropy) images activate a conda env where `python` resolves to 3.6.13. node-gyp's gyp source uses the walrus operator (Python 3.8+), so the tree-sitter native build crashes with SyntaxError. Pointing `npm_config_python` at the next available system python (3.9 / 3.10 / 3.11 / 3.12) sidesteps conda's selection cleanly.

2. **Bare env var names** — I had copied harbor's `MINICODE_BENCHMARK_*` prefix convention into this driver, but that prefix only works because harbor has its own translation step. The minicode CLI reads bare names directly (`MAX_STEPS`, `MODEL_TIMEOUT_SECONDS`, …). With the prefixed names, `MODEL_TIMEOUT_SECONDS` defaulted to 60s — long thinking-model responses tripped on it and exited mid-run.

3. **Stop swallowing npm install errors** — both above were invisible until I reran a failing instance by hand because the install line was `npm install -g … >/dev/null 2>&1`. Now we capture full npm output to `/out/npm-install.log` and surface its tail on failure. Tiny disk cost, huge debuggability win.

## Empirical verification
With these fixes:
- 6/6 retries of originally-failed tasks succeeded
- Total stage 2.5 run cost: ~\$1 (well under the published \$0.38/task × 10 baseline)
- 10/10 trajectories produced; 2 of those are empty because Gemini 2.5 Pro consumed reasoning budget without emitting tool calls — a separate model-side concern, not this driver

## Test plan
- [x] Manual reproduction of npm install on django container without fix → tree-sitter SyntaxError on Python 3.6
- [x] Same reproduction with `npm_config_python=/usr/bin/python3.10` → clean install
- [x] Stage 2.5 retry of 6 failed tasks → 6/6 trajectories produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)