### PR TITLE
Benchmark mode: retry once when an attempt makes zero tool calls

### DIFF
--- a/src/cli/benchmark-run.ts
+++ b/src/cli/benchmark-run.ts
@@ -104,11 +104,23 @@ const BENCHMARK_SYSTEM_PROMPT_SUFFIX = [
   "- \"I have implemented X\" is not the same as \"tests pass.\" Do not declare completion without observing an explicit green signal (exit code 0, all-pass marker) from the canonical test runner over the full suite.",
 ].join("\n");
 
-const BENCHMARK_RETRY_REMINDER = [
+const BENCHMARK_RETRY_REMINDER_APPROVAL = [
   "Benchmark harness reminder:",
   "- This task is already approved.",
   "- Do not ask for confirmation or present a plan without acting.",
   "- Use tools, make the required edits immediately, and finish the task.",
+].join("\n");
+
+// Used when the previous attempt emitted zero tool calls — either pure
+// reasoning that produced no output (Gemini 2.5 Pro's thinking-paralysis
+// mode) or narration claiming work was done without any tool calls.
+// In benchmark mode every task requires code changes; zero tool calls
+// is a definite failure regardless of what the response text claims.
+const BENCHMARK_RETRY_REMINDER_NO_ACTION = [
+  "Benchmark harness reminder:",
+  "- Your previous response made zero tool calls. The task is not complete.",
+  '- Code changes only happen through tool calls (edit_file / write_file). Text alone — including past-tense statements like "I\'ve added X" or future-tense plans like "I\'ll add X" — is not a change.',
+  "- Begin by reading the relevant files with read_file or read_symbol, then make the edits with edit_file / write_file, then verify the result with run_command.",
 ].join("\n");
 
 const CONFIRMATION_REQUEST_PATTERNS = [
@@ -123,6 +135,8 @@ const CONFIRMATION_REQUEST_PATTERNS = [
   /\bneed your approval\b/i,
   /\bpermission\b/i,
 ];
+
+export type BenchmarkRetryReason = "approval_seeking" | "no_action";
 
 const SPECIALIZED_TOOL_NAMES = new Set([
   "read_symbol",
@@ -159,6 +173,50 @@ export function isBenchmarkApprovalSeekingResponse(text: string): boolean {
     return false;
   }
   return CONFIRMATION_REQUEST_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function countToolCallsInMessages(messages: SessionMessage[]): number {
+  let count = 0;
+  for (const message of messages) {
+    if (message.role === "assistant" && message.toolCalls?.length) {
+      count += message.toolCalls.length;
+    }
+  }
+  return count;
+}
+
+/**
+ * Decide whether a benchmark attempt should be retried once with an
+ * additional reminder appended to the prompt. Returns the reason (so the
+ * caller can pick a matching reminder), or `null` if the attempt looks
+ * fine as-is.
+ *
+ * Two failure modes warrant retry:
+ *   - `no_action`: the model emitted zero tool calls in the entire turn.
+ *     In benchmark mode every task requires code changes, so a tool-call-
+ *     free response is by definition incomplete. Covers both pure-
+ *     reasoning failures (visible text empty) and hallucinated-completion
+ *     narration ("I've added the helper" with no edit_file call).
+ *   - `approval_seeking`: the model asked for confirmation rather than
+ *     acting, even though it made some tool calls.
+ */
+export function getBenchmarkRetryReason(attempt: {
+  text: string;
+  toolCallCount: number;
+}): BenchmarkRetryReason | null {
+  if (attempt.toolCallCount === 0) {
+    return "no_action";
+  }
+  if (isBenchmarkApprovalSeekingResponse(attempt.text)) {
+    return "approval_seeking";
+  }
+  return null;
+}
+
+export function getBenchmarkRetryReminder(reason: BenchmarkRetryReason): string {
+  return reason === "approval_seeking"
+    ? BENCHMARK_RETRY_REMINDER_APPROVAL
+    : BENCHMARK_RETRY_REMINDER_NO_ACTION;
 }
 
 function stableSerialize(value: unknown): string {
@@ -561,13 +619,22 @@ export async function runBenchmarkCommand(argv: string[]): Promise<void> {
       verbose: args.verbose,
       ...(projectIndex !== undefined ? { projectIndex } : {}),
     });
-    if (isBenchmarkApprovalSeekingResponse(attempt.text)) {
+    const retryReason = getBenchmarkRetryReason({
+      text: attempt.text,
+      toolCallCount: countToolCallsInMessages(attempt.messages),
+    });
+    if (retryReason !== null) {
       if (args.verbose) {
+        const description =
+          retryReason === "approval_seeking"
+            ? "Model asked for confirmation"
+            : "Model emitted zero tool calls (pure-reasoning or narration-only response)";
         console.error(
-          "[benchmark] Model asked for confirmation; retrying once with a non-interactive reminder.",
+          `[benchmark] ${description}; retrying once with a non-interactive reminder.`,
         );
       }
-      attempt = await runBenchmarkAttempt(`${prompt}\n\n${BENCHMARK_RETRY_REMINDER}`, {
+      const reminder = getBenchmarkRetryReminder(retryReason);
+      attempt = await runBenchmarkAttempt(`${prompt}\n\n${reminder}`, {
         config,
         modelClient,
         toolRegistry,

--- a/tests/benchmark-run.test.ts
+++ b/tests/benchmark-run.test.ts
@@ -3,6 +3,8 @@ import { test } from "node:test";
 
 import {
   buildBenchmarkToolTrace,
+  getBenchmarkRetryReason,
+  getBenchmarkRetryReminder,
   getBenchmarkSystemPromptSuffix,
   isBenchmarkApprovalSeekingResponse,
   parseBenchmarkRunArgs,
@@ -86,6 +88,73 @@ test("normal benchmark summaries are not treated as approval-seeking", () => {
     ),
     false,
   );
+});
+
+test("getBenchmarkRetryReason flags zero-tool-call attempts as no_action", () => {
+  // Pure-reasoning failure (Gemini 2.5 Pro's "thought a lot, emitted
+  // nothing" mode). Despite empty text, the attempt is still a definite
+  // failure in benchmark mode since the task needs code changes.
+  assert.equal(
+    getBenchmarkRetryReason({ text: "", toolCallCount: 0 }),
+    "no_action",
+  );
+  // Hallucinated-completion failure: the model narrates work without
+  // making any tool calls. Caught the same way — zero tool calls is
+  // the load-bearing signal, not the text.
+  assert.equal(
+    getBenchmarkRetryReason({
+      text: "I've added the new transformation to astropy/coordinates/itrs.py and registered it with the frame_transform_graph.",
+      toolCallCount: 0,
+    }),
+    "no_action",
+  );
+  // Future-tense planning without action — also covered.
+  assert.equal(
+    getBenchmarkRetryReason({
+      text: "I will add the helper function to utils.py and update the imports.",
+      toolCallCount: 0,
+    }),
+    "no_action",
+  );
+});
+
+test("getBenchmarkRetryReason flags approval-seeking when tool calls exist", () => {
+  assert.equal(
+    getBenchmarkRetryReason({
+      text: "I found the changes needed. Please confirm and I'll apply them.",
+      toolCallCount: 5,
+    }),
+    "approval_seeking",
+  );
+});
+
+test("getBenchmarkRetryReason returns null for normal completion with tool calls", () => {
+  assert.equal(
+    getBenchmarkRetryReason({
+      text: "Updated src/app.ts, ran npm test, all tests passed.",
+      toolCallCount: 12,
+    }),
+    null,
+  );
+});
+
+test("getBenchmarkRetryReminder returns distinct reminders for the two reasons", () => {
+  const approval = getBenchmarkRetryReminder("approval_seeking");
+  const noAction = getBenchmarkRetryReminder("no_action");
+
+  // Approval reminder leans on "already approved" — the model was acting
+  // but asked for permission.
+  assert.match(approval, /already approved/i);
+  assert.doesNotMatch(approval, /zero tool calls/i);
+
+  // No-action reminder names the failure mode explicitly so the model
+  // understands what changed.
+  assert.match(noAction, /zero tool calls/i);
+  assert.match(noAction, /edit_file/);
+  // Calls out both the past-tense and future-tense narration traps that
+  // were observed in the Gemini 2.5 Pro empty-trajectory investigation.
+  assert.match(noAction, /past-tense/i);
+  assert.match(noAction, /future-tense/i);
 });
 
 test("parseBenchmarkRunArgs preserves prompt text and benchmark flags", () => {


### PR DESCRIPTION
## Summary
Stage 2.5 of the ContextBench wiring lost 2 of 10 Gemini 2.5 Pro tasks to two distinct empty-trajectory failures:

- **Pure reasoning**: 2678 reasoning tokens, 0 visible text, 0 tool calls. The model thought for 30s and emitted nothing.
- **Hallucinated completion**: *"I've added your proposed implementation to `astropy/coordinates/itrs.py`. This includes the new transformation functions…"* — narrating work that never happened, zero tool calls.

A determinism re-run showed pure-reasoning is variance-driven (the same task succeeded with 26 tool calls the second time) while hallucinated completion is stubborn on certain prompts. Either way the existing approval-seeking retry (`please confirm` / `may I proceed`) missed both shapes.

## Approach
- Add a second retry reason `no_action` that fires when an attempt's tool-call count is zero. Load-bearing signal is the count, not the text — so the same trigger catches both failure modes.
- Tailor the reminder text: the `no_action` reminder names the past-tense ("I've added") and future-tense ("I'll add") narration traps explicitly so the model on the second pass understands what changed.
- Keep the existing approval-seeking detection and reminder for the unchanged "asked to confirm" case.

## API
- New: `BenchmarkRetryReason = "approval_seeking" | "no_action"`
- New: `getBenchmarkRetryReason({text, toolCallCount}) → reason | null`
- New: `getBenchmarkRetryReminder(reason) → string`
- `isBenchmarkApprovalSeekingResponse(text)` retained for back-compat (only checks the approval patterns).

## Test plan
- [x] Empty text + 0 tool calls → `no_action`
- [x] Past-tense narration + 0 tool calls → `no_action`
- [x] Future-tense plan + 0 tool calls → `no_action`
- [x] Approval-seeking + tool calls > 0 → `approval_seeking`
- [x] Normal summary + tool calls > 0 → `null`
- [x] `getBenchmarkRetryReminder` returns distinct strings for each reason, with `no_action` containing both narration-trap callouts
- [x] Full suite: 749/751 (2 documented preexisting env-leak failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)