### PR TITLE
Benchmark retry: force tool call + cap reasoning when first attempt collapses

### DIFF
--- a/packages/agent-sdk/src/agent/agent.ts
+++ b/packages/agent-sdk/src/agent/agent.ts
@@ -568,6 +568,9 @@ export class CodingAgent {
         ...(this.config.reasoningMaxTokens !== undefined
           ? { reasoningMaxTokens: this.config.reasoningMaxTokens }
           : {}),
+        ...(this.config.toolChoice !== undefined
+          ? { toolChoice: this.config.toolChoice }
+          : {}),
         ...(this.onUiUpdate
           ? {
               onStream: (chunk: string) => {

--- a/packages/agent-sdk/src/agent/types.ts
+++ b/packages/agent-sdk/src/agent/types.ts
@@ -47,6 +47,19 @@ export type SessionMessage = UserMessage | AssistantMessage | ToolResultMessage;
 /** Valid reasoning effort levels for models that support reasoning tokens. */
 export type ReasoningEffort = "xhigh" | "high" | "medium" | "low" | "minimal" | "none";
 
+/**
+ * Constrains how the model uses tools on a given chat call.
+ *   - `"auto"` (default): model decides whether to call a tool or reply with text.
+ *   - `"required"`: model MUST call at least one tool. Useful for forcing
+ *     action after a no-action attempt — prevents the model from burning
+ *     its budget in extended thinking and returning nothing.
+ *   - `"none"`: model may not call tools.
+ *
+ * If `tools` is empty, `"required"` is silently downgraded to `"auto"` (the
+ * provider would otherwise reject the request).
+ */
+export type ToolChoice = "auto" | "required" | "none";
+
 export interface AgentConfig {
   modelProvider: "anthropic" | "openai-compatible";
   model: string;
@@ -97,6 +110,14 @@ export interface AgentConfig {
   reasoningMaxTokens?: number;
   /** Rebuild the system prompt (including code map) every agent step. Disabling improves KV cache hit rates for local models. Default: false */
   enableDynamicPrompt?: boolean;
+  /**
+   * When set, forwarded to `ModelClient.chat` on every step. Mainly used by
+   * the benchmark retry path to set `"required"` on a second attempt after
+   * the first attempt produced no action (forces the model to commit to a
+   * tool call rather than another pure-thinking collapse). Unset in normal
+   * agent operation.
+   */
+  toolChoice?: ToolChoice;
 }
 
 export interface ToolSchema {
@@ -221,6 +242,8 @@ export interface ModelClient {
     reasoningEffort?: ReasoningEffort;
     /** See `AgentConfig.reasoningMaxTokens`. */
     reasoningMaxTokens?: number;
+    /** See `AgentConfig.toolChoice`. Silently downgraded to `"auto"` when `tools` is empty. */
+    toolChoice?: ToolChoice;
     onStream?: (chunk: string) => void;
     signal?: AbortSignal;
     /**

--- a/packages/agent-sdk/src/model/client.ts
+++ b/packages/agent-sdk/src/model/client.ts
@@ -12,6 +12,7 @@ import type {
   ReasoningEffort,
   SessionMessage,
   ToolCall,
+  ToolChoice,
   ToolSchema,
 } from "../agent/types.js";
 import {
@@ -639,6 +640,25 @@ function effortToBudgetFraction(effort: ReasoningEffort): number {
   }
 }
 
+function mapAnthropicToolChoice(
+  choice: ToolChoice | undefined,
+  toolCount: number,
+): { type: "auto" } | { type: "any" } | { type: "none" } | null {
+  if (choice === undefined) return null;
+  if (choice === "required" && toolCount === 0) return { type: "auto" };
+  if (choice === "required") return { type: "any" };
+  if (choice === "none") return { type: "none" };
+  return { type: "auto" };
+}
+
+function resolveOpenAIToolChoice(
+  choice: ToolChoice | undefined,
+  toolCount: number,
+): "auto" | "required" | "none" {
+  if (choice === "required" && toolCount === 0) return "auto";
+  return choice ?? "auto";
+}
+
 export class AnthropicModelClient implements ModelClient {
   private readonly client: Anthropic;
   private readonly timeoutSeconds: number;
@@ -670,6 +690,7 @@ export class AnthropicModelClient implements ModelClient {
     maxTokens: number;
     reasoningEffort?: ReasoningEffort;
     reasoningMaxTokens?: number;
+    toolChoice?: ToolChoice;
     onStream?: (chunk: string) => void;
     signal?: AbortSignal;
     cacheableSystem?: boolean;
@@ -746,7 +767,15 @@ export class AnthropicModelClient implements ModelClient {
           }
         : {};
 
-    const requestParams = { ...baseParams, ...thinkingParam };
+    const anthropicToolChoice = mapAnthropicToolChoice(
+      params.toolChoice,
+      toolsForRequest.length,
+    );
+    const toolChoiceParam = anthropicToolChoice
+      ? { tool_choice: anthropicToolChoice }
+      : {};
+
+    const requestParams = { ...baseParams, ...thinkingParam, ...toolChoiceParam };
     const requestOptions = params.signal ? { signal: params.signal } : undefined;
 
     return withRetry(async () => {
@@ -958,6 +987,7 @@ export class OpenAICompatibleModelClient implements ModelClient {
     maxTokens: number;
     reasoningEffort?: ReasoningEffort;
     reasoningMaxTokens?: number;
+    toolChoice?: ToolChoice;
     onStream?: (chunk: string) => void;
     signal?: AbortSignal;
     cacheableSystem?: boolean;
@@ -997,7 +1027,7 @@ export class OpenAICompatibleModelClient implements ModelClient {
       model: params.model,
       messages: toOpenAICompatibleMessages(params.system, params.messages),
       tools: toOpenAICompatibleTools(toolsForRequest),
-      tool_choice: "auto",
+      tool_choice: resolveOpenAIToolChoice(params.toolChoice, toolsForRequest.length),
       max_tokens: params.maxTokens,
       stream: useStream,
     };

--- a/packages/agent-sdk/tests/model-client-anthropic-structured-output.test.ts
+++ b/packages/agent-sdk/tests/model-client-anthropic-structured-output.test.ts
@@ -245,3 +245,83 @@ test("anthropic client extracts synthetic call alongside real tool calls", async
   assert.equal(response.toolCalls.length, 1);
   assert.equal(response.toolCalls[0]?.name, "read_file");
 });
+
+// ---------------------------------------------------------------------------
+// tool_choice forwarding
+// ---------------------------------------------------------------------------
+
+test("anthropic client omits tool_choice by default", async () => {
+  const fake = makeFakeClient({
+    finalMessage: {
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+  });
+  const client = new AnthropicModelClient("test-key", {
+    client: fake.fakeClient as never,
+  });
+  await client.chat({
+    model: "claude-test",
+    system: "sys",
+    messages: [{ role: "user", content: "hi" }],
+    tools: [
+      { name: "read_file", description: "read", input_schema: { type: "object", properties: {} } },
+    ],
+    maxTokens: 64,
+  });
+  assert.equal(fake.captured.params.tool_choice, undefined);
+});
+
+test("anthropic client forwards toolChoice='required' as { type: 'any' }", async () => {
+  const fake = makeFakeClient({
+    finalMessage: {
+      content: [
+        {
+          type: "tool_use",
+          id: "tu_1",
+          name: "read_file",
+          input: { path: "foo.ts" },
+        },
+      ],
+      stop_reason: "tool_use",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+  });
+  const client = new AnthropicModelClient("test-key", {
+    client: fake.fakeClient as never,
+  });
+  await client.chat({
+    model: "claude-test",
+    system: "sys",
+    messages: [{ role: "user", content: "hi" }],
+    tools: [
+      { name: "read_file", description: "read", input_schema: { type: "object", properties: {} } },
+    ],
+    maxTokens: 64,
+    toolChoice: "required",
+  });
+  assert.deepEqual(fake.captured.params.tool_choice, { type: "any" });
+});
+
+test("anthropic client downgrades toolChoice='required' to { type: 'auto' } when tools is empty", async () => {
+  const fake = makeFakeClient({
+    finalMessage: {
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+  });
+  const client = new AnthropicModelClient("test-key", {
+    client: fake.fakeClient as never,
+  });
+  await client.chat({
+    model: "claude-test",
+    system: "sys",
+    messages: [{ role: "user", content: "hi" }],
+    tools: [],
+    maxTokens: 64,
+    toolChoice: "required",
+  });
+  assert.deepEqual(fake.captured.params.tool_choice, { type: "auto" });
+});

--- a/packages/agent-sdk/tests/model-client-openai.test.ts
+++ b/packages/agent-sdk/tests/model-client-openai.test.ts
@@ -813,3 +813,99 @@ test("openai-compatible client does not mistake regular text for a leaked tool c
   assert.equal(response.toolCalls.length, 0);
   assert.match(response.text, /To call the tool/);
 });
+
+// ---------------------------------------------------------------------------
+// tool_choice
+// ---------------------------------------------------------------------------
+
+test("openai-compatible client defaults tool_choice to 'auto'", async () => {
+  let capturedBody: Record<string, unknown> | null = null;
+  const fetchImpl: typeof fetch = async (_url, init) => {
+    capturedBody = JSON.parse((init?.body as string) ?? "{}");
+    return new Response(
+      JSON.stringify({
+        choices: [{ finish_reason: "stop", message: { content: "ok" } }],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+  await client.chat({
+    model: "test-model",
+    system: "Test",
+    messages: [{ role: "user", content: "Hi" }],
+    tools: [
+      { name: "echo", description: "Echo back", input_schema: { type: "object", properties: {} } },
+    ],
+    maxTokens: 32000,
+  });
+
+  assert.equal((capturedBody as { tool_choice?: unknown } | null)?.tool_choice, "auto");
+});
+
+test("openai-compatible client forwards tool_choice='required' when set", async () => {
+  let capturedBody: Record<string, unknown> | null = null;
+  const fetchImpl: typeof fetch = async (_url, init) => {
+    capturedBody = JSON.parse((init?.body as string) ?? "{}");
+    return new Response(
+      JSON.stringify({
+        choices: [{ finish_reason: "stop", message: { content: "ok" } }],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+  await client.chat({
+    model: "test-model",
+    system: "Test",
+    messages: [{ role: "user", content: "Hi" }],
+    tools: [
+      { name: "echo", description: "Echo back", input_schema: { type: "object", properties: {} } },
+    ],
+    maxTokens: 32000,
+    toolChoice: "required",
+  });
+
+  assert.equal((capturedBody as { tool_choice?: unknown } | null)?.tool_choice, "required");
+});
+
+test("openai-compatible client downgrades toolChoice='required' to 'auto' when tools is empty", async () => {
+  // Providers reject `tool_choice: "required"` with no tools — silently
+  // downgrade to keep callers from having to guard at every site.
+  let capturedBody: Record<string, unknown> | null = null;
+  const fetchImpl: typeof fetch = async (_url, init) => {
+    capturedBody = JSON.parse((init?.body as string) ?? "{}");
+    return new Response(
+      JSON.stringify({
+        choices: [{ finish_reason: "stop", message: { content: "ok" } }],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+
+  const client = new OpenAICompatibleModelClient({
+    baseUrl: "http://localhost:1234/v1",
+    fetchImpl,
+  });
+  await client.chat({
+    model: "test-model",
+    system: "Test",
+    messages: [{ role: "user", content: "Hi" }],
+    tools: [],
+    maxTokens: 32000,
+    toolChoice: "required",
+  });
+
+  assert.equal((capturedBody as { tool_choice?: unknown } | null)?.tool_choice, "auto");
+});

--- a/src/cli/benchmark-run.ts
+++ b/src/cli/benchmark-run.ts
@@ -61,6 +61,18 @@ export interface BenchmarkRunResult {
   diffOut?: string;
   toolCalls: BenchmarkToolCallTrace[];
   toolUsage: BenchmarkToolUsageSummary;
+  /**
+   * Populated when the first attempt triggered a retry (no_action,
+   * no_mutation, or approval_seeking). Lets downstream analysis tell
+   * "model collapsed once and a retry rescued it" apart from "model went
+   * through normally" without needing verbose stderr capture. `null` when
+   * no retry fired.
+   */
+  retry: {
+    reason: BenchmarkRetryReason;
+    toolChoice: "required";
+    reasoningMaxTokens: number;
+  } | null;
 }
 
 export interface BenchmarkToolCallTrace {
@@ -774,6 +786,9 @@ export async function runBenchmarkCommand(argv: string[]): Promise<void> {
       verbose: args.verbose,
       ...(projectIndex !== undefined ? { projectIndex } : {}),
     });
+    let retryRecord:
+      | { reason: BenchmarkRetryReason; toolChoice: "required"; reasoningMaxTokens: number }
+      | null = null;
     const retryReason = getBenchmarkRetryReason({
       text: attempt.text,
       toolCallCount: countToolCallsInMessages(attempt.messages),
@@ -795,10 +810,28 @@ export async function runBenchmarkCommand(argv: string[]): Promise<void> {
       const priorReasoningBlock = buildPriorReasoningContext(
         attempt.reasoningContent,
       );
+      // Force a tool call on the retry AND cap reasoning. The first attempt
+      // already failed to act; `tool_choice: required` commits the model to
+      // emit a tool call, and the reasoning cap starves the dynamic-thinking
+      // path that produced the original collapse (Gemini 2.5 Pro routinely
+      // burns 10K+ reasoning tokens before returning nothing). The cap is
+      // above what a typical planning step needs (~1-2K tokens) but well
+      // below the observed collapse zone.
+      const RETRY_REASONING_MAX_TOKENS = 2000;
+      const retryConfig = {
+        ...config,
+        toolChoice: "required" as const,
+        reasoningMaxTokens: RETRY_REASONING_MAX_TOKENS,
+      };
+      retryRecord = {
+        reason: retryReason,
+        toolChoice: "required",
+        reasoningMaxTokens: RETRY_REASONING_MAX_TOKENS,
+      };
       attempt = await runBenchmarkAttempt(
         `${prompt}\n\n${reminder}${priorReasoningBlock}`,
         {
-          config,
+          config: retryConfig,
           modelClient,
           toolRegistry,
           verbose: args.verbose,
@@ -832,6 +865,7 @@ export async function runBenchmarkCommand(argv: string[]): Promise<void> {
       ...(diffOutPath ? { diffOut: diffOutPath } : {}),
       toolCalls,
       toolUsage: summarizeBenchmarkToolUsage(toolCalls, attempt.text),
+      retry: retryRecord,
     };
     const payload = JSON.stringify(result, null, 2);
 

--- a/src/cli/benchmark-run.ts
+++ b/src/cli/benchmark-run.ts
@@ -70,8 +70,8 @@ export interface BenchmarkRunResult {
    */
   retry: {
     reason: BenchmarkRetryReason;
-    toolChoice: "required";
-    reasoningMaxTokens: number;
+    toolChoice?: "required";
+    reasoningMaxTokens?: number;
   } | null;
 }
 
@@ -207,6 +207,21 @@ const CONFIRMATION_REQUEST_PATTERNS = [
 ];
 
 export type BenchmarkRetryReason = "approval_seeking" | "no_action" | "no_mutation";
+
+/**
+ * Whether the retry path should force a tool call (`toolChoice: "required"`)
+ * AND cap reasoning to 2K tokens on the retried attempt. Default is true —
+ * this is the validated rescue behavior for collapse-prone retries. Set
+ * `BENCHMARK_RETRY_FORCE_TOOLS=0` (or `false`/`no`/`off`) to disable; the
+ * retry will then run with the same model config as the first attempt.
+ *
+ * The escape hatch exists so a future model that misbehaves under
+ * `tool_choice: required` can be unblocked without a code revert.
+ */
+export function isRetryForceToolsEnabled(env: NodeJS.ProcessEnv): boolean {
+  const value = (env.BENCHMARK_RETRY_FORCE_TOOLS ?? "").trim().toLowerCase();
+  return value !== "0" && value !== "false" && value !== "no" && value !== "off";
+}
 
 const SPECIALIZED_TOOL_NAMES = new Set([
   "read_symbol",
@@ -787,7 +802,7 @@ export async function runBenchmarkCommand(argv: string[]): Promise<void> {
       ...(projectIndex !== undefined ? { projectIndex } : {}),
     });
     let retryRecord:
-      | { reason: BenchmarkRetryReason; toolChoice: "required"; reasoningMaxTokens: number }
+      | { reason: BenchmarkRetryReason; toolChoice?: "required"; reasoningMaxTokens?: number }
       | null = null;
     const retryReason = getBenchmarkRetryReason({
       text: attempt.text,
@@ -816,18 +831,23 @@ export async function runBenchmarkCommand(argv: string[]): Promise<void> {
       // path that produced the original collapse (Gemini 2.5 Pro routinely
       // burns 10K+ reasoning tokens before returning nothing). The cap is
       // above what a typical planning step needs (~1-2K tokens) but well
-      // below the observed collapse zone.
+      // below the observed collapse zone. Opt-out via env var.
       const RETRY_REASONING_MAX_TOKENS = 2000;
-      const retryConfig = {
-        ...config,
-        toolChoice: "required" as const,
-        reasoningMaxTokens: RETRY_REASONING_MAX_TOKENS,
-      };
-      retryRecord = {
-        reason: retryReason,
-        toolChoice: "required",
-        reasoningMaxTokens: RETRY_REASONING_MAX_TOKENS,
-      };
+      const forceTools = isRetryForceToolsEnabled(process.env);
+      const retryConfig = forceTools
+        ? {
+            ...config,
+            toolChoice: "required" as const,
+            reasoningMaxTokens: RETRY_REASONING_MAX_TOKENS,
+          }
+        : config;
+      retryRecord = forceTools
+        ? {
+            reason: retryReason,
+            toolChoice: "required",
+            reasoningMaxTokens: RETRY_REASONING_MAX_TOKENS,
+          }
+        : { reason: retryReason };
       attempt = await runBenchmarkAttempt(
         `${prompt}\n\n${reminder}${priorReasoningBlock}`,
         {

--- a/tests/benchmark-run.test.ts
+++ b/tests/benchmark-run.test.ts
@@ -9,6 +9,7 @@ import {
   getBenchmarkRetryReminder,
   getBenchmarkSystemPromptSuffix,
   isBenchmarkApprovalSeekingResponse,
+  isRetryForceToolsEnabled,
   looksLikeShellFileMutation,
   parseBenchmarkRunArgs,
   summarizeBenchmarkToolUsage,
@@ -509,4 +510,38 @@ test("benchmark tool usage summary reports repeated-call stops", () => {
       count: 3,
     },
   ]);
+});
+
+// ---------------------------------------------------------------------------
+// isRetryForceToolsEnabled
+// ---------------------------------------------------------------------------
+
+test("isRetryForceToolsEnabled defaults to true when env var unset", () => {
+  assert.equal(isRetryForceToolsEnabled({}), true);
+});
+
+test("isRetryForceToolsEnabled defaults to true when env var is empty/whitespace", () => {
+  assert.equal(isRetryForceToolsEnabled({ BENCHMARK_RETRY_FORCE_TOOLS: "" }), true);
+  assert.equal(isRetryForceToolsEnabled({ BENCHMARK_RETRY_FORCE_TOOLS: "   " }), true);
+});
+
+test("isRetryForceToolsEnabled returns false for explicit disable values", () => {
+  for (const value of ["0", "false", "no", "off", "FALSE", "NO", "Off"]) {
+    assert.equal(
+      isRetryForceToolsEnabled({ BENCHMARK_RETRY_FORCE_TOOLS: value }),
+      false,
+      `expected false for input ${JSON.stringify(value)}`,
+    );
+  }
+});
+
+test("isRetryForceToolsEnabled returns true for affirmative or unrecognized values", () => {
+  // Unrecognized values fall back to "on" — keeping the safe default for typos.
+  for (const value of ["1", "true", "yes", "on", "TRUE", "anything"]) {
+    assert.equal(
+      isRetryForceToolsEnabled({ BENCHMARK_RETRY_FORCE_TOOLS: value }),
+      true,
+      `expected true for input ${JSON.stringify(value)}`,
+    );
+  }
 });

--- a/tests/reasoning-effort.test.ts
+++ b/tests/reasoning-effort.test.ts
@@ -350,3 +350,62 @@ test("agent loop omits reasoningEffort when not configured", async () => {
   await agent.runTurn("Hello");
   assert.equal(capturedParams.reasoningEffort, undefined);
 });
+
+// ---------------------------------------------------------------------------
+// Agent loop passes toolChoice to model client
+// ---------------------------------------------------------------------------
+
+test("agent loop passes toolChoice to model client chat call when set", async () => {
+  let capturedToolChoice: unknown = "<unset>";
+
+  const config: AgentConfig = {
+    ...createTestAgentConfig("/tmp"),
+    toolChoice: "required",
+  };
+
+  const mockClient = {
+    async chat(params: { toolChoice?: unknown }): Promise<ModelResponse> {
+      capturedToolChoice = params.toolChoice;
+      return {
+        text: "Response",
+        toolCalls: [],
+        stopReason: "end_turn",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      };
+    },
+  };
+
+  const agent = new CodingAgent({
+    config,
+    modelClient: mockClient,
+    toolRegistry: new ToolRegistry([]),
+  });
+
+  await agent.runTurn("Hello");
+  assert.equal(capturedToolChoice, "required");
+});
+
+test("agent loop omits toolChoice when not configured", async () => {
+  let capturedParams: Record<string, unknown> = {};
+
+  const mockClient = {
+    async chat(params: Record<string, unknown>): Promise<ModelResponse> {
+      capturedParams = params;
+      return {
+        text: "Response",
+        toolCalls: [],
+        stopReason: "end_turn",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      };
+    },
+  };
+
+  const agent = new CodingAgent({
+    config: createTestAgentConfig("/tmp"),
+    modelClient: mockClient,
+    toolRegistry: new ToolRegistry([]),
+  });
+
+  await agent.runTurn("Hello");
+  assert.equal(capturedParams.toolChoice, undefined);
+});


### PR DESCRIPTION
## Summary

- Adds opt-in `toolChoice` ("auto" | "required" | "none") to `ModelClient.chat` and `AgentConfig`, plumbed through both providers (Anthropic `{type: "any"}`, OpenAI-compatible `"required"`). Silently downgrades to `"auto"` when the request has no tools.
- The benchmark retry path (PR #216, #219) now sets `toolChoice: "required"` AND `reasoningMaxTokens: 2000` on the retry attempt. The first commits the model to action; the second starves the dynamic-thinking path that caused the original collapse (Gemini 2.5 Pro routinely burns 10K+ reasoning tokens before returning nothing).
- Records `retry` metadata in `BenchmarkRunResult` so post-run analysis can distinguish "first attempt succeeded" from "retry rescued."

## Background

PR #219 surfaced extended-thinking content when the model collapses to pure thinking, but didn't fix the failure. Validation on `deb49033` × `gemini-2.5-pro` showed 2/3 runs hit the pure-thinking collapse and retries never recovered — the second attempt would just re-collapse with the same failure shape.

This change turns the retry into a real rescue mechanism. Tested over three n=3 batches on the same task:

| Batch | Retry intervention | Patches |
|---|---|---|
| pr219-validation | none | 2/3 (first-attempt variance; retry never fired) |
| toolchoice-v2 | `toolChoice: "required"` only | 1/3 (model often ignored the directive) |
| **this PR** | `toolChoice: "required"` + `reasoningMaxTokens: 2000` | **2/3 — both via retry rescue, not first-attempt luck** |

The cap is the load-bearing change: when OpenRouter→Gemini honors `tool_choice: required` (it sometimes doesn't), the cap stops per-step reasoning from running away and the model produces usable tool calls.

## Scope

- Real users unaffected: `config.toolChoice` is unset by default, the agent loop only forwards it when configured.
- The retry-only application means at worst this is a no-op on a turn that was already going to fail.
- 8 new unit tests across both clients + agent plumbing; full suite 779/781 (same 2 preexisting env-leak failures).

## Test plan

- [x] `npm test` — 779/781 (preexisting failures unchanged)
- [x] Build + pack a tarball, validate n=3 against `deb49033` × `gemini-2.5-pro`
- [x] Confirm `retry` field appears in `result.json` so post-run analysis can see rescue events
- [ ] Regression check via gemini-3-flash on minicode tasks + ts-bench (skipped per branch-merge discussion; SDK changes are additive, real-user paths don't set the new field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)