### PR TITLE
[codex] Fix Anthropic tool result handling

### DIFF
--- a/packages/agent-sdk/src/model/client.ts
+++ b/packages/agent-sdk/src/model/client.ts
@@ -24,6 +24,9 @@ import {
 const DEFAULT_MODEL_START_TIMEOUT_SECONDS = 60;
 const RETRY_ATTEMPTS = 3;
 const RETRY_BASE_DELAY_MS = 500;
+const ANTHROPIC_MIN_THINKING_BUDGET_TOKENS = 1024;
+const MISSING_TOOL_RESULT_CONTENT =
+  "Tool result unavailable because the previous minicode run ended before recording output.";
 
 /**
  * If the caller supplied an `outputSchema`, look for the synthetic
@@ -50,9 +53,33 @@ function toAnthropicMessages(
   messages: SessionMessage[],
 ): Anthropic.MessageParam[] {
   const converted: Anthropic.MessageParam[] = [];
+  let pendingToolCalls: ToolCall[] = [];
+  let pendingToolResults: Anthropic.ContentBlockParam[] = [];
+
+  const flushPendingToolResults = () => {
+    if (pendingToolResults.length === 0 && pendingToolCalls.length === 0) {
+      return;
+    }
+
+    for (const toolCall of pendingToolCalls) {
+      pendingToolResults.push({
+        type: "tool_result",
+        tool_use_id: toolCall.id,
+        content: MISSING_TOOL_RESULT_CONTENT,
+      });
+    }
+
+    converted.push({
+      role: "user",
+      content: pendingToolResults,
+    });
+    pendingToolResults = [];
+    pendingToolCalls = [];
+  };
 
   for (const message of messages) {
     if (message.role === "user") {
+      flushPendingToolResults();
       converted.push({
         role: "user",
         content: message.content,
@@ -61,6 +88,7 @@ function toAnthropicMessages(
     }
 
     if (message.role === "assistant") {
+      flushPendingToolResults();
       const content: Anthropic.ContentBlockParam[] = [];
       if (message.content.trim().length > 0) {
         content.push({
@@ -82,20 +110,26 @@ function toAnthropicMessages(
         role: "assistant",
         content: content.length > 0 ? content : "",
       });
+      pendingToolCalls = [...(message.toolCalls ?? [])];
       continue;
     }
 
-    converted.push({
-      role: "user",
-      content: [
-        {
-          type: "tool_result",
-          tool_use_id: message.toolCallId,
-          content: message.content,
-        },
-      ],
+    const pendingToolCallIndex = pendingToolCalls.findIndex(
+      (toolCall) => toolCall.id === message.toolCallId,
+    );
+    if (pendingToolCallIndex === -1) {
+      continue;
+    }
+
+    pendingToolResults.push({
+      type: "tool_result",
+      tool_use_id: message.toolCallId,
+      content: message.content,
     });
+    pendingToolCalls.splice(pendingToolCallIndex, 1);
   }
+
+  flushPendingToolResults();
 
   return converted;
 }
@@ -387,9 +421,6 @@ type OpenAICompatibleMessage =
       content: string;
     };
 
-const MISSING_TOOL_RESULT_CONTENT =
-  "Tool result unavailable because the previous minicode run ended before recording output.";
-
 function toOpenAICompatibleMessages(
   system: string,
   messages: SessionMessage[],
@@ -643,9 +674,11 @@ function effortToBudgetFraction(effort: ReasoningEffort): number {
 function mapAnthropicToolChoice(
   choice: ToolChoice | undefined,
   toolCount: number,
+  thinkingEnabled = false,
 ): { type: "auto" } | { type: "any" } | { type: "none" } | null {
   if (choice === undefined) return null;
   if (choice === "required" && toolCount === 0) return { type: "auto" };
+  if (choice === "required" && thinkingEnabled) return { type: "auto" };
   if (choice === "required") return { type: "any" };
   if (choice === "none") return { type: "none" };
   return { type: "auto" };
@@ -753,10 +786,27 @@ export class AnthropicModelClient implements ModelClient {
             Math.round(params.maxTokens * effortToBudgetFraction(params.reasoningEffort)),
           )
         : 0;
-    const cappedBudget =
+    let cappedBudget =
       params.reasoningMaxTokens !== undefined && params.reasoningMaxTokens > 0
         ? Math.min(effortBudget || params.reasoningMaxTokens, params.reasoningMaxTokens)
         : effortBudget;
+    if (
+      cappedBudget > 0 &&
+      cappedBudget < ANTHROPIC_MIN_THINKING_BUDGET_TOKENS
+    ) {
+      cappedBudget =
+        params.reasoningMaxTokens !== undefined &&
+        params.reasoningMaxTokens > 0 &&
+        params.reasoningMaxTokens < ANTHROPIC_MIN_THINKING_BUDGET_TOKENS
+          ? 0
+          : ANTHROPIC_MIN_THINKING_BUDGET_TOKENS;
+    }
+    if (cappedBudget >= params.maxTokens) {
+      cappedBudget = params.maxTokens - 1;
+    }
+    if (cappedBudget < ANTHROPIC_MIN_THINKING_BUDGET_TOKENS) {
+      cappedBudget = 0;
+    }
     const thinkingParam =
       cappedBudget > 0
         ? {
@@ -770,6 +820,7 @@ export class AnthropicModelClient implements ModelClient {
     const anthropicToolChoice = mapAnthropicToolChoice(
       params.toolChoice,
       toolsForRequest.length,
+      cappedBudget > 0,
     );
     const toolChoiceParam = anthropicToolChoice
       ? { tool_choice: anthropicToolChoice }

--- a/packages/agent-sdk/src/model/client.ts
+++ b/packages/agent-sdk/src/model/client.ts
@@ -54,9 +54,14 @@ function toAnthropicMessages(
 ): Anthropic.MessageParam[] {
   const converted: Anthropic.MessageParam[] = [];
   let pendingToolCalls: ToolCall[] = [];
+  // Anthropic requires consecutive tool_result blocks grouped into a
+  // single user message, so results are buffered until the next boundary.
   let pendingToolResults: Anthropic.ContentBlockParam[] = [];
 
-  const flushPendingToolResults = () => {
+  // Keep this recovery policy in sync with toOpenAICompatibleMessages:
+  // skip orphan tool results, and synthesize placeholders for interrupted
+  // histories where an assistant tool_use has no recorded result.
+  const flushMissingToolResults = () => {
     if (pendingToolResults.length === 0 && pendingToolCalls.length === 0) {
       return;
     }
@@ -79,7 +84,7 @@ function toAnthropicMessages(
 
   for (const message of messages) {
     if (message.role === "user") {
-      flushPendingToolResults();
+      flushMissingToolResults();
       converted.push({
         role: "user",
         content: message.content,
@@ -88,7 +93,7 @@ function toAnthropicMessages(
     }
 
     if (message.role === "assistant") {
-      flushPendingToolResults();
+      flushMissingToolResults();
       const content: Anthropic.ContentBlockParam[] = [];
       if (message.content.trim().length > 0) {
         content.push({
@@ -129,7 +134,7 @@ function toAnthropicMessages(
     pendingToolCalls.splice(pendingToolCallIndex, 1);
   }
 
-  flushPendingToolResults();
+  flushMissingToolResults();
 
   return converted;
 }
@@ -677,11 +682,27 @@ function mapAnthropicToolChoice(
   thinkingEnabled = false,
 ): { type: "auto" } | { type: "any" } | { type: "none" } | null {
   if (choice === undefined) return null;
-  if (choice === "required" && toolCount === 0) return { type: "auto" };
-  if (choice === "required" && thinkingEnabled) return { type: "auto" };
+  if (choice === "required" && (toolCount === 0 || thinkingEnabled)) {
+    // Anthropic does not support forced tool use with extended thinking.
+    return { type: "auto" };
+  }
   if (choice === "required") return { type: "any" };
   if (choice === "none") return { type: "none" };
   return { type: "auto" };
+}
+
+function clampAnthropicThinkingBudget(
+  requestedBudget: number,
+  maxTokens: number,
+): number {
+  const maxAllowed = maxTokens - 1;
+  if (
+    requestedBudget < ANTHROPIC_MIN_THINKING_BUDGET_TOKENS ||
+    maxAllowed < ANTHROPIC_MIN_THINKING_BUDGET_TOKENS
+  ) {
+    return 0;
+  }
+  return Math.min(requestedBudget, maxAllowed);
 }
 
 function resolveOpenAIToolChoice(
@@ -786,29 +807,26 @@ export class AnthropicModelClient implements ModelClient {
             Math.round(params.maxTokens * effortToBudgetFraction(params.reasoningEffort)),
           )
         : 0;
-    let cappedBudget =
+    const requestedBudget =
       params.reasoningMaxTokens !== undefined && params.reasoningMaxTokens > 0
         ? Math.min(effortBudget || params.reasoningMaxTokens, params.reasoningMaxTokens)
         : effortBudget;
-    if (
-      cappedBudget > 0 &&
-      cappedBudget < ANTHROPIC_MIN_THINKING_BUDGET_TOKENS
-    ) {
-      cappedBudget =
-        params.reasoningMaxTokens !== undefined &&
-        params.reasoningMaxTokens > 0 &&
-        params.reasoningMaxTokens < ANTHROPIC_MIN_THINKING_BUDGET_TOKENS
+    const normalizedBudget =
+      requestedBudget > 0 &&
+      requestedBudget < ANTHROPIC_MIN_THINKING_BUDGET_TOKENS
+        ? params.reasoningMaxTokens !== undefined &&
+          params.reasoningMaxTokens > 0 &&
+          params.reasoningMaxTokens < ANTHROPIC_MIN_THINKING_BUDGET_TOKENS
           ? 0
-          : ANTHROPIC_MIN_THINKING_BUDGET_TOKENS;
-    }
-    if (cappedBudget >= params.maxTokens) {
-      cappedBudget = params.maxTokens - 1;
-    }
-    if (cappedBudget < ANTHROPIC_MIN_THINKING_BUDGET_TOKENS) {
-      cappedBudget = 0;
-    }
+          : ANTHROPIC_MIN_THINKING_BUDGET_TOKENS
+        : requestedBudget;
+    const cappedBudget = clampAnthropicThinkingBudget(
+      normalizedBudget,
+      params.maxTokens,
+    );
+    const thinkingEnabled = cappedBudget > 0;
     const thinkingParam =
-      cappedBudget > 0
+      thinkingEnabled
         ? {
             thinking: {
               type: "enabled" as const,
@@ -820,7 +838,7 @@ export class AnthropicModelClient implements ModelClient {
     const anthropicToolChoice = mapAnthropicToolChoice(
       params.toolChoice,
       toolsForRequest.length,
-      cappedBudget > 0,
+      thinkingEnabled,
     );
     const toolChoiceParam = anthropicToolChoice
       ? { tool_choice: anthropicToolChoice }

--- a/packages/agent-sdk/tests/model-client-anthropic-structured-output.test.ts
+++ b/packages/agent-sdk/tests/model-client-anthropic-structured-output.test.ts
@@ -196,6 +196,121 @@ test("anthropic client passes through unchanged when outputSchema is omitted", a
   assert.equal(response.text, "hello");
 });
 
+test("anthropic client groups parallel tool results into one user message", async () => {
+  const fake = makeFakeClient({
+    finalMessage: {
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+  });
+
+  const client = new AnthropicModelClient("test-key", {
+    client: fake.fakeClient as never,
+  });
+
+  await client.chat({
+    model: "claude-test",
+    system: "sys",
+    messages: [
+      { role: "user", content: "inspect" },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { id: "tu_1", name: "read_file", input: { path: "a.ts" } },
+          { id: "tu_2", name: "search", input: { pattern: "foo" } },
+        ],
+      },
+      {
+        role: "tool",
+        toolCallId: "tu_1",
+        toolName: "read_file",
+        content: "file contents",
+      },
+      {
+        role: "tool",
+        toolCallId: "tu_2",
+        toolName: "search",
+        content: "search results",
+      },
+    ],
+    tools: [
+      { name: "read_file", description: "r", input_schema: { type: "object", properties: {} } },
+      { name: "search", description: "s", input_schema: { type: "object", properties: {} } },
+    ],
+    maxTokens: 64,
+  });
+
+  const messages = fake.captured.params.messages as Array<Record<string, unknown>>;
+  assert.equal(messages.length, 3);
+  assert.equal(messages[1]?.role, "assistant");
+  const assistantContent = messages[1]?.content as Array<Record<string, unknown>>;
+  assert.deepEqual(
+    assistantContent.map((block) => block.type),
+    ["tool_use", "tool_use"],
+  );
+
+  assert.equal(messages[2]?.role, "user");
+  const toolResults = messages[2]?.content as Array<Record<string, unknown>>;
+  assert.deepEqual(
+    toolResults.map((block) => block.type),
+    ["tool_result", "tool_result"],
+  );
+  assert.deepEqual(
+    toolResults.map((block) => block.tool_use_id),
+    ["tu_1", "tu_2"],
+  );
+  assert.deepEqual(
+    toolResults.map((block) => block.content),
+    ["file contents", "search results"],
+  );
+});
+
+test("anthropic client inserts placeholder results for interrupted tool calls", async () => {
+  const fake = makeFakeClient({
+    finalMessage: {
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+  });
+
+  const client = new AnthropicModelClient("test-key", {
+    client: fake.fakeClient as never,
+  });
+
+  await client.chat({
+    model: "claude-test",
+    system: "sys",
+    messages: [
+      { role: "user", content: "inspect" },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { id: "tu_1", name: "read_file", input: { path: "a.ts" } },
+        ],
+      },
+      { role: "user", content: "new request" },
+    ],
+    tools: [
+      { name: "read_file", description: "r", input_schema: { type: "object", properties: {} } },
+    ],
+    maxTokens: 64,
+  });
+
+  const messages = fake.captured.params.messages as Array<Record<string, unknown>>;
+  assert.equal(messages.length, 4);
+  const placeholderMessage = messages[2];
+  assert.equal(placeholderMessage?.role, "user");
+  const content = placeholderMessage?.content as Array<Record<string, unknown>>;
+  assert.equal(content[0]?.type, "tool_result");
+  assert.equal(content[0]?.tool_use_id, "tu_1");
+  assert.match(String(content[0]?.content), /Tool result unavailable/);
+  assert.deepEqual(messages[3], { role: "user", content: "new request" });
+});
+
 test("anthropic client extracts synthetic call alongside real tool calls", async () => {
   // Multi-tool step: model calls a real tool AND the synthetic tool.
   // The synthetic call should be extracted; the real call should
@@ -324,4 +439,55 @@ test("anthropic client downgrades toolChoice='required' to { type: 'auto' } when
     toolChoice: "required",
   });
   assert.deepEqual(fake.captured.params.tool_choice, { type: "auto" });
+});
+
+test("anthropic client clamps low thinking budgets to the provider minimum", async () => {
+  const fake = makeFakeClient({
+    finalMessage: {
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+  });
+  const client = new AnthropicModelClient("test-key", {
+    client: fake.fakeClient as never,
+  });
+  await client.chat({
+    model: "claude-test",
+    system: "sys",
+    messages: [{ role: "user", content: "hi" }],
+    tools: [
+      { name: "read_file", description: "read", input_schema: { type: "object", properties: {} } },
+    ],
+    maxTokens: 4096,
+    reasoningEffort: "minimal",
+    toolChoice: "required",
+  });
+  assert.deepEqual(fake.captured.params.thinking, {
+    type: "enabled",
+    budget_tokens: 1024,
+  });
+  assert.deepEqual(fake.captured.params.tool_choice, { type: "auto" });
+});
+
+test("anthropic client omits thinking when max token cap is below provider minimum", async () => {
+  const fake = makeFakeClient({
+    finalMessage: {
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+  });
+  const client = new AnthropicModelClient("test-key", {
+    client: fake.fakeClient as never,
+  });
+  await client.chat({
+    model: "claude-test",
+    system: "sys",
+    messages: [{ role: "user", content: "hi" }],
+    tools: [],
+    maxTokens: 512,
+    reasoningEffort: "high",
+  });
+  assert.equal(fake.captured.params.thinking, undefined);
 });

--- a/packages/agent-sdk/tests/model-client-anthropic-structured-output.test.ts
+++ b/packages/agent-sdk/tests/model-client-anthropic-structured-output.test.ts
@@ -267,6 +267,126 @@ test("anthropic client groups parallel tool results into one user message", asyn
   );
 });
 
+test("anthropic client keeps out-of-order tool results without placeholders", async () => {
+  const fake = makeFakeClient({
+    finalMessage: {
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+  });
+
+  const client = new AnthropicModelClient("test-key", {
+    client: fake.fakeClient as never,
+  });
+
+  await client.chat({
+    model: "claude-test",
+    system: "sys",
+    messages: [
+      { role: "user", content: "inspect" },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { id: "tu_1", name: "read_file", input: { path: "a.ts" } },
+          { id: "tu_2", name: "search", input: { pattern: "foo" } },
+        ],
+      },
+      {
+        role: "tool",
+        toolCallId: "tu_2",
+        toolName: "search",
+        content: "search results",
+      },
+      {
+        role: "tool",
+        toolCallId: "tu_1",
+        toolName: "read_file",
+        content: "file contents",
+      },
+    ],
+    tools: [
+      { name: "read_file", description: "r", input_schema: { type: "object", properties: {} } },
+      { name: "search", description: "s", input_schema: { type: "object", properties: {} } },
+    ],
+    maxTokens: 64,
+  });
+
+  const messages = fake.captured.params.messages as Array<Record<string, unknown>>;
+  const toolResults = messages[2]?.content as Array<Record<string, unknown>>;
+  assert.deepEqual(
+    toolResults.map((block) => block.tool_use_id),
+    ["tu_2", "tu_1"],
+  );
+  assert.deepEqual(
+    toolResults.map((block) => block.content),
+    ["search results", "file contents"],
+  );
+  assert.ok(
+    toolResults.every(
+      (block) => !String(block.content).includes("Tool result unavailable"),
+    ),
+  );
+});
+
+test("anthropic client drops orphan tool results", async () => {
+  const fake = makeFakeClient({
+    finalMessage: {
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+  });
+
+  const client = new AnthropicModelClient("test-key", {
+    client: fake.fakeClient as never,
+  });
+
+  await client.chat({
+    model: "claude-test",
+    system: "sys",
+    messages: [
+      { role: "user", content: "inspect" },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { id: "tu_1", name: "read_file", input: { path: "a.ts" } },
+        ],
+      },
+      {
+        role: "tool",
+        toolCallId: "tu_99",
+        toolName: "search",
+        content: "orphan result",
+      },
+      {
+        role: "tool",
+        toolCallId: "tu_1",
+        toolName: "read_file",
+        content: "file contents",
+      },
+    ],
+    tools: [
+      { name: "read_file", description: "r", input_schema: { type: "object", properties: {} } },
+      { name: "search", description: "s", input_schema: { type: "object", properties: {} } },
+    ],
+    maxTokens: 64,
+  });
+
+  const messages = fake.captured.params.messages as Array<Record<string, unknown>>;
+  const toolResults = messages[2]?.content as Array<Record<string, unknown>>;
+  assert.deepEqual(
+    toolResults.map((block) => block.tool_use_id),
+    ["tu_1"],
+  );
+  assert.deepEqual(
+    toolResults.map((block) => block.content),
+    ["file contents"],
+  );
+});
+
 test("anthropic client inserts placeholder results for interrupted tool calls", async () => {
   const fake = makeFakeClient({
     finalMessage: {
@@ -488,6 +608,29 @@ test("anthropic client omits thinking when max token cap is below provider minim
     tools: [],
     maxTokens: 512,
     reasoningEffort: "high",
+  });
+  assert.equal(fake.captured.params.thinking, undefined);
+});
+
+test("anthropic client omits thinking when explicit reasoning cap is below provider minimum", async () => {
+  const fake = makeFakeClient({
+    finalMessage: {
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+  });
+  const client = new AnthropicModelClient("test-key", {
+    client: fake.fakeClient as never,
+  });
+  await client.chat({
+    model: "claude-test",
+    system: "sys",
+    messages: [{ role: "user", content: "hi" }],
+    tools: [],
+    maxTokens: 8192,
+    reasoningEffort: "high",
+    reasoningMaxTokens: 512,
   });
   assert.equal(fake.captured.params.thinking, undefined);
 });


### PR DESCRIPTION
## Summary

Fixes the Anthropic model client request shaping for tool-use conversations and tightens Anthropic-specific request validation behavior.

## What changed

- Groups consecutive internal tool-result messages into a single Anthropic `user` message containing multiple `tool_result` blocks.
- Adds placeholder `tool_result` blocks when a previous assistant tool call is present in history without a recorded result, matching the OpenAI-compatible converter’s recovery behavior.
- Clamps Anthropic extended-thinking budgets to the provider minimum of 1024 tokens and omits `thinking` when the available output budget is too small.
- Downgrades `toolChoice: "required"` to Anthropic `auto` when extended thinking is enabled, avoiding an incompatible request shape.
- Adds focused mock-client coverage for parallel tool calls, interrupted histories, tool choice, structured output, and thinking budget behavior.

## Why

Anthropic’s Messages API is stricter than OpenAI-compatible chat formats: `tool_use` blocks need corresponding `tool_result` blocks immediately afterward in the next user message. The previous converter emitted each tool result as its own user message, which is risky for parallel tool calls and can lead to API 400s once the client is exercised against real Anthropic keys.

## Validation

- `PATH=/root/.nvm/versions/node/v22.16.0/bin:$PATH node --test --import tsx tests/model-client-anthropic-structured-output.test.ts`
- `PATH=/root/.nvm/versions/node/v22.16.0/bin:$PATH node --test --import tsx tests/model-client-*.test.ts`
- `PATH=/root/.nvm/versions/node/v22.16.0/bin:$PATH npm run build`
- `PATH=/root/.nvm/versions/node/v22.16.0/bin:$PATH npm run lint --workspace=packages/agent-sdk`

Note: I could not run a live Anthropic API smoke test because no `ANTHROPIC_API_KEY` is configured yet.