### PR TITLE
[codex] Add Anthropic web UI connect flow

### DIFF
--- a/packages/agent-sdk/src/agent/types.ts
+++ b/packages/agent-sdk/src/agent/types.ts
@@ -77,6 +77,7 @@ export interface AgentConfig {
   maxToolOutputChars: number;
   openAiBaseUrl: string;
   openAiApiKey?: string;
+  anthropicApiKey?: string;
 
   /** Deduplicate repeated read_file calls for the same file within a turn. Default: false */
   enableFileReadDedup?: boolean;

--- a/packages/agent-sdk/src/model/client.ts
+++ b/packages/agent-sdk/src/model/client.ts
@@ -1206,7 +1206,7 @@ export function createModelClient(config: AgentConfig): ModelClient {
     });
   }
   return new AnthropicModelClient(
-    process.env.ANTHROPIC_API_KEY,
+    config.anthropicApiKey ?? process.env.ANTHROPIC_API_KEY,
     { timeoutSeconds: config.modelTimeoutSeconds },
   );
 }

--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -31,6 +31,7 @@ export function formatConfigForDisplay(config: AgentConfig): string {
     "commandDenylist: " + config.commandDenylist.length + " patterns",
     "openAiBaseUrl: " + config.openAiBaseUrl,
     "openAiApiKey: " + (config.openAiApiKey ? "***" : "(unset)"),
+    "anthropicApiKey: " + (config.anthropicApiKey ? "***" : "(unset)"),
     "enableFileReadDedup: " + (config.enableFileReadDedup ?? false),
     "enableAdaptiveKeepRecent: " + (config.enableAdaptiveKeepRecent ?? false),
     "enableToolOutputTruncation: " + (config.enableToolOutputTruncation ?? false),
@@ -65,7 +66,11 @@ export function getConfigMissing(config: AgentConfig): string[] {
     missing.push("OPENROUTER_API_KEY is not set");
   }
 
-  if (config.modelProvider === "anthropic" && !process.env.ANTHROPIC_API_KEY) {
+  if (
+    config.modelProvider === "anthropic" &&
+    !config.anthropicApiKey?.trim() &&
+    !process.env.ANTHROPIC_API_KEY?.trim()
+  ) {
     missing.push("ANTHROPIC_API_KEY is not set");
   }
 
@@ -94,7 +99,9 @@ export function getConfiguredProvider(
   const explicitModelProvider = parseExplicitModelProvider(env.MODEL_PROVIDER);
 
   if (config.modelProvider === "anthropic") {
-    return explicitModelProvider === "anthropic" || hasExplicitConfigValue(env.ANTHROPIC_API_KEY)
+    return explicitModelProvider === "anthropic" ||
+      hasExplicitConfigValue(env.ANTHROPIC_API_KEY) ||
+      hasExplicitConfigValue(config.anthropicApiKey)
       ? "anthropic"
       : null;
   }
@@ -336,6 +343,7 @@ export async function loadAgentConfig(
   const openAiApiKey = isOpenRouter
     ? (env.OPENROUTER_API_KEY ?? env.OPENAI_API_KEY)
     : env.OPENAI_API_KEY;
+  const anthropicApiKey = env.ANTHROPIC_API_KEY;
 
   return {
     modelProvider: parseModelProvider(
@@ -386,6 +394,7 @@ export async function loadAgentConfig(
     ),
     openAiBaseUrl: rawBaseUrl,
     ...(openAiApiKey !== undefined ? { openAiApiKey } : {}),
+    ...(anthropicApiKey !== undefined ? { anthropicApiKey } : {}),
     enableFileReadDedup: parseBoolean(
       env.ENABLE_FILE_READ_DEDUP,
       true,
@@ -422,4 +431,3 @@ export async function loadAgentConfig(
     })(),
   };
 }
-

--- a/src/serve/agent-bridge.ts
+++ b/src/serve/agent-bridge.ts
@@ -45,7 +45,7 @@ export class AgentBridge {
   private modelClient: ReturnType<typeof createModelClient> | undefined;
   private projectIndex: ProjectIndex | undefined;
   private toolRegistry: ReturnType<typeof createToolRegistry> | undefined;
-  private sessionProviderConnection: "openrouter" | "openai-compatible" | null = null;
+  private sessionProviderConnection: "anthropic" | "openrouter" | "openai-compatible" | null = null;
   private busy = false;
   private abortController: AbortController | null = null;
   private broadcast: (msg: ServerMessage) => void;
@@ -395,6 +395,33 @@ export class AgentBridge {
     return this.sessionProviderConnection === "openai-compatible";
   }
 
+  isAnthropicSessionConnected(): boolean {
+    return this.sessionProviderConnection === "anthropic";
+  }
+
+  connectAnthropic(apiKey: string): void {
+    const trimmedKey = apiKey.trim();
+    if (!trimmedKey) {
+      throw new Error("Anthropic API key is required.");
+    }
+    if (this.busy) {
+      throw new Error("busy");
+    }
+
+    const currentSession = this.agent?.getSession();
+    (this.config as {
+      modelProvider: "anthropic";
+      anthropicApiKey: string;
+      openAiApiKey?: string;
+    }).modelProvider = "anthropic";
+    (this.config as { anthropicApiKey: string }).anthropicApiKey = trimmedKey;
+    delete (this.config as { openAiApiKey?: string }).openAiApiKey;
+    this.sessionProviderConnection = "anthropic";
+
+    this.modelClient = createModelClient(this.config);
+    this.agent = this.createAgent(currentSession);
+  }
+
   connectOpenRouter(apiKey: string): void {
     const trimmedKey = apiKey.trim();
     if (!trimmedKey) {
@@ -412,6 +439,7 @@ export class AgentBridge {
     }).modelProvider = "openai-compatible";
     (this.config as { openAiBaseUrl: string }).openAiBaseUrl = "https://openrouter.ai/api/v1";
     (this.config as { openAiApiKey: string }).openAiApiKey = trimmedKey;
+    delete (this.config as { anthropicApiKey?: string }).anthropicApiKey;
     this.sessionProviderConnection = "openrouter";
 
     this.modelClient = createModelClient(this.config);
@@ -441,6 +469,7 @@ export class AgentBridge {
     } else {
       delete (this.config as { openAiApiKey?: string }).openAiApiKey;
     }
+    delete (this.config as { anthropicApiKey?: string }).anthropicApiKey;
 
     this.sessionProviderConnection = "openai-compatible";
     this.modelClient = createModelClient(this.config);
@@ -463,6 +492,17 @@ export class AgentBridge {
       throw new Error("busy");
     }
     if (this.sessionProviderConnection !== "openai-compatible") {
+      return false;
+    }
+
+    return this.disconnectSessionProvider();
+  }
+
+  disconnectAnthropic(): boolean {
+    if (this.busy) {
+      throw new Error("busy");
+    }
+    if (this.sessionProviderConnection !== "anthropic") {
       return false;
     }
 

--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -64,6 +64,11 @@ interface OpenAiCompatibleConnectRequestBody {
   persistToEnv?: boolean;
 }
 
+interface AnthropicConnectRequestBody {
+  apiKey?: string;
+  persistToEnv?: boolean;
+}
+
 interface OpenRouterDisconnectResponse {
   ok: boolean;
   disconnected: boolean;
@@ -77,6 +82,7 @@ interface OpenRouterDisconnectResponse {
 }
 
 type OpenAiCompatibleDisconnectResponse = OpenRouterDisconnectResponse;
+type AnthropicDisconnectResponse = OpenRouterDisconnectResponse;
 
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
   res.writeHead(status, { "Content-Type": "application/json" });
@@ -198,6 +204,7 @@ export function createRequestHandler(
           provider: config.modelProvider,
           baseUrl: config.openAiBaseUrl,
           configuredProvider: getConfiguredProvider(config, resolvedEnv.values),
+          sessionAnthropicConnected: bridge.isAnthropicSessionConnected(),
           sessionOpenRouterConnected: bridge.isOpenRouterSessionConnected(),
           sessionOpenAiCompatibleConnected: bridge.isOpenAiCompatibleSessionConnected(),
           needsSetup: missing.length > 0,
@@ -324,6 +331,75 @@ export function createRequestHandler(
         return;
       }
 
+      if (pathname === "/api/anthropic/connect" && method === "POST") {
+        const body = JSON.parse(await readBody(req)) as AnthropicConnectRequestBody;
+        const trimmedApiKey = body.apiKey?.trim() ?? "";
+        if (!trimmedApiKey) {
+          sendJson(res, 400, { error: "apiKey is required" });
+          return;
+        }
+
+        try {
+          bridge.connectAnthropic(trimmedApiKey);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Failed to configure Anthropic";
+          sendJson(res, message === "busy" ? 409 : 400, { error: message });
+          return;
+        }
+
+        let persistedToEnv = false;
+        let persistedEnvPath: string | null = null;
+        let persistWarning: string | null = null;
+
+        if (body.persistToEnv === true) {
+          try {
+            const result = await upsertHomeEnvValues({
+              values: {
+                MODEL_PROVIDER: "anthropic",
+                ANTHROPIC_API_KEY: trimmedApiKey,
+              },
+              ...(minicodeHome ? { minicodeHome } : {}),
+            });
+            persistedToEnv = true;
+            persistedEnvPath = result.path;
+          } catch (error) {
+            const message = error instanceof Error ? error.message : "Failed to update ~/.minicode/.env";
+            persistedEnvPath = getHomeEnvPath(minicodeHome);
+            persistWarning = `Anthropic connected for this serve session, but minicode could not update ${persistedEnvPath}: ${message}`;
+          }
+        }
+
+        const missing = getConfigMissing(config);
+        const onlyModelMissing = missing.length === 1 && missing[0] === "MODEL is not set";
+        const message = persistWarning
+          ? `${persistWarning}${onlyModelMissing ? " Select a model to continue." : ""}`
+          : persistedToEnv
+            ? (
+              onlyModelMissing
+                ? "Anthropic connected for this serve session and saved to ~/.minicode/.env. Select a model to continue, and minicode will remember it for future runs."
+                : "Anthropic connected for this serve session and saved to ~/.minicode/.env for future runs."
+            )
+            : (
+              onlyModelMissing
+                ? "Anthropic connected for this serve session. Select a model to continue."
+                : "Anthropic connected for this serve session."
+            );
+        sendJson(res, 200, {
+          ok: true,
+          sessionOnly: true,
+          persistedToEnv,
+          persistedEnvPath,
+          persistWarning,
+          provider: config.modelProvider,
+          model: config.model,
+          baseUrl: config.openAiBaseUrl,
+          needsSetup: missing.length > 0,
+          missing,
+          message,
+        });
+        return;
+      }
+
       if (pathname === "/api/openai-compatible/connect" && method === "POST") {
         const body = JSON.parse(await readBody(req)) as OpenAiCompatibleConnectRequestBody;
         if (!body.baseUrl || typeof body.baseUrl !== "string") {
@@ -433,6 +509,34 @@ export function createRequestHandler(
           message: disconnected
             ? "Removed the session-only OpenRouter connection and restored your original provider settings."
             : "No session-only OpenRouter connection was active.",
+        };
+        sendJson(res, 200, body);
+        return;
+      }
+
+      if (pathname === "/api/anthropic/disconnect" && method === "POST") {
+        let disconnected = false;
+        try {
+          disconnected = bridge.disconnectAnthropic();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Failed to remove Anthropic session";
+          sendJson(res, message === "busy" ? 409 : 400, { error: message });
+          return;
+        }
+
+        const missing = getConfigMissing(config);
+        const body: AnthropicDisconnectResponse = {
+          ok: true,
+          disconnected,
+          sessionOnly: true,
+          provider: config.modelProvider,
+          model: config.model,
+          baseUrl: config.openAiBaseUrl,
+          needsSetup: missing.length > 0,
+          missing,
+          message: disconnected
+            ? "Removed the session-only Anthropic connection and restored your original provider settings."
+            : "No session-only Anthropic connection was active.",
         };
         sendJson(res, 200, body);
         return;

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -22,6 +22,7 @@ interface StatusResponse {
   provider: string;
   baseUrl?: string;
   configuredProvider?: "anthropic" | "openrouter" | "openai-compatible" | null;
+  sessionAnthropicConnected?: boolean;
   sessionOpenRouterConnected?: boolean;
   sessionOpenAiCompatibleConnected?: boolean;
   needsSetup?: boolean;
@@ -147,6 +148,8 @@ interface OpenRouterDisconnectResponse {
 type OpenAiCompatibleConnectResponse = OpenRouterConnectResponse;
 
 type OpenAiCompatibleDisconnectResponse = OpenRouterDisconnectResponse;
+type AnthropicConnectResponse = OpenRouterConnectResponse;
+type AnthropicDisconnectResponse = OpenRouterDisconnectResponse;
 
 interface ModelSwitchResponse {
   model: string;
@@ -204,17 +207,31 @@ const openAiCompatibleBaseUrlInput = document.getElementById("openai-compatible-
 const openAiCompatibleApiKeyInput = document.getElementById("openai-compatible-api-key") as HTMLInputElement;
 const openAiCompatiblePersistCheckbox = document.getElementById("openai-compatible-persist-checkbox") as HTMLInputElement;
 const openAiCompatibleConnectStatus = document.getElementById("openai-compatible-connect-status")!;
+const anthropicConnectModal = document.getElementById("anthropic-connect-modal")!;
+const anthropicConnectBackdrop = document.getElementById("anthropic-connect-backdrop")!;
+const anthropicConnectCloseBtn = document.getElementById("anthropic-connect-close") as HTMLButtonElement;
+const anthropicConnectCancelBtn = document.getElementById("anthropic-connect-cancel") as HTMLButtonElement;
+const anthropicConnectContinueBtn = document.getElementById("anthropic-connect-continue") as HTMLButtonElement;
+const anthropicApiKeyInput = document.getElementById("anthropic-api-key") as HTMLInputElement;
+const anthropicPersistCheckbox = document.getElementById("anthropic-persist-checkbox") as HTMLInputElement;
+const anthropicConnectStatus = document.getElementById("anthropic-connect-status")!;
 const settingsPath = document.getElementById("settings-path")!;
 const settingsList = document.getElementById("settings-list")!;
 const settingsBanner = document.getElementById("settings-banner")!;
+const settingsAnthropicSession = document.getElementById("settings-anthropic-session")!;
+const settingsAnthropicSessionMeta = document.getElementById("settings-anthropic-session-meta")!;
 const settingsOpenRouterSession = document.getElementById("settings-openrouter-session")!;
 const settingsOpenRouterSessionMeta = document.getElementById("settings-openrouter-session-meta")!;
 const settingsOpenAiCompatibleSession = document.getElementById("settings-openai-compatible-session")!;
 const settingsOpenAiCompatibleSessionMeta = document.getElementById("settings-openai-compatible-session-meta")!;
 const settingsSaveBtn = document.getElementById("settings-save") as HTMLButtonElement;
 const settingsResetBtn = document.getElementById("settings-reset") as HTMLButtonElement;
+const disconnectAnthropicBtn = document.getElementById("disconnect-anthropic-btn") as HTMLButtonElement;
 const disconnectOpenRouterBtn = document.getElementById("disconnect-openrouter-btn") as HTMLButtonElement;
 const disconnectOpenAiCompatibleBtn = document.getElementById("disconnect-openai-compatible-btn") as HTMLButtonElement;
+const connectAnthropicButtons = Array.from(
+  document.querySelectorAll<HTMLButtonElement>("[data-anthropic-connect]"),
+);
 const connectOpenRouterButtons = Array.from(
   document.querySelectorAll<HTMLButtonElement>("[data-openrouter-connect]"),
 );
@@ -234,6 +251,7 @@ let hadToolCalls = false;
 let settingsPayload: SettingsPayload | null = null;
 let activeSavedSession: SessionMeta | null = null;
 let activeBaseUrl = "";
+let sessionAnthropicConnected = false;
 let sessionOpenRouterConnected = false;
 let sessionOpenAiCompatibleConnected = false;
 const sessionRefreshTracker = createLatestRequestTracker();
@@ -345,6 +363,16 @@ function clearOpenAiCompatibleConnectStatus(): void {
   openAiCompatibleConnectStatus.className = "config-connect-status hidden";
 }
 
+function setAnthropicConnectStatus(message: string, tone: "info" | "success" | "error"): void {
+  anthropicConnectStatus.textContent = message;
+  anthropicConnectStatus.className = `config-connect-status ${tone}`;
+}
+
+function clearAnthropicConnectStatus(): void {
+  anthropicConnectStatus.textContent = "";
+  anthropicConnectStatus.className = "config-connect-status hidden";
+}
+
 function normalizeBaseUrl(value: string): string {
   return value.trim().replace(/\/+$/, "");
 }
@@ -392,6 +420,10 @@ function isOpenRouterConnectModalOpen(): boolean {
 
 function isOpenAiCompatibleConnectModalOpen(): boolean {
   return isModalOpen(openAiCompatibleConnectModal);
+}
+
+function isAnthropicConnectModalOpen(): boolean {
+  return isModalOpen(anthropicConnectModal);
 }
 
 function encodeBase64Url(bytes: Uint8Array): string {
@@ -610,6 +642,88 @@ async function disconnectOpenAiCompatible(): Promise<void> {
   }
 }
 
+async function connectAnthropic(): Promise<void> {
+  const apiKey = anthropicApiKeyInput.value.trim();
+
+  if (!apiKey) {
+    setAnthropicConnectStatus("API key is required.", "error");
+    return;
+  }
+
+  clearAnthropicConnectStatus();
+  clearSettingsBanner();
+  anthropicConnectContinueBtn.disabled = true;
+
+  try {
+    const res = await fetch("/api/anthropic/connect", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        apiKey,
+        persistToEnv: anthropicPersistCheckbox.checked,
+      }),
+    });
+    const body = await res.json() as AnthropicConnectResponse | { error: string };
+    if (!res.ok) {
+      throw new Error("error" in body ? body.error : `Failed to connect Anthropic (${res.status})`);
+    }
+
+    activeBaseUrl = body.baseUrl;
+    addMessage(body.message, "thinking");
+    const tone = body.persistWarning
+      ? "info"
+      : (body.needsSetup ? "info" : "success");
+    setConfigConnectStatus(body.message, tone);
+    setSettingsBanner(body.message, tone === "success" ? "success" : "info");
+    closeAnthropicConnectModal();
+    await fetchStatus();
+    await refreshModelList();
+
+    const onlyModelMissing =
+      body.needsSetup &&
+      body.missing.length === 1 &&
+      body.missing[0]?.includes("MODEL");
+    if (onlyModelMissing) {
+      modelDropdown.classList.remove("hidden");
+      sessionDropdown.classList.add("hidden");
+      focusModelSearchInput();
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to connect Anthropic";
+    setAnthropicConnectStatus(message, "error");
+  } finally {
+    anthropicConnectContinueBtn.disabled = false;
+  }
+}
+
+async function disconnectAnthropic(): Promise<void> {
+  disconnectAnthropicBtn.disabled = true;
+  clearSettingsBanner();
+
+  try {
+    const res = await fetch("/api/anthropic/disconnect", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+    const body = await res.json() as AnthropicDisconnectResponse | { error: string };
+    if (!res.ok) {
+      throw new Error("error" in body ? body.error : `Failed to disconnect Anthropic (${res.status})`);
+    }
+
+    activeBaseUrl = body.baseUrl;
+    addMessage(body.message, "thinking");
+    setSettingsBanner(body.message, body.disconnected ? "success" : "info");
+    clearConfigConnectStatus();
+    await fetchStatus();
+    await refreshModelList();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to disconnect Anthropic";
+    setSettingsBanner(message, "error");
+  } finally {
+    disconnectAnthropicBtn.disabled = false;
+  }
+}
+
 async function fetchStatus(): Promise<void> {
   try {
     const res = await fetch("/api/status");
@@ -618,6 +732,7 @@ async function fetchStatus(): Promise<void> {
     modelInfo.classList.toggle("placeholder", !data.model);
     activeModel = data.model;
     activeBaseUrl = data.baseUrl ?? "";
+    sessionAnthropicConnected = data.sessionAnthropicConnected ?? false;
     sessionOpenRouterConnected = data.sessionOpenRouterConnected ?? false;
     sessionOpenAiCompatibleConnected = data.sessionOpenAiCompatibleConnected ?? false;
     renderSessionProviderControls();
@@ -988,34 +1103,57 @@ function clearSettingsBanner(): void {
 }
 
 function renderSessionProviderControls(): void {
+  if (sessionAnthropicConnected) {
+    settingsAnthropicSession.classList.remove("hidden");
+    settingsAnthropicSessionMeta.textContent =
+      "This session-only connection overrides your original provider settings until you disconnect or restart serve.";
+    settingsOpenRouterSession.classList.add("hidden");
+    settingsOpenRouterSessionMeta.textContent = "";
+    settingsOpenAiCompatibleSession.classList.add("hidden");
+    settingsOpenAiCompatibleSessionMeta.textContent = "";
+    disconnectAnthropicBtn.disabled = false;
+    disconnectOpenRouterBtn.disabled = false;
+    disconnectOpenAiCompatibleBtn.disabled = false;
+    return;
+  }
+
   if (sessionOpenRouterConnected) {
+    settingsAnthropicSession.classList.add("hidden");
+    settingsAnthropicSessionMeta.textContent = "";
     settingsOpenRouterSession.classList.remove("hidden");
     settingsOpenRouterSessionMeta.textContent = activeBaseUrl
       ? `Endpoint: ${activeBaseUrl}. This session-only connection overrides your original provider settings until you disconnect or restart serve.`
       : "This session-only connection overrides your original provider settings until you disconnect or restart serve.";
     settingsOpenAiCompatibleSession.classList.add("hidden");
     settingsOpenAiCompatibleSessionMeta.textContent = "";
+    disconnectAnthropicBtn.disabled = false;
     disconnectOpenRouterBtn.disabled = false;
     disconnectOpenAiCompatibleBtn.disabled = false;
     return;
   }
 
   if (sessionOpenAiCompatibleConnected) {
+    settingsAnthropicSession.classList.add("hidden");
+    settingsAnthropicSessionMeta.textContent = "";
     settingsOpenAiCompatibleSession.classList.remove("hidden");
     settingsOpenAiCompatibleSessionMeta.textContent = activeBaseUrl
       ? `Endpoint: ${activeBaseUrl}. This session-only connection overrides your original provider settings until you disconnect or restart serve.`
       : "This session-only connection overrides your original provider settings until you disconnect or restart serve.";
     settingsOpenRouterSession.classList.add("hidden");
     settingsOpenRouterSessionMeta.textContent = "";
+    disconnectAnthropicBtn.disabled = false;
     disconnectOpenRouterBtn.disabled = false;
     disconnectOpenAiCompatibleBtn.disabled = false;
     return;
   }
 
+  settingsAnthropicSession.classList.add("hidden");
+  settingsAnthropicSessionMeta.textContent = "";
   settingsOpenRouterSession.classList.add("hidden");
   settingsOpenRouterSessionMeta.textContent = "";
   settingsOpenAiCompatibleSession.classList.add("hidden");
   settingsOpenAiCompatibleSessionMeta.textContent = "";
+  disconnectAnthropicBtn.disabled = false;
   disconnectOpenRouterBtn.disabled = false;
   disconnectOpenAiCompatibleBtn.disabled = false;
 }
@@ -1291,6 +1429,24 @@ function closeOpenAiCompatibleConnectModal(): void {
   closeModal(openAiCompatibleConnectModal);
   openAiCompatibleConnectContinueBtn.disabled = false;
   clearOpenAiCompatibleConnectStatus();
+}
+
+function openAnthropicConnectModal(): void {
+  closeHeaderMenus();
+  openModal(anthropicConnectModal);
+  anthropicApiKeyInput.value = "";
+  anthropicPersistCheckbox.checked = false;
+  anthropicConnectContinueBtn.disabled = false;
+  clearAnthropicConnectStatus();
+  requestAnimationFrame(() => {
+    anthropicApiKeyInput.focus();
+  });
+}
+
+function closeAnthropicConnectModal(): void {
+  closeModal(anthropicConnectModal);
+  anthropicConnectContinueBtn.disabled = false;
+  clearAnthropicConnectStatus();
 }
 
 // Form handling
@@ -1876,6 +2032,18 @@ openAiCompatibleConnectCancelBtn.addEventListener("click", () => {
   closeOpenAiCompatibleConnectModal();
 });
 
+anthropicConnectBackdrop.addEventListener("click", () => {
+  closeAnthropicConnectModal();
+});
+
+anthropicConnectCloseBtn.addEventListener("click", () => {
+  closeAnthropicConnectModal();
+});
+
+anthropicConnectCancelBtn.addEventListener("click", () => {
+  closeAnthropicConnectModal();
+});
+
 settingsResetBtn.addEventListener("click", () => {
   clearSettingsBanner();
   renderSettings();
@@ -1937,6 +2105,10 @@ settingsList.addEventListener("change", () => {
   updateSettingsActions();
 });
 
+disconnectAnthropicBtn.addEventListener("click", () => {
+  void disconnectAnthropic();
+});
+
 disconnectOpenRouterBtn.addEventListener("click", () => {
   void disconnectOpenRouter();
 });
@@ -1957,10 +2129,20 @@ document.addEventListener("keydown", (event: KeyboardEvent) => {
     closeOpenAiCompatibleConnectModal();
     return;
   }
+  if (isAnthropicConnectModalOpen()) {
+    closeAnthropicConnectModal();
+    return;
+  }
   if (isSettingsModalOpen()) {
     closeSettings();
   }
 });
+
+for (const button of connectAnthropicButtons) {
+  button.addEventListener("click", () => {
+    openAnthropicConnectModal();
+  });
+}
 
 for (const button of connectOpenRouterButtons) {
   button.addEventListener("click", () => {
@@ -1987,6 +2169,10 @@ openAiCompatibleApiKeyInput.addEventListener("input", () => {
   clearOpenAiCompatibleConnectStatus();
 });
 
+anthropicApiKeyInput.addEventListener("input", () => {
+  clearAnthropicConnectStatus();
+});
+
 openRouterConnectContinueBtn.addEventListener("click", () => {
   openRouterConnectContinueBtn.disabled = true;
   closeOpenRouterConnectModal();
@@ -1995,6 +2181,10 @@ openRouterConnectContinueBtn.addEventListener("click", () => {
 
 openAiCompatibleConnectContinueBtn.addEventListener("click", () => {
   void connectOpenAiCompatible();
+});
+
+anthropicConnectContinueBtn.addEventListener("click", () => {
+  void connectAnthropic();
 });
 
 // -- Resizable pane divider --

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -113,6 +113,18 @@
                   <span class="config-overlay-action-note">Starts with common presets, but the endpoint stays editable.</span>
                 </div>
               </div>
+
+              <div id="config-overlay-anthropic" class="config-overlay-spotlight config-overlay-spotlight-secondary">
+                <div class="config-overlay-spotlight-copy">
+                  <span class="config-overlay-spotlight-badge">Hosted model</span>
+                  <strong>Connect Anthropic</strong>
+                  <p>Paste an Anthropic API key to connect this <code>minicode serve</code> session without editing config files first.</p>
+                </div>
+                <div class="config-overlay-actions config-overlay-spotlight-actions">
+                  <button id="connect-anthropic-btn" class="dropdown-action" type="button" data-anthropic-connect="true">Connect Anthropic</button>
+                  <span class="config-overlay-action-note">Session-only by default, with optional persistence.</span>
+                </div>
+              </div>
             </div>
             <p id="config-overlay-intro">minicode needs a model provider to run. Configure one of the following:</p>
             <div class="config-overlay-options">
@@ -221,6 +233,13 @@ MODEL=your-model-name</pre>
       </div>
 
       <div id="settings-banner" class="settings-banner hidden" role="status" aria-live="polite"></div>
+      <div id="settings-anthropic-session" class="settings-session-banner hidden" role="status" aria-live="polite">
+        <div class="settings-session-copy">
+          <div class="settings-session-title">Anthropic is connected for this serve session</div>
+          <div id="settings-anthropic-session-meta" class="settings-session-meta"></div>
+        </div>
+        <button id="disconnect-anthropic-btn" class="header-btn" type="button">Disconnect Anthropic</button>
+      </div>
       <div id="settings-openrouter-session" class="settings-session-banner hidden" role="status" aria-live="polite">
         <div class="settings-session-copy">
           <div class="settings-session-title">OpenRouter is connected for this serve session</div>
@@ -241,6 +260,7 @@ MODEL=your-model-name</pre>
           <div class="settings-session-meta">Temporarily connect a provider for this serve session, or optionally save it to <code>~/.minicode/.env</code>.</div>
         </div>
         <div class="settings-provider-shortcuts-actions">
+          <button class="header-btn" type="button" data-anthropic-connect="true">Connect Anthropic</button>
           <button class="header-btn" type="button" data-openrouter-connect="true">Connect OpenRouter</button>
           <button class="header-btn" type="button" data-openai-compatible-connect="true">Connect OpenAI-compatible</button>
         </div>
@@ -368,6 +388,56 @@ MODEL=your-model-name</pre>
         <div class="settings-actions">
           <button id="openai-compatible-connect-cancel" class="header-btn" type="button">Cancel</button>
           <button id="openai-compatible-connect-continue" class="dropdown-action" type="button">Continue</button>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <div id="anthropic-connect-modal" class="modal hidden" aria-hidden="true">
+    <div id="anthropic-connect-backdrop" class="modal-backdrop"></div>
+    <section class="modal-panel modal-panel-compact" role="dialog" aria-modal="true" aria-labelledby="anthropic-connect-title">
+      <div class="modal-header">
+        <div>
+          <h2 id="anthropic-connect-title">Connect Anthropic</h2>
+          <p class="modal-subtitle">Configure Anthropic for this <code>minicode serve</code> session and optionally save it for future runs.</p>
+        </div>
+        <button id="anthropic-connect-close" class="header-btn" type="button">Close</button>
+      </div>
+
+      <div class="openrouter-connect-body">
+        <p class="openrouter-connect-lead">
+          Paste an Anthropic API key to point this serve session at the Anthropic runtime path. By default, the key is held only by this live session.
+        </p>
+
+        <div class="openrouter-connect-note">
+          <strong>Connection details</strong>
+          <p>minicode will use <code>MODEL_PROVIDER=anthropic</code> for this session. Select an Anthropic model afterward if one is not already configured.</p>
+        </div>
+
+        <label class="provider-input-group" for="anthropic-api-key">
+          <span class="provider-input-label">API key</span>
+          <input id="anthropic-api-key" class="provider-input" type="password" placeholder="sk-ant-..." spellcheck="false" autocomplete="off" />
+        </label>
+
+        <label class="openrouter-persist-toggle" for="anthropic-persist-checkbox">
+          <input id="anthropic-persist-checkbox" type="checkbox" />
+          <span>Save the Anthropic credentials and provider default to <code>~/.minicode/.env</code> after connecting.</span>
+        </label>
+
+        <p class="openrouter-connect-help">
+          When enabled, minicode will write <code>ANTHROPIC_API_KEY</code> and set <code>MODEL_PROVIDER=anthropic</code>. Nothing is written unless you check the box.
+        </p>
+
+        <p id="anthropic-connect-status" class="config-connect-status hidden"></p>
+      </div>
+
+      <div class="modal-footer">
+        <p class="settings-footnote">
+          Session-only credentials are cleared when this serve process exits or you disconnect.
+        </p>
+        <div class="settings-actions">
+          <button id="anthropic-connect-cancel" class="header-btn" type="button">Cancel</button>
+          <button id="anthropic-connect-continue" class="dropdown-action" type="button">Continue</button>
         </div>
       </div>
     </section>

--- a/src/web/setup-overlay-state.ts
+++ b/src/web/setup-overlay-state.ts
@@ -40,7 +40,7 @@ export function deriveSetupOverlayState(input: SetupOverlayStateInput): SetupOve
 
   return {
     introText,
-    hideQuickConnects: hasConfiguredProvider,
+    hideQuickConnects: false,
     hideOpenRouterSpotlight: configuredProvider === "openrouter" && isOnlyModelMissing,
     missingItems: filteredMissingItems,
     showModelSelectionHint: hasConfiguredProvider,

--- a/tests/config-integration.test.ts
+++ b/tests/config-integration.test.ts
@@ -508,6 +508,18 @@ describe("getConfigMissing and getConfigSetupMessage", () => {
     });
   });
 
+  test("returns no ANTHROPIC_API_KEY missing when session config has key", async () => {
+    await withEnv({ ANTHROPIC_API_KEY: undefined }, async () => {
+      const config = {
+        ...createTestAgentConfig("/tmp"),
+        modelProvider: "anthropic" as const,
+        model: "claude-sonnet-4-20250514",
+        anthropicApiKey: "sk-ant-session",
+      };
+      assert.deepEqual(getConfigMissing(config), []);
+    });
+  });
+
   test("does not require ANTHROPIC_API_KEY for openai-compatible provider", async () => {
     await withEnv({ ANTHROPIC_API_KEY: undefined }, async () => {
       const config = {
@@ -1075,5 +1087,15 @@ describe("getConfiguredProvider", () => {
       const resolvedEnv = await resolveConfigEnv({ minicodeHome: home });
       assert.equal(getConfiguredProvider(config, resolvedEnv.values), "openai-compatible");
     });
+  });
+
+  test("returns anthropic when session config has an Anthropic key", async () => {
+    const config = {
+      ...createTestAgentConfig("/tmp"),
+      modelProvider: "anthropic" as const,
+      anthropicApiKey: "sk-ant-session",
+    };
+
+    assert.equal(getConfiguredProvider(config, {}), "anthropic");
   });
 });

--- a/tests/serve.integration.test.ts
+++ b/tests/serve.integration.test.ts
@@ -26,6 +26,8 @@ class MockBridge extends AgentBridge {
   turnHistory: string[] = [];
   openRouterKey: string | undefined;
   openRouterSessionActive = false;
+  anthropicApiKey: string | undefined;
+  anthropicSessionActive = false;
   openAiCompatibleApiKey: string | undefined;
   openAiCompatibleSessionActive = false;
   refreshIndexCount = 0;
@@ -117,17 +119,22 @@ class MockBridge extends AgentBridge {
   override connectOpenRouter(apiKey: string): void {
     this.openRouterKey = apiKey;
     this.openRouterSessionActive = true;
+    this.anthropicApiKey = undefined;
+    this.anthropicSessionActive = false;
     this.openAiCompatibleApiKey = undefined;
     this.openAiCompatibleSessionActive = false;
     this._config.modelProvider = "openai-compatible";
     this._config.openAiBaseUrl = "https://openrouter.ai/api/v1";
     this._config.openAiApiKey = apiKey;
+    delete this._config.anthropicApiKey;
   }
 
   override connectOpenAiCompatible(baseUrl: string, apiKey?: string): void {
     this.openAiCompatibleSessionActive = true;
     this.openRouterKey = undefined;
     this.openRouterSessionActive = false;
+    this.anthropicApiKey = undefined;
+    this.anthropicSessionActive = false;
     this.openAiCompatibleApiKey = apiKey?.trim() || undefined;
     this._config.modelProvider = "openai-compatible";
     this._config.openAiBaseUrl = baseUrl.trim().replace(/\/+$/, "");
@@ -136,6 +143,19 @@ class MockBridge extends AgentBridge {
     } else {
       delete this._config.openAiApiKey;
     }
+    delete this._config.anthropicApiKey;
+  }
+
+  override connectAnthropic(apiKey: string): void {
+    this.anthropicApiKey = apiKey;
+    this.anthropicSessionActive = true;
+    this.openRouterKey = undefined;
+    this.openRouterSessionActive = false;
+    this.openAiCompatibleApiKey = undefined;
+    this.openAiCompatibleSessionActive = false;
+    this._config.modelProvider = "anthropic";
+    this._config.anthropicApiKey = apiKey;
+    delete this._config.openAiApiKey;
   }
 
   override disconnectOpenRouter(): boolean {
@@ -149,6 +169,7 @@ class MockBridge extends AgentBridge {
     this._config.model = this._baseConfig.model;
     this._config.openAiBaseUrl = this._baseConfig.openAiBaseUrl;
     delete this._config.openAiApiKey;
+    delete this._config.anthropicApiKey;
     return true;
   }
 
@@ -167,11 +188,31 @@ class MockBridge extends AgentBridge {
     this._config.model = this._baseConfig.model;
     this._config.openAiBaseUrl = this._baseConfig.openAiBaseUrl;
     delete this._config.openAiApiKey;
+    delete this._config.anthropicApiKey;
     return true;
   }
 
   override isOpenAiCompatibleSessionConnected(): boolean {
     return this.openAiCompatibleSessionActive;
+  }
+
+  override disconnectAnthropic(): boolean {
+    if (!this.anthropicSessionActive) {
+      return false;
+    }
+
+    this.anthropicSessionActive = false;
+    this.anthropicApiKey = undefined;
+    this._config.modelProvider = this._baseConfig.modelProvider;
+    this._config.model = this._baseConfig.model;
+    this._config.openAiBaseUrl = this._baseConfig.openAiBaseUrl;
+    delete this._config.openAiApiKey;
+    delete this._config.anthropicApiKey;
+    return true;
+  }
+
+  override isAnthropicSessionConnected(): boolean {
+    return this.anthropicSessionActive;
   }
 
   override switchModel(modelId: string): void {
@@ -927,6 +968,124 @@ test("GET /api/status exposes OpenRouter session state and base URL", async () =
   assert.equal(body.sessionOpenRouterConnected, true);
 });
 
+test("POST /api/anthropic/connect stores a session-only Anthropic key", async () => {
+  const bridge = new MockBridge();
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/anthropic/connect`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ apiKey: " sk-ant-session-key " }),
+  });
+  assert.equal(res.status, 200);
+
+  const body = await res.json() as {
+    ok: boolean;
+    sessionOnly: boolean;
+    persistedToEnv: boolean;
+    persistedEnvPath: string | null;
+    persistWarning: string | null;
+    needsSetup: boolean;
+    missing: string[];
+    message: string;
+  };
+  assert.equal(body.ok, true);
+  assert.equal(body.sessionOnly, true);
+  assert.equal(body.persistedToEnv, false);
+  assert.equal(body.persistedEnvPath, null);
+  assert.equal(body.persistWarning, null);
+  assert.equal(body.needsSetup, false);
+  assert.deepEqual(body.missing, []);
+  assert.equal(body.message, "Anthropic connected for this serve session.");
+  assert.equal(bridge.getConfig().modelProvider, "anthropic");
+  assert.equal(bridge.getConfig().anthropicApiKey, "sk-ant-session-key");
+  assert.equal(bridge.getConfig().openAiApiKey, undefined);
+  assert.equal(bridge.isAnthropicSessionConnected(), true);
+});
+
+test("POST /api/anthropic/connect can persist Anthropic setup to ~/.minicode/.env", async () => {
+  const bridge = new MockBridge();
+  const minicodeHome = mkdtempSync(path.join(os.tmpdir(), "minicode-anthropic-home-"));
+  const base = await startTestServer(bridge, { minicodeHome });
+
+  try {
+    const res = await fetch(`${base}/api/anthropic/connect`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ apiKey: "sk-ant-session-key", persistToEnv: true }),
+    });
+    assert.equal(res.status, 200);
+
+    const body = await res.json() as {
+      persistedToEnv: boolean;
+      persistedEnvPath: string | null;
+      persistWarning: string | null;
+      message: string;
+    };
+    assert.equal(body.persistedToEnv, true);
+    assert.equal(body.persistWarning, null);
+    assert.equal(body.persistedEnvPath, path.join(minicodeHome, ".env"));
+    assert.match(body.message, /saved to ~\/\.minicode\/\.env/);
+
+    const envContents = readFileSync(path.join(minicodeHome, ".env"), "utf8");
+    assert.match(envContents, /^MODEL_PROVIDER=anthropic$/m);
+    assert.match(envContents, /^ANTHROPIC_API_KEY=sk-ant-session-key$/m);
+  } finally {
+    rmSync(minicodeHome, { recursive: true, force: true });
+  }
+});
+
+test("POST /api/anthropic/disconnect removes the session-only Anthropic connection", async () => {
+  const bridge = new MockBridge();
+  bridge.connectAnthropic("sk-ant-session-key");
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/anthropic/disconnect`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
+  assert.equal(res.status, 200);
+
+  const body = await res.json() as {
+    ok: boolean;
+    disconnected: boolean;
+    sessionOnly: boolean;
+    provider: string;
+    message: string;
+  };
+  assert.equal(body.ok, true);
+  assert.equal(body.disconnected, true);
+  assert.equal(body.sessionOnly, true);
+  assert.equal(body.provider, "anthropic");
+  assert.equal(
+    body.message,
+    "Removed the session-only Anthropic connection and restored your original provider settings.",
+  );
+  assert.equal(bridge.isAnthropicSessionConnected(), false);
+  assert.equal(bridge.getConfig().modelProvider, "anthropic");
+  assert.equal(bridge.getConfig().anthropicApiKey, undefined);
+});
+
+test("GET /api/status exposes Anthropic session state", async () => {
+  const bridge = new MockBridge();
+  bridge.connectAnthropic("sk-ant-session-key");
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/status`);
+  assert.equal(res.status, 200);
+
+  const body = await res.json() as {
+    sessionAnthropicConnected: boolean;
+    sessionOpenRouterConnected: boolean;
+    sessionOpenAiCompatibleConnected: boolean;
+    provider: string;
+  };
+  assert.equal(body.provider, "anthropic");
+  assert.equal(body.sessionAnthropicConnected, true);
+  assert.equal(body.sessionOpenRouterConnected, false);
+  assert.equal(body.sessionOpenAiCompatibleConnected, false);
+});
+
 test("POST /api/openai-compatible/connect stores a session-only endpoint", async () => {
   const bridge = new MockBridge();
   const base = await startTestServer(bridge);
@@ -1062,6 +1221,20 @@ test("POST /api/openrouter/connect returns 400 when code is missing", async () =
     body: JSON.stringify({ codeVerifier: "pkce-verifier" }),
   });
   assert.equal(res.status, 400);
+});
+
+test("POST /api/anthropic/connect returns 400 when API key is missing", async () => {
+  const bridge = new MockBridge();
+  const base = await startTestServer(bridge);
+
+  const res = await fetch(`${base}/api/anthropic/connect`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ apiKey: "  " }),
+  });
+  assert.equal(res.status, 400);
+  const body = await res.json() as { error: string };
+  assert.equal(body.error, "apiKey is required");
 });
 
 test("POST /api/openrouter/connect surfaces exchange failures", async () => {

--- a/tests/settings-ui.test.ts
+++ b/tests/settings-ui.test.ts
@@ -14,12 +14,17 @@ test("built HTML contains settings entry point and modal shell", () => {
     html.includes('id="connect-openai-compatible-btn"'),
     "HTML should contain the OpenAI-compatible connect button",
   );
+  assert.ok(html.includes('id="connect-anthropic-btn"'), "HTML should contain the Anthropic connect button");
   assert.ok(html.includes('id="config-overlay-intro"'), "HTML should contain the setup overlay intro copy");
   assert.ok(html.includes("Try minicode for free with OpenRouter"), "HTML should promote the free OpenRouter quick start");
   assert.ok(html.includes('id="openrouter-connect-modal"'), "HTML should contain the OpenRouter consent modal");
   assert.ok(
     html.includes('id="openai-compatible-connect-modal"'),
     "HTML should contain the OpenAI-compatible connect modal",
+  );
+  assert.ok(
+    html.includes('id="anthropic-connect-modal"'),
+    "HTML should contain the Anthropic connect modal",
   );
   assert.ok(
     html.includes('id="openai-compatible-preset"'),
@@ -31,6 +36,7 @@ test("built HTML contains settings entry point and modal shell", () => {
     html.includes('id="disconnect-openai-compatible-btn"'),
     "HTML should contain the OpenAI-compatible disconnect button",
   );
+  assert.ok(html.includes('id="disconnect-anthropic-btn"'), "HTML should contain the Anthropic disconnect button");
   assert.ok(!html.includes('id="settings-scope"'), "HTML should no longer contain the settings scope selector");
   assert.ok(html.includes('id="settings-save"'), "HTML should contain the settings save action");
 });
@@ -65,6 +71,8 @@ test("built JS contains config loading and saving logic for settings", () => {
     js.includes("/api/openai-compatible/disconnect"),
     "JS should call the OpenAI-compatible disconnect API",
   );
+  assert.ok(js.includes("/api/anthropic/connect"), "JS should call the Anthropic connect API");
+  assert.ok(js.includes("/api/anthropic/disconnect"), "JS should call the Anthropic disconnect API");
   assert.ok(js.includes("persistToHomeEnv"), "JS should support persisting the selected model after OpenRouter setup");
   assert.ok(js.includes("code_challenge_method"), "JS should generate an OpenRouter PKCE auth request");
   assert.ok(js.includes("sessionStorage"), "JS should persist the PKCE verifier for the OAuth callback");
@@ -74,6 +82,7 @@ test("built JS contains config loading and saving logic for settings", () => {
     js.includes("sessionOpenAiCompatibleConnected"),
     "JS should track session-only OpenAI-compatible state",
   );
+  assert.ok(js.includes("sessionAnthropicConnected"), "JS should track session-only Anthropic state");
   assert.ok(js.includes("OPENAI_COMPATIBLE_PRESETS"), "JS should include OpenAI-compatible endpoint presets");
   assert.ok(js.includes("Save settings"), "JS should contain the settings save action text");
   assert.ok(js.includes("settingsPayload"), "JS should track settings payload state");

--- a/tests/setup-overlay-state.test.ts
+++ b/tests/setup-overlay-state.test.ts
@@ -17,7 +17,7 @@ test("fresh install hides MODEL missing copy until a provider is configured", ()
   assert.equal(state.modelSelectionNote, null);
 });
 
-test("configured OpenAI-compatible provider keeps model guidance visible", () => {
+test("configured OpenAI-compatible provider keeps model guidance and quick connects visible", () => {
   const state = deriveSetupOverlayState({
     configuredProvider: "openai-compatible",
     missing: ["MODEL is not set"],
@@ -27,14 +27,14 @@ test("configured OpenAI-compatible provider keeps model guidance visible", () =>
     state.introText,
     "An OpenAI-compatible provider is already configured. Select a model to continue:",
   );
-  assert.equal(state.hideQuickConnects, true);
+  assert.equal(state.hideQuickConnects, false);
   assert.equal(state.hideOpenRouterSpotlight, false);
   assert.deepEqual(state.missingItems, ["MODEL is not set"]);
   assert.equal(state.showModelSelectionHint, true);
   assert.equal(state.modelSelectionNote, null);
 });
 
-test("configured OpenRouter provider keeps model guidance and hides spotlight", () => {
+test("configured OpenRouter provider keeps model guidance and hides OpenRouter spotlight", () => {
   const state = deriveSetupOverlayState({
     configuredProvider: "openrouter",
     missing: ["MODEL is not set"],
@@ -44,7 +44,7 @@ test("configured OpenRouter provider keeps model guidance and hides spotlight", 
     state.introText,
     "OpenRouter is already configured. Select a model to continue:",
   );
-  assert.equal(state.hideQuickConnects, true);
+  assert.equal(state.hideQuickConnects, false);
   assert.equal(state.hideOpenRouterSpotlight, true);
   assert.deepEqual(state.missingItems, ["MODEL is not set"]);
   assert.equal(state.showModelSelectionHint, true);


### PR DESCRIPTION
## Summary

Adds a first-class Anthropic quick-connect path to the web UI, matching the existing OpenAI-compatible session connect flow.

## What changed

- Added Connect Anthropic buttons in the setup overlay and Settings menu.
- Added an Anthropic connection modal with API key input and optional persistence to `~/.minicode/.env`.
- Added `/api/anthropic/connect` and `/api/anthropic/disconnect` endpoints for session-only provider switching.
- Added session-scoped `anthropicApiKey` support so the UI flow does not need to mutate process env.
- Added UI, config, and serve integration coverage for the new flow.

## Validation

- `npm run build`
- `npm run lint`
- `node --test --import tsx tests/settings-ui.test.ts tests/serve.integration.test.ts tests/config-integration.test.ts`