### PR TITLE
Benchmark mode: detect shell mutations, protect test_patch, retry plan-only runs

### DIFF
--- a/benchmarks/contextbench/run_minicode.py
+++ b/benchmarks/contextbench/run_minicode.py
@@ -155,9 +155,20 @@ fi
 cd "$WS"
 
 if [ -s /tmp/test.patch ]; then
-  git apply --whitespace=nowarn /tmp/test.patch \\
-    || git apply --reject --whitespace=nowarn /tmp/test.patch \\
-    || true
+  if git apply --whitespace=nowarn /tmp/test.patch; then
+    # Commit the test_patch so the model can't accidentally revert it with
+    # `git checkout`. Observed in trace analysis: models that run
+    # `git checkout <test_file>` to clean their own scratch edits also blow
+    # away the canonical failing tests, which silently corrupts scoring.
+    git -c user.email=benchmark@minicode -c user.name=minicode-benchmark \\
+      add -A
+    git -c user.email=benchmark@minicode -c user.name=minicode-benchmark \\
+      commit -m "ContextBench: apply test_patch" --allow-empty >/dev/null
+  else
+    # Couldn't apply cleanly — fall back to --reject so the failure is
+    # visible via .rej files, but don't commit a half-applied state.
+    git apply --reject --whitespace=nowarn /tmp/test.patch || true
+  fi
 fi
 
 if ! command -v node >/dev/null 2>&1 \\

--- a/src/cli/benchmark-run.ts
+++ b/src/cli/benchmark-run.ts
@@ -85,6 +85,11 @@ export interface BenchmarkToolUsageSummary {
   fileReadTotal: number;
   searchTotal: number;
   mutationTotal: number;
+  // Subset of commandTotal: run_command calls whose shell command looks
+  // like it mutates the filesystem (heredoc-into-file, sed -i, tee, etc.).
+  // Counted separately from mutationTotal so the structured-vs-shell
+  // breakdown is preserved.
+  shellMutationTotal: number;
   commandTotal: number;
   skippedTotal: number;
   repeatedStop: boolean;
@@ -124,6 +129,19 @@ const BENCHMARK_RETRY_REMINDER_NO_ACTION = [
   "- Begin by reading the relevant files with read_file or read_symbol, then make the edits with edit_file / write_file, then verify the result with run_command.",
 ].join("\n");
 
+// Used when the previous attempt made tool calls but never mutated any
+// file (no edit_file/write_file, no `cat > FILE`/`sed -i`/`tee` shell
+// edit). Observed shape: model reads a few symbols, narrates a plan
+// ("Here's how I'll fix it: 1. … 2. …"), and stops without acting.
+// Distinct from `approval_seeking` (no explicit confirmation request)
+// and from `no_action` (tool-call count > 0).
+const BENCHMARK_RETRY_REMINDER_NO_MUTATION = [
+  "Benchmark harness reminder:",
+  "- Your previous response read files but never edited any. The task is not complete.",
+  "- Code changes only happen through file mutations: edit_file / write_file (preferred), or a shell command that writes to a file (e.g. `cat > path <<EOF`, `sed -i ...`).",
+  "- Reading more files is not progress on its own. Identify the file to change, make the edit, then verify with run_command.",
+].join("\n");
+
 const CONFIRMATION_REQUEST_PATTERNS = [
   /\bplease confirm\b/i,
   /\bconfirm and i(?:'|’)ll\b/i,
@@ -137,7 +155,7 @@ const CONFIRMATION_REQUEST_PATTERNS = [
   /\bpermission\b/i,
 ];
 
-export type BenchmarkRetryReason = "approval_seeking" | "no_action";
+export type BenchmarkRetryReason = "approval_seeking" | "no_action" | "no_mutation";
 
 const SPECIALIZED_TOOL_NAMES = new Set([
   "read_symbol",
@@ -152,6 +170,43 @@ const SEARCH_TOOL_NAMES = new Set(["search"]);
 const MUTATION_TOOL_NAMES = new Set(["edit_file", "write_file"]);
 const COMMAND_TOOL_NAMES = new Set(["run_command"]);
 const REPEATED_TOOL_CALL_STOP_TEXT = "Stopped due to repeated identical tool calls";
+
+// Heuristics for "this shell command modified a file." Observed during
+// trace analysis: gemini-3-pro routinely uses `cat > FILE <<EOF` /
+// `cat >> FILE` heredocs instead of edit_file/write_file, so the model
+// is doing real work while our toolUsage.mutationTotal reads zero. The
+// retry detector and mutation analysis both need to recognize these as
+// real edits.
+const SHELL_MUTATION_PATTERNS: RegExp[] = [
+  // Redirect to a file: `> path`, `>> path`, or with a leading fd like `2> path`.
+  // Excludes `/dev/null`, `/dev/stderr`, and fd redirects (`>&2`).
+  /(?:^|[^&>])>>?\s*(?!\/dev\/null\b|\/dev\/stderr\b|&\d)[^\s|;&<>]+/,
+  // sed in-place edit.
+  /\bsed\b[^|;]*\s-i\b/,
+  // tee writes its stdin to one or more files.
+  /\btee\b(?!\s+--help\b)/,
+  // Python `open(..., "w"|"a"|"r+"|"wb"|"ab").write(...)` invocation (covers
+  // the common `python -c "..."` mutation shape).
+  /\bopen\s*\(\s*['"][^'"]+['"]\s*,\s*['"][rwa]\+?b?\+?['"]\s*\)\s*\.\s*write\b/,
+];
+
+export function looksLikeShellFileMutation(command: string): boolean {
+  if (typeof command !== "string" || command.length === 0) {
+    return false;
+  }
+  return SHELL_MUTATION_PATTERNS.some((pattern) => pattern.test(command));
+}
+
+function toolCallLooksLikeShellMutation(toolCall: {
+  name: string;
+  input: Record<string, unknown>;
+}): boolean {
+  if (!COMMAND_TOOL_NAMES.has(toolCall.name)) {
+    return false;
+  }
+  const command = toolCall.input?.command;
+  return typeof command === "string" && looksLikeShellFileMutation(command);
+}
 
 interface BenchmarkAttemptResult {
   text: string;
@@ -187,12 +242,41 @@ function countToolCallsInMessages(messages: SessionMessage[]): number {
 }
 
 /**
+ * Count any tool call that produced a real workspace mutation, whether via
+ * the structured tools (edit_file / write_file) or via a shell command
+ * that looks like a file write (heredoc into a file, sed -i, tee, etc.).
+ */
+export function countMutationsInMessages(messages: SessionMessage[]): number {
+  let count = 0;
+  for (const message of messages) {
+    if (message.role !== "assistant" || !message.toolCalls?.length) {
+      continue;
+    }
+    for (const toolCall of message.toolCalls) {
+      if (MUTATION_TOOL_NAMES.has(toolCall.name)) {
+        count += 1;
+        continue;
+      }
+      if (
+        toolCallLooksLikeShellMutation({
+          name: toolCall.name,
+          input: (toolCall.input ?? {}) as Record<string, unknown>,
+        })
+      ) {
+        count += 1;
+      }
+    }
+  }
+  return count;
+}
+
+/**
  * Decide whether a benchmark attempt should be retried once with an
  * additional reminder appended to the prompt. Returns the reason (so the
  * caller can pick a matching reminder), or `null` if the attempt looks
  * fine as-is.
  *
- * Two failure modes warrant retry:
+ * Three failure modes warrant retry, checked in this order:
  *   - `no_action`: the model emitted zero tool calls in the entire turn.
  *     In benchmark mode every task requires code changes, so a tool-call-
  *     free response is by definition incomplete. Covers both pure-
@@ -200,10 +284,17 @@ function countToolCallsInMessages(messages: SessionMessage[]): number {
  *     narration ("I've added the helper" with no edit_file call).
  *   - `approval_seeking`: the model asked for confirmation rather than
  *     acting, even though it made some tool calls.
+ *   - `no_mutation`: the model made tool calls but never produced a file
+ *     mutation — read-only exploration that stopped at a plan. Observed
+ *     on Gemini 2.5 Pro: 3 read_symbol calls followed by a future-tense
+ *     plan, no edit. mutationCount counts both structured and shell-based
+ *     mutations so this only fires when the model genuinely did nothing
+ *     to the workspace.
  */
 export function getBenchmarkRetryReason(attempt: {
   text: string;
   toolCallCount: number;
+  mutationCount: number;
 }): BenchmarkRetryReason | null {
   if (attempt.toolCallCount === 0) {
     return "no_action";
@@ -211,13 +302,21 @@ export function getBenchmarkRetryReason(attempt: {
   if (isBenchmarkApprovalSeekingResponse(attempt.text)) {
     return "approval_seeking";
   }
+  if (attempt.mutationCount === 0) {
+    return "no_mutation";
+  }
   return null;
 }
 
 export function getBenchmarkRetryReminder(reason: BenchmarkRetryReason): string {
-  return reason === "approval_seeking"
-    ? BENCHMARK_RETRY_REMINDER_APPROVAL
-    : BENCHMARK_RETRY_REMINDER_NO_ACTION;
+  switch (reason) {
+    case "approval_seeking":
+      return BENCHMARK_RETRY_REMINDER_APPROVAL;
+    case "no_action":
+      return BENCHMARK_RETRY_REMINDER_NO_ACTION;
+    case "no_mutation":
+      return BENCHMARK_RETRY_REMINDER_NO_MUTATION;
+  }
 }
 
 function stableSerialize(value: unknown): string {
@@ -283,6 +382,7 @@ export function summarizeBenchmarkToolUsage(
   let fileReadTotal = 0;
   let searchTotal = 0;
   let mutationTotal = 0;
+  let shellMutationTotal = 0;
   let commandTotal = 0;
   let skippedTotal = 0;
 
@@ -304,6 +404,9 @@ export function summarizeBenchmarkToolUsage(
     }
     if (COMMAND_TOOL_NAMES.has(toolCall.name)) {
       commandTotal += 1;
+      if (toolCallLooksLikeShellMutation(toolCall)) {
+        shellMutationTotal += 1;
+      }
     }
     if (toolCall.skipped) {
       skippedTotal += 1;
@@ -330,6 +433,7 @@ export function summarizeBenchmarkToolUsage(
     fileReadTotal,
     searchTotal,
     mutationTotal,
+    shellMutationTotal,
     commandTotal,
     skippedTotal,
     repeatedStop:
@@ -629,13 +733,16 @@ export async function runBenchmarkCommand(argv: string[]): Promise<void> {
     const retryReason = getBenchmarkRetryReason({
       text: attempt.text,
       toolCallCount: countToolCallsInMessages(attempt.messages),
+      mutationCount: countMutationsInMessages(attempt.messages),
     });
     if (retryReason !== null) {
       if (args.verbose) {
         const description =
           retryReason === "approval_seeking"
             ? "Model asked for confirmation"
-            : "Model emitted zero tool calls (pure-reasoning or narration-only response)";
+            : retryReason === "no_action"
+              ? "Model emitted zero tool calls (pure-reasoning or narration-only response)"
+              : "Model made tool calls but never mutated any file (plan-only response)";
         console.error(
           `[benchmark] ${description}; retrying once with a non-interactive reminder.`,
         );

--- a/tests/benchmark-run.test.ts
+++ b/tests/benchmark-run.test.ts
@@ -3,10 +3,12 @@ import { test } from "node:test";
 
 import {
   buildBenchmarkToolTrace,
+  countMutationsInMessages,
   getBenchmarkRetryReason,
   getBenchmarkRetryReminder,
   getBenchmarkSystemPromptSuffix,
   isBenchmarkApprovalSeekingResponse,
+  looksLikeShellFileMutation,
   parseBenchmarkRunArgs,
   summarizeBenchmarkToolUsage,
 } from "../src/cli/benchmark-run.js";
@@ -95,7 +97,7 @@ test("getBenchmarkRetryReason flags zero-tool-call attempts as no_action", () =>
   // nothing" mode). Despite empty text, the attempt is still a definite
   // failure in benchmark mode since the task needs code changes.
   assert.equal(
-    getBenchmarkRetryReason({ text: "", toolCallCount: 0 }),
+    getBenchmarkRetryReason({ text: "", toolCallCount: 0, mutationCount: 0 }),
     "no_action",
   );
   // Hallucinated-completion failure: the model narrates work without
@@ -105,6 +107,7 @@ test("getBenchmarkRetryReason flags zero-tool-call attempts as no_action", () =>
     getBenchmarkRetryReason({
       text: "I've added the new transformation to astropy/coordinates/itrs.py and registered it with the frame_transform_graph.",
       toolCallCount: 0,
+      mutationCount: 0,
     }),
     "no_action",
   );
@@ -113,6 +116,7 @@ test("getBenchmarkRetryReason flags zero-tool-call attempts as no_action", () =>
     getBenchmarkRetryReason({
       text: "I will add the helper function to utils.py and update the imports.",
       toolCallCount: 0,
+      mutationCount: 0,
     }),
     "no_action",
   );
@@ -123,24 +127,56 @@ test("getBenchmarkRetryReason flags approval-seeking when tool calls exist", () 
     getBenchmarkRetryReason({
       text: "I found the changes needed. Please confirm and I'll apply them.",
       toolCallCount: 5,
+      mutationCount: 0,
     }),
     "approval_seeking",
   );
 });
 
-test("getBenchmarkRetryReason returns null for normal completion with tool calls", () => {
+test("getBenchmarkRetryReason flags plan-only attempts as no_mutation", () => {
+  // Observed on Gemini 2.5 Pro 71f348da: 3 read-only tool calls
+  // (search_code_map + 2 read_symbol) followed by a future-tense plan
+  // ("Here's how I'll fix it: 1. Read X. 2. Modify Y. 3. I'll replace Z.")
+  // and no edit. Approval-seeking detector doesn't fire (no "please confirm")
+  // and no_action doesn't fire (toolCallCount > 0) — needs a third signal.
+  assert.equal(
+    getBenchmarkRetryReason({
+      text: "Here's how I'll fix it: 1. Read sliced_wcs.py. 2. Modify world_to_pixel_values. 3. I'll replace the 1. fallback.",
+      toolCallCount: 3,
+      mutationCount: 0,
+    }),
+    "no_mutation",
+  );
+});
+
+test("getBenchmarkRetryReason returns null when mutations occurred", () => {
   assert.equal(
     getBenchmarkRetryReason({
       text: "Updated src/app.ts, ran npm test, all tests passed.",
       toolCallCount: 12,
+      mutationCount: 2,
     }),
     null,
   );
 });
 
-test("getBenchmarkRetryReminder returns distinct reminders for the two reasons", () => {
+test("getBenchmarkRetryReason prioritizes no_action over no_mutation", () => {
+  // Defensive: a zero-tool-call attempt also has zero mutations, but the
+  // reminder for no_action is more specific. Make sure that path wins.
+  assert.equal(
+    getBenchmarkRetryReason({
+      text: "I will edit utils.py.",
+      toolCallCount: 0,
+      mutationCount: 0,
+    }),
+    "no_action",
+  );
+});
+
+test("getBenchmarkRetryReminder returns distinct reminders for each reason", () => {
   const approval = getBenchmarkRetryReminder("approval_seeking");
   const noAction = getBenchmarkRetryReminder("no_action");
+  const noMutation = getBenchmarkRetryReminder("no_mutation");
 
   // Approval reminder leans on "already approved" — the model was acting
   // but asked for permission.
@@ -155,6 +191,83 @@ test("getBenchmarkRetryReminder returns distinct reminders for the two reasons",
   // were observed in the Gemini 2.5 Pro empty-trajectory investigation.
   assert.match(noAction, /past-tense/i);
   assert.match(noAction, /future-tense/i);
+
+  // No-mutation reminder is distinct — the model DID call tools, just
+  // never edited anything. It should mention reading-without-editing,
+  // and acknowledge shell-based edits as legitimate (since some models
+  // prefer `cat > file` over edit_file).
+  assert.match(noMutation, /read files but never edited/i);
+  assert.match(noMutation, /cat > path|sed -i/);
+  assert.notEqual(noMutation, noAction);
+  assert.notEqual(noMutation, approval);
+});
+
+test("looksLikeShellFileMutation detects common file-writing shells", () => {
+  // Heredoc into file — the gemini-3-pro 71f348da pattern.
+  assert.equal(
+    looksLikeShellFileMutation("cat > path/to/file.py <<'EOF'\nbody\nEOF"),
+    true,
+  );
+  // Append redirect with heredoc.
+  assert.equal(
+    looksLikeShellFileMutation("cat << 'EOF' >> tests/foo.py\nbody\nEOF"),
+    true,
+  );
+  // In-place sed.
+  assert.equal(looksLikeShellFileMutation("sed -i 's/old/new/g' foo.py"), true);
+  // tee.
+  assert.equal(looksLikeShellFileMutation("echo x | tee path/to/file"), true);
+  // Python open().write().
+  assert.equal(
+    looksLikeShellFileMutation(
+      'python -c "open(\'foo.py\', \'w\').write(\'body\')"',
+    ),
+    true,
+  );
+});
+
+test("looksLikeShellFileMutation rejects read-only and benign redirects", () => {
+  // Pure read.
+  assert.equal(looksLikeShellFileMutation("cat path/to/file.py"), false);
+  // Pipe + cat with output to /dev/null.
+  assert.equal(
+    looksLikeShellFileMutation("python script.py > /dev/null 2>&1"),
+    false,
+  );
+  // File descriptor redirect (no file write).
+  assert.equal(looksLikeShellFileMutation("python script.py 2>&1"), false);
+  // pytest invocation — no redirect, no in-place edit.
+  assert.equal(
+    looksLikeShellFileMutation("python -m pytest tests/foo.py"),
+    false,
+  );
+  // git commands operate on the index, not arbitrary file writes — we
+  // don't count them as code mutations.
+  assert.equal(looksLikeShellFileMutation("git checkout tests/foo.py"), false);
+  assert.equal(looksLikeShellFileMutation("git add ."), false);
+});
+
+test("countMutationsInMessages counts structured + shell mutations together", () => {
+  const messages: SessionMessage[] = [
+    { role: "user", content: "task" },
+    {
+      role: "assistant",
+      content: "",
+      toolCalls: [
+        { id: "1", name: "read_file", input: { path: "a.py" } },
+        { id: "2", name: "edit_file", input: { path: "a.py", old_string: "x", new_string: "y" } },
+        {
+          id: "3",
+          name: "run_command",
+          input: { command: "cat > b.py <<'EOF'\nprint('hi')\nEOF" },
+        },
+        { id: "4", name: "run_command", input: { command: "python -m pytest" } },
+      ],
+    },
+    { role: "assistant", content: "done" },
+  ];
+  // edit_file + the heredoc command count; read_file and pytest don't.
+  assert.equal(countMutationsInMessages(messages), 2);
 });
 
 test("parseBenchmarkRunArgs preserves prompt text and benchmark flags", () => {
@@ -284,8 +397,46 @@ test("benchmark tool usage summary separates structured tools from file reads", 
   assert.equal(summary.specializedByName.get_dependencies, 1);
   assert.equal(summary.fileReadTotal, 1);
   assert.equal(summary.mutationTotal, 1);
+  assert.equal(summary.shellMutationTotal, 0);
   assert.equal(summary.commandTotal, 1);
   assert.deepEqual(summary.repeatedToolCalls, []);
+});
+
+test("benchmark tool usage summary counts shell-based file edits as shellMutation", () => {
+  // Gemini-3-Pro pattern: `cat > FILE <<EOF` heredoc instead of edit_file.
+  // mutationTotal stays at the structured-tool count; shellMutationTotal
+  // exposes the shell-based edits without inflating mutationTotal.
+  const summary = summarizeBenchmarkToolUsage(
+    [
+      {
+        step: 1,
+        name: "run_command",
+        input: { command: "cat > foo.py <<'EOF'\nprint('hi')\nEOF" },
+        result: "ok",
+        skipped: false,
+      },
+      {
+        step: 2,
+        name: "run_command",
+        input: { command: "sed -i 's/old/new/g' bar.py" },
+        result: "ok",
+        skipped: false,
+      },
+      {
+        step: 3,
+        name: "run_command",
+        input: { command: "python -m pytest" },
+        result: "ok",
+        skipped: false,
+      },
+    ],
+    "Done",
+  );
+
+  assert.equal(summary.total, 3);
+  assert.equal(summary.commandTotal, 3);
+  assert.equal(summary.mutationTotal, 0);
+  assert.equal(summary.shellMutationTotal, 2);
 });
 
 test("benchmark tool usage summary reports repeated-call stops", () => {


### PR DESCRIPTION
## Summary

Three improvements bundled from a ContextBench/SWE-Bench trace audit. Each addresses a distinct way the harness was silently mishandling real model behavior:

1. **Driver commits the test_patch after applying it** so a model running `git checkout <test_file>` to clean its own scratch edits doesn't blow away the canonical failing tests. Silently corrupted scoring before; visible no-op now.
2. **`toolUsage.shellMutationTotal`** counts `run_command` calls that look like file edits (`cat > FILE <<EOF` heredocs, `sed -i`, `tee`, `open(..., "w").write()` in `python -c`). Observed on gemini-3-pro: 83 tool calls and `mutationTotal: 0` despite real edits to `sliced_wcs.py`, because the model prefers shell heredocs over `edit_file`. `mutationTotal` keeps its existing meaning (structured tools only) so the split is preserved.
3. **`no_mutation` retry reason** — fires when the model made tool calls but never edited any file. Observed on Gemini 2.5 Pro 71f348da: 3 read-only tool calls followed by a future-tense plan ("Here's how I'll fix it: 1. Read X. 2. Modify Y. …") and no edit. `no_action` didn't fire (toolCallCount > 0) and `approval_seeking` didn't fire (no confirmation phrasing). The new detector uses `countMutationsInMessages` which counts both structured edits and shell mutations, so it only fires when the model genuinely did nothing to the workspace.

## How each surfaced

- (1) gemini-3-pro 71f348da run #1 (before #217): committed its fix mid-run, then later session also showed multiple `git checkout test_sliced_wcs.py` calls that reverted the canonical SWE-bench failing tests.
- (2) gemini-3-pro 71f348da run #2 (after #217): patch correctly captured but `toolUsage.mutationTotal: 0` despite 81 `run_command` calls including many `cat > FILE <<EOF` heredoc writes.
- (3) gemini-2.5-pro 71f348da run (Stage 2.5): 3 tool calls (search + 2 read_symbol), 0 mutations, text ended mid-sentence in the middle of a future-tense plan. Retry would not have fired under the old detector.

## Test plan

- [x] `node --test --import tsx tests/benchmark-run.test.ts` — 19/19 pass (10 new across the three areas)
- [x] `npm run lint`
- [x] `npm test` — 758 pass / 2 fail (preexisting env-leak failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)