### PR TITLE
Benchmark mode: snapshot HEAD so committed fixes survive in the diff

### DIFF
--- a/benchmarks/contextbench/run_minicode.py
+++ b/benchmarks/contextbench/run_minicode.py
@@ -198,13 +198,21 @@ minicode benchmark run \\
 """
 
 
+def _as_text(value: object) -> str:
+    # subprocess.TimeoutExpired ignores text=True on Python 3.14 and stashes
+    # the partial captures as bytes. Normalize to str for write_text.
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value or ""  # type: ignore[return-value]
+
+
 def write_task_outputs(out_dir: Path, task: Task, container_result: subprocess.CompletedProcess) -> None:
     """Surface container stdout/stderr to the host. result.json,
     <instance_id>.traj.json, and minicode.patch are already on the host via
     the volume mount.
     """
-    (out_dir / "container.stdout").write_text(container_result.stdout or "")
-    (out_dir / "container.stderr").write_text(container_result.stderr or "")
+    (out_dir / "container.stdout").write_text(_as_text(container_result.stdout))
+    (out_dir / "container.stderr").write_text(_as_text(container_result.stderr))
     (out_dir / "task.json").write_text(json.dumps(
         {
             "instance_id": task.instance_id,

--- a/src/benchmark/workspace-changes.ts
+++ b/src/benchmark/workspace-changes.ts
@@ -79,6 +79,49 @@ async function getWorkspaceGitPrefix(workspaceRoot: string): Promise<string> {
   return prefix.trim();
 }
 
+/**
+ * Snapshot the current HEAD so we can diff against it at the end of a run
+ * even if the model committed in between. Returns null when the workspace
+ * is not a git repo or has no commits yet.
+ */
+export async function captureBaselineRef(workspaceRoot: string): Promise<string | null> {
+  if (!(await isGitRepository(workspaceRoot))) {
+    return null;
+  }
+  const sha = (await runGit(workspaceRoot, ["rev-parse", "HEAD"], true)).trim();
+  return sha.length > 0 ? sha : null;
+}
+
+function parseNameStatusLine(line: string): WorkspaceStatusEntry | undefined {
+  if (line.length === 0) {
+    return undefined;
+  }
+  // git diff --name-status output is tab-separated: STATUS\tPATH or
+  // STATUS\tOLD\tNEW (for renames/copies, status looks like R100 / C75).
+  const parts = line.split("\t");
+  const rawStatus = parts[0];
+  if (!rawStatus) {
+    return undefined;
+  }
+  const code = rawStatus.charAt(0);
+  if (code === "R" || code === "C") {
+    const previousPath = parts[1];
+    const nextPath = parts[2];
+    if (!previousPath || !nextPath) {
+      return undefined;
+    }
+    return { status: `${code} `, path: nextPath, previousPath };
+  }
+  const filePath = parts[1];
+  if (!filePath) {
+    return undefined;
+  }
+  // Map to the two-char porcelain-ish status the downstream code expects.
+  // We don't try to be exact — the only meaningful check downstream is the
+  // "??" untracked case, which is handled separately via git status.
+  return { status: `${code} `, path: filePath };
+}
+
 function stripWorkspacePrefix(
   filePath: string,
   workspacePrefix: string,
@@ -94,7 +137,10 @@ function stripWorkspacePrefix(
     : filePath;
 }
 
-export async function collectWorkspaceChanges(workspaceRoot: string): Promise<WorkspaceChanges> {
+export async function collectWorkspaceChanges(
+  workspaceRoot: string,
+  baselineRef?: string,
+): Promise<WorkspaceChanges> {
   const isGitRepo = await isGitRepository(workspaceRoot);
   if (!isGitRepo) {
     return {
@@ -106,15 +152,8 @@ export async function collectWorkspaceChanges(workspaceRoot: string): Promise<Wo
 
   const workspacePrefix = await getWorkspaceGitPrefix(workspaceRoot);
 
-  const statusOutput = await runGit(
-    workspaceRoot,
-    ["status", "--porcelain=v1", "--untracked-files=all", "--", "."],
-    true,
-  );
-  const entries = statusOutput
-    .split(/\r?\n/)
-    .map((line) => parseStatusLine(line))
-    .map((entry) => entry
+  const remap = (entry: WorkspaceStatusEntry | undefined): WorkspaceStatusEntry | undefined =>
+    entry
       ? {
           ...entry,
           path: stripWorkspacePrefix(entry.path, workspacePrefix),
@@ -122,8 +161,47 @@ export async function collectWorkspaceChanges(workspaceRoot: string): Promise<Wo
             ? { previousPath: stripWorkspacePrefix(entry.previousPath, workspacePrefix) }
             : {}),
         }
-      : undefined)
+      : undefined;
+
+  // Always pull untracked entries from `git status` — they're never part of
+  // a baseline diff because they aren't tracked yet.
+  const statusOutput = await runGit(
+    workspaceRoot,
+    ["status", "--porcelain=v1", "--untracked-files=all", "--", "."],
+    true,
+  );
+  const statusEntries = statusOutput
+    .split(/\r?\n/)
+    .map((line) => parseStatusLine(line))
+    .map(remap)
     .filter((entry): entry is WorkspaceStatusEntry => entry !== undefined);
+
+  let entries: WorkspaceStatusEntry[];
+  if (baselineRef) {
+    // Tracked changes: anything that differs between the baseline commit and
+    // the current working tree. Captures committed, staged, AND unstaged
+    // edits in one shot.
+    const nameStatusOutput = await runGit(
+      workspaceRoot,
+      ["diff", "--name-status", baselineRef, "--", "."],
+      true,
+    );
+    const trackedEntries = nameStatusOutput
+      .split(/\r?\n/)
+      .map((line) => parseNameStatusLine(line))
+      .map(remap)
+      .filter((entry): entry is WorkspaceStatusEntry => entry !== undefined);
+    const untrackedEntries = statusEntries.filter((entry) => entry.status === "??");
+    const seen = new Set<string>();
+    entries = [];
+    for (const entry of [...trackedEntries, ...untrackedEntries]) {
+      if (seen.has(entry.path)) continue;
+      seen.add(entry.path);
+      entries.push(entry);
+    }
+  } else {
+    entries = statusEntries;
+  }
 
   const changedFiles = [...new Set(entries.map((entry) => entry.path))];
   return {
@@ -133,17 +211,23 @@ export async function collectWorkspaceChanges(workspaceRoot: string): Promise<Wo
   };
 }
 
-export async function getWorkspaceDiff(workspaceRoot: string): Promise<string | null> {
-  const changes = await collectWorkspaceChanges(workspaceRoot);
+export async function getWorkspaceDiff(
+  workspaceRoot: string,
+  baselineRef?: string,
+): Promise<string | null> {
+  const changes = await collectWorkspaceChanges(workspaceRoot, baselineRef);
   if (!changes.isGitRepo) {
     return null;
   }
 
-  const trackedDiff = await runGit(
-    workspaceRoot,
-    ["diff", "--binary", "--no-ext-diff", "--relative", "--", "."],
-    true,
-  );
+  // With a baseline ref we diff working-tree vs baseline directly, which
+  // captures committed + staged + unstaged in one pass. Without one we
+  // fall back to the working-tree-vs-index behavior — useful when the
+  // caller hasn't snapshotted a starting point.
+  const trackedDiffArgs = baselineRef
+    ? ["diff", "--binary", "--no-ext-diff", "--relative", baselineRef, "--", "."]
+    : ["diff", "--binary", "--no-ext-diff", "--relative", "--", "."];
+  const trackedDiff = await runGit(workspaceRoot, trackedDiffArgs, true);
 
   const untrackedDiffs: string[] = [];
   for (const entry of changes.entries) {
@@ -167,8 +251,9 @@ export async function getWorkspaceDiff(workspaceRoot: string): Promise<string | 
 export async function writeWorkspaceDiff(
   workspaceRoot: string,
   outPath: string,
+  baselineRef?: string,
 ): Promise<boolean> {
-  const combinedDiff = await getWorkspaceDiff(workspaceRoot);
+  const combinedDiff = await getWorkspaceDiff(workspaceRoot, baselineRef);
   if (combinedDiff === null) {
     return false;
   }

--- a/src/cli/benchmark-run.ts
+++ b/src/cli/benchmark-run.ts
@@ -15,6 +15,7 @@ import {
   resolveBenchmarkEnv,
 } from "../benchmark/config.js";
 import {
+  captureBaselineRef,
   collectWorkspaceChanges,
   getWorkspaceDiff,
   writeWorkspaceDiff,
@@ -610,6 +611,12 @@ export async function runBenchmarkCommand(argv: string[]): Promise<void> {
 
     const toolRegistry = createToolRegistry(config, projectIndex);
 
+    // Snapshot HEAD before the model runs so we can diff against this point
+    // even if it commits its fix mid-run. Without this, `git diff` (which
+    // compares working-tree vs index) is blind to committed changes and the
+    // patch returned to the harness would be empty.
+    const baselineRef = (await captureBaselineRef(config.workspaceRoot)) ?? undefined;
+
     const startedAt = new Date().toISOString();
     const started = performance.now();
     let attempt = await runBenchmarkAttempt(prompt, {
@@ -645,11 +652,11 @@ export async function runBenchmarkCommand(argv: string[]): Promise<void> {
     const durationMs = performance.now() - started;
     const completedAt = new Date().toISOString();
 
-    const changes = await collectWorkspaceChanges(config.workspaceRoot);
+    const changes = await collectWorkspaceChanges(config.workspaceRoot, baselineRef);
     let diffOutPath: string | undefined;
     if (args.diffOut) {
       diffOutPath = path.resolve(cwd, args.diffOut);
-      await writeWorkspaceDiff(config.workspaceRoot, diffOutPath);
+      await writeWorkspaceDiff(config.workspaceRoot, diffOutPath, baselineRef);
     }
 
     const toolCalls = buildBenchmarkToolTrace(attempt.messages);
@@ -681,7 +688,7 @@ export async function runBenchmarkCommand(argv: string[]): Promise<void> {
 
     if (args.contextBenchTrajectory) {
       const trajectoryPath = path.resolve(cwd, args.contextBenchTrajectory);
-      const patch = (await getWorkspaceDiff(config.workspaceRoot)) ?? "";
+      const patch = (await getWorkspaceDiff(config.workspaceRoot, baselineRef)) ?? "";
       const trajectory = buildContextBenchTrajectory({
         systemPrompt: BENCHMARK_SYSTEM_PROMPT_SUFFIX,
         userPrompt: prompt,

--- a/tests/workspace-changes.test.ts
+++ b/tests/workspace-changes.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { afterEach, test } from "node:test";
 
 import {
+  captureBaselineRef,
   collectWorkspaceChanges,
   writeWorkspaceDiff,
 } from "../src/benchmark/workspace-changes.js";
@@ -108,4 +109,63 @@ test("workspace diff only includes files inside the selected workspace subtree",
   assert.match(diff, /diff --git a\/README\.md b\/README\.md/);
   assert.doesNotMatch(diff, /sibling\.ts/);
   assert.doesNotMatch(diff, /ROOT\.md/);
+});
+
+test("baseline ref captures committed changes that would otherwise be invisible", async () => {
+  // Regression: Gemini-3-Pro ran `git add` + `git commit` mid-task on a
+  // benchmark run. The old `git diff` (working-tree vs index) saw nothing
+  // and the harness threw away a working fix.
+  const workspaceRoot = await createGitWorkspace();
+  const baseline = await captureBaselineRef(workspaceRoot);
+  assert.ok(baseline && baseline.length >= 7, "baseline ref should be a SHA");
+
+  // Model edits a tracked file and commits, then leaves an untracked helper.
+  await writeFile(path.join(workspaceRoot, "src", "app.ts"), "export const value = 2;\n", "utf8");
+  execFileSync("git", ["add", "src/app.ts"], { cwd: workspaceRoot, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "fix value"], { cwd: workspaceRoot, stdio: "ignore" });
+  await writeFile(path.join(workspaceRoot, "reproduce.py"), "print('hi')\n", "utf8");
+
+  const withoutBaseline = await collectWorkspaceChanges(workspaceRoot);
+  // Without the baseline we miss the committed file entirely.
+  assert.deepEqual(withoutBaseline.changedFiles.sort(), ["reproduce.py"]);
+
+  const withBaseline = await collectWorkspaceChanges(workspaceRoot, baseline ?? undefined);
+  assert.deepEqual(withBaseline.changedFiles.sort(), ["reproduce.py", "src/app.ts"]);
+
+  const diffPath = path.join(workspaceRoot, "artifacts", "with-baseline.patch");
+  const wrote = await writeWorkspaceDiff(workspaceRoot, diffPath, baseline ?? undefined);
+  assert.equal(wrote, true);
+  const diff = await readFile(diffPath, "utf8");
+  assert.match(diff, /diff --git a\/src\/app\.ts b\/src\/app\.ts/);
+  assert.match(diff, /-export const value = 1;/);
+  assert.match(diff, /\+export const value = 2;/);
+  assert.match(diff, /diff --git a\/reproduce\.py b\/reproduce\.py/);
+});
+
+test("baseline ref also captures staged and unstaged changes (no false negatives)", async () => {
+  const workspaceRoot = await createGitWorkspace();
+  const baseline = await captureBaselineRef(workspaceRoot);
+
+  // One staged tracked change, one unstaged tracked change, one untracked.
+  await mkdir(path.join(workspaceRoot, "src"), { recursive: true });
+  await writeFile(path.join(workspaceRoot, "src", "app.ts"), "export const value = 99;\n", "utf8");
+  execFileSync("git", ["add", "src/app.ts"], { cwd: workspaceRoot, stdio: "ignore" });
+  await writeFile(path.join(workspaceRoot, "src", "app.ts"), "export const value = 100;\n", "utf8");
+  await writeFile(path.join(workspaceRoot, "notes.md"), "# notes\n", "utf8");
+
+  const changes = await collectWorkspaceChanges(workspaceRoot, baseline ?? undefined);
+  assert.deepEqual(changes.changedFiles.sort(), ["notes.md", "src/app.ts"]);
+
+  const diffPath = path.join(workspaceRoot, "artifacts", "mixed.patch");
+  await writeWorkspaceDiff(workspaceRoot, diffPath, baseline ?? undefined);
+  const diff = await readFile(diffPath, "utf8");
+  assert.match(diff, /\+export const value = 100;/);
+  assert.match(diff, /diff --git a\/notes\.md b\/notes\.md/);
+});
+
+test("captureBaselineRef returns null for a non-git workspace", async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "minicode-workspace-changes-nongit-"));
+  tempDirs.push(workspaceRoot);
+  const baseline = await captureBaselineRef(workspaceRoot);
+  assert.equal(baseline, null);
 });


### PR DESCRIPTION
## Summary

- `getWorkspaceDiff` previously ran `git diff` (working-tree vs index), which is blind to committed changes. If a benchmark model ran `git commit` mid-task — entirely reasonable behavior — its fix was silently lost from the patch returned to the harness.
- Fix: snapshot `git rev-parse HEAD` at the start of `runBenchmarkCommand` and thread the SHA through `collectWorkspaceChanges` / `getWorkspaceDiff` / `writeWorkspaceDiff` as an optional `baselineRef`. With a baseline we use `git diff <baseline>` and `git diff --name-status <baseline>`, capturing committed + staged + unstaged uniformly. Without a baseline the functions fall back to the existing behavior, so non-benchmark callers are unaffected.
- Side-fixes a Python 3.14 quirk in `run_minicode.py`: `subprocess.TimeoutExpired` returns its captured streams as `bytes` even when `text=True` was passed, which crashed `write_task_outputs` and aborted the rest of a batch when one task hit the container timeout. Normalized via `_as_text`.

## How this surfaced

Running gemini-3.1-pro-preview on the ContextBench task `SWE-Bench-Verified__python__maintenance__bugfix__71f348da`:

- Step 23: model correctly edits `astropy/wcs/wcsapi/wrappers/sliced_wcs.py` (the canonical fix); subsequent pytest runs confirm it works
- Step 54: `git add astropy/wcs/wcsapi/wrappers/sliced_wcs.py`
- Step 55: `git commit -m \"Fix dropped dimensions handling in SlicedLowLevelWCS world_to_pixel_values\"` → exit 0, \"1 file changed, 3 insertions(+), 1 deletion(-)\"
- End of run: `minicode.patch` contains only the untracked `reproduce.py` because the fix was committed away from `git diff`'s view

Earlier model runs (gemini-2.5-pro, haiku-4.5, gemini-3-flash) didn't `git commit` so the bug stayed latent. A rerun on the same task after this fix produces the expected patch with both the source fix and an added test in `changedFiles`.

## Test plan

- [x] `node --test --import tsx tests/workspace-changes.test.ts` — 7/7 pass (3 new: committed-only, mixed-states, non-git fallback)
- [x] `npm run lint`
- [x] `npm test` — 752 pass / 2 fail (preexisting env-leak failures unrelated to this change)
- [x] End-to-end: ContextBench rerun of 71f348da produced a `minicode.patch` with the source-file fix instead of just the untracked repro script

🤖 Generated with [Claude Code](https://claude.com/claude-code)