### PR TITLE
Move language-specific entry-point / watch logic into plugins

### DIFF
--- a/packages/agent-sdk/src/indexer/types.ts
+++ b/packages/agent-sdk/src/indexer/types.ts
@@ -68,6 +68,16 @@ export interface LanguagePlugin {
     symbols: IndexedSymbol[],
     projectFiles: Map<string, string>,
   ): DependencyEdge[] | Promise<DependencyEdge[]>;
+
+  /**
+   * Whether `filePath` is a conventional entry-point file for this language
+   * (e.g. `index.ts` for TS/JS, `__init__.py`/`__main__.py` for Python,
+   * `main.go` for Go). The code map ranks entry points above other files.
+   *
+   * Optional: plugins that don't implement it simply contribute no
+   * entry-point hints, and the host falls back to its built-in default.
+   */
+  isEntryPoint?(filePath: string): boolean;
 }
 
 /**

--- a/packages/agent-sdk/src/tools/search.ts
+++ b/packages/agent-sdk/src/tools/search.ts
@@ -137,7 +137,7 @@ export function createSearchTool(options: SearchToolOptions): ToolDefinition {
         },
         include: {
           type: "string",
-          description: "Optional glob include filter, e.g. *.ts",
+          description: "Optional glob include filter to restrict matched files, e.g. \"src/**\".",
         },
       },
       required: ["pattern"],

--- a/packages/minicode-plugin-python/src/index.ts
+++ b/packages/minicode-plugin-python/src/index.ts
@@ -514,6 +514,13 @@ function createPlugin() {
       return EXTENSIONS.some((ext) => lower.endsWith(ext));
     },
 
+    isEntryPoint(filePath: string): boolean {
+      // Package roots (`__init__.py`) and runnable module entries
+      // (`__main__.py`) are Python's structural entry points.
+      const name = filePath.replace(/\\/g, "/").split("/").pop() ?? "";
+      return name === "__init__.py" || name === "__main__.py";
+    },
+
     indexFile(filePath: string, content: string): IndexedSymbol[] {
       const tree = parse(filePath, content);
       const symbols: IndexedSymbol[] = [];

--- a/packages/minicode-plugin-python/tests/python-plugin.test.ts
+++ b/packages/minicode-plugin-python/tests/python-plugin.test.ts
@@ -33,6 +33,15 @@ const SAMPLE_PY = [
   "",
 ].join("\n");
 
+test("Python plugin flags package entry points", () => {
+  assert.ok(pythonPlugin.isEntryPoint, "plugin should provide isEntryPoint");
+  assert.equal(pythonPlugin.isEntryPoint!("pkg/__init__.py"), true);
+  assert.equal(pythonPlugin.isEntryPoint!("pkg/__main__.py"), true);
+  assert.equal(pythonPlugin.isEntryPoint!("__init__.py"), true);
+  assert.equal(pythonPlugin.isEntryPoint!("pkg/helpers.py"), false);
+  assert.equal(pythonPlugin.isEntryPoint!("pkg/main.py"), false);
+});
+
 test("Python plugin extracts classes, methods, functions, type aliases with module-prefixed qualifiedNames", () => {
   const symbols = pythonPlugin.indexFile("sample.py", SAMPLE_PY);
   const names = symbols.map((s) => s.qualifiedName);

--- a/src/indexer/code-map.ts
+++ b/src/indexer/code-map.ts
@@ -35,9 +35,26 @@ function selectFormatter(): typeof formatSymbol {
     : formatSymbolNamed;
 }
 
-function isEntryPointFile(filePath: string): boolean {
-  const name = filePath.replace(/\\/g, "/");
-  return /(?:^|\/)index\.[jt]sx?$/.test(name);
+/**
+ * Built-in fallback used when no language plugin recognizes a file as an
+ * entry point. Matches TS/JS `index.*` files — the historical default,
+ * kept as a safety net so behavior is unchanged when plugins don't
+ * implement {@link LanguagePlugin.isEntryPoint}.
+ */
+const DEFAULT_ENTRY_POINT_RE = /(?:^|\/)index\.[jt]sx?$/;
+
+/**
+ * Whether `filePath` should be ranked as an entry point in the code map.
+ * Consults the plugin-provided predicate first (entry-point conventions are
+ * language-specific — `__init__.py`, `main.go`, etc.) and falls back to the
+ * built-in TS/JS `index.*` regex when no plugin claims it.
+ */
+export function isEntryPointFile(
+  filePath: string,
+  pluginIsEntryPoint?: (filePath: string) => boolean,
+): boolean {
+  if (pluginIsEntryPoint?.(filePath)) return true;
+  return DEFAULT_ENTRY_POINT_RE.test(filePath.replace(/\\/g, "/"));
 }
 
 /**
@@ -86,6 +103,7 @@ function expandFocusSet(
 function createSymbolRanker(
   adjacency: { byFrom: Map<string, DependencyEdge[]>; byTo: Map<string, DependencyEdge[]> },
   focusSymbols?: Set<string>,
+  isEntryPoint?: (filePath: string) => boolean,
 ) {
   const refCount = new Map<string, number>();
   for (const [target, edges] of adjacency.byTo) {
@@ -109,8 +127,8 @@ function createSymbolRanker(
     const refA = refCount.get(a.qualifiedName) ?? 0;
     const refB = refCount.get(b.qualifiedName) ?? 0;
     if (refA !== refB) return refB - refA;
-    const entryA = isEntryPointFile(a.filePath) ? 1 : 0;
-    const entryB = isEntryPointFile(b.filePath) ? 1 : 0;
+    const entryA = isEntryPointFile(a.filePath, isEntryPoint) ? 1 : 0;
+    const entryB = isEntryPointFile(b.filePath, isEntryPoint) ? 1 : 0;
     return entryB - entryA;
   };
 }
@@ -125,12 +143,16 @@ export type { CodeMapResult };
  * @param focusSymbols Optional set of symbol qualified names to boost to the top.
  *   These symbols (and their 1-hop dependency neighbors) will be ranked above all
  *   others, ensuring they survive truncation within the token budget.
+ * @param isEntryPoint Optional plugin-provided predicate for entry-point files,
+ *   used (with a built-in TS/JS fallback) to break ranking ties. See
+ *   {@link isEntryPointFile}.
  */
 export function generateCodeMap(
   symbolsByFile: Map<string, IndexedSymbol[]>,
   tokenBudget = DEFAULT_TOKEN_BUDGET,
   dependencyEdges?: DependencyEdge[],
   focusSymbols?: Set<string>,
+  isEntryPoint?: (filePath: string) => boolean,
 ): CodeMapResult {
   const totalCount = [...symbolsByFile.values()].reduce(
     (sum, syms) => sum + syms.length,
@@ -143,7 +165,7 @@ export function generateCodeMap(
     ? buildAdjacencyMaps(dependencyEdges)
     : { byFrom: new Map<string, DependencyEdge[]>(), byTo: new Map<string, DependencyEdge[]>() };
   const rank = dependencyEdges
-    ? createSymbolRanker(adjacency, focusSymbols)
+    ? createSymbolRanker(adjacency, focusSymbols, isEntryPoint)
     : (a: IndexedSymbol, b: IndexedSymbol) =>
         (a.exported === b.exported ? 0 : a.exported ? -1 : 1);
 

--- a/src/indexer/plugins/typescript.ts
+++ b/src/indexer/plugins/typescript.ts
@@ -86,6 +86,10 @@ function createPlugin() {
       return EXTENSIONS.some((ext) => lower.endsWith(ext));
     },
 
+    isEntryPoint(filePath: string): boolean {
+      return /(?:^|\/)index\.[jt]sx?$/.test(filePath.replace(/\\/g, "/"));
+    },
+
     indexFile(filePath: string, content: string): IndexedSymbol[] {
       const sourceFile = ts.createSourceFile(
         filePath,

--- a/src/indexer/project-index.ts
+++ b/src/indexer/project-index.ts
@@ -119,6 +119,11 @@ export function createProjectIndex(
   let adjacencyFrom = buildAdjacencyFrom(dependencyEdges);
   const root = path.resolve(workspaceRoot);
 
+  // Entry-point conventions are language-specific (`index.ts`, `__init__.py`,
+  // `main.go`, ...). Ask each plugin; code-map keeps a built-in fallback.
+  const pluginIsEntryPoint = (filePath: string): boolean =>
+    plugins.some((p) => p.isEntryPoint?.(filePath) ?? false);
+
   function rebuildSymbolsMap(): void {
     const normalizedSymbols = normalizeIndexedSymbols(files);
     symbols.clear();
@@ -333,7 +338,13 @@ export function createProjectIndex(
     },
 
     getCodeMap(tokenBudget?: number, focusSymbols?: Set<string>): CodeMapResult {
-      return generateCodeMap(files, tokenBudget, dependencyEdges, focusSymbols);
+      return generateCodeMap(
+        files,
+        tokenBudget,
+        dependencyEdges,
+        focusSymbols,
+        pluginIsEntryPoint,
+      );
     },
 
     async reindexFile(filePath: string, content: string): Promise<void> {

--- a/src/serve/agent-bridge.ts
+++ b/src/serve/agent-bridge.ts
@@ -23,7 +23,7 @@ import {
   saveIndex,
 } from "../indexer/cache.js";
 import { buildProjectIndex } from "../indexer/project-index.js";
-import type { ProjectIndex } from "../indexer/types.js";
+import type { LanguagePlugin, ProjectIndex } from "../indexer/types.js";
 import { sortModelsAlphabetically } from "../model-utils.js";
 import { createToolRegistry } from "../tools/registry.js";
 import {
@@ -37,6 +37,20 @@ import { getSymbolDisplayName } from "../indexer/symbol-names.js";
 import type { ServerMessage } from "./types.js";
 
 export type UiListener = (msg: ServerMessage) => void;
+
+/**
+ * Build the set of file extensions the file watcher should react to from the
+ * loaded language plugins. Sourcing this from `plugins.extensions` (rather than
+ * a hardcoded TS/JS list) means any indexed language — Python, Go, etc. —
+ * triggers re-indexing in serve mode.
+ */
+export function watchExtensionsForPlugins(
+  plugins: LanguagePlugin[],
+): Set<string> {
+  return new Set(
+    plugins.flatMap((p) => p.extensions.map((ext) => ext.toLowerCase())),
+  );
+}
 
 export class AgentBridge {
   private agent: CodingAgent | undefined;
@@ -301,7 +315,6 @@ export class AgentBridge {
 
   // ── File watcher for automatic reindexing ──
 
-  private static readonly WATCH_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx"]);
   private static readonly SKIP_DIRS = new Set(["node_modules", ".git", "dist", "build", "coverage"]);
   private static readonly REINDEX_DEBOUNCE_MS = 300;
 
@@ -313,6 +326,7 @@ export class AgentBridge {
     if (!this.projectIndex || this.fileWatcher) return;
 
     const workspaceRoot = this.config.workspaceRoot;
+    const watchExtensions = watchExtensionsForPlugins(this.projectIndex.plugins);
 
     try {
       this.fileWatcher = watch(workspaceRoot, { recursive: true }, (_event, filename) => {
@@ -326,7 +340,7 @@ export class AgentBridge {
 
         // Skip non-indexable extensions
         const ext = path.extname(normalized).toLowerCase();
-        if (!AgentBridge.WATCH_EXTENSIONS.has(ext)) return;
+        if (!watchExtensions.has(ext)) return;
 
         // Debounce: if same file changes rapidly, only reindex once
         const existing = this.reindexTimers.get(normalized);

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
-import { generateCodeMap } from "../src/indexer/code-map.js";
+import { generateCodeMap, isEntryPointFile } from "../src/indexer/code-map.js";
 import { getPluginForFile, loadPlugins } from "../src/indexer/plugin-loader.js";
 import { buildProjectIndex } from "../src/indexer/project-index.js";
 import { typescriptPlugin } from "../src/indexer/plugins/typescript.js";
@@ -103,6 +103,33 @@ test("Code map generator produces expected format", () => {
   assert.ok(result.text.includes("sample.ts"));
   assert.ok(result.text.includes("CodingAgent"));
   assert.ok(result.text.includes("runTurn"));
+});
+
+test("isEntryPointFile recognizes TS index files via the default fallback", () => {
+  assert.equal(isEntryPointFile("src/index.ts"), true);
+  assert.equal(isEntryPointFile("index.tsx"), true);
+  assert.equal(isEntryPointFile("a/b/index.js"), true);
+  assert.equal(isEntryPointFile("a/b/index.jsx"), true);
+  assert.equal(isEntryPointFile("src/util.ts"), false);
+  assert.equal(isEntryPointFile("cmd/main.go"), false);
+});
+
+test("isEntryPointFile consults a plugin-provided predicate, with the regex as fallback", () => {
+  const pluginCheck = (f: string) => f === "main.go" || f.endsWith("/main.go");
+  // Plugin recognizes it even though the regex would not.
+  assert.equal(isEntryPointFile("cmd/main.go", pluginCheck), true);
+  // Plugin says no, but the legacy regex fallback still fires for TS index files.
+  assert.equal(isEntryPointFile("src/index.ts", pluginCheck), true);
+  // Neither the plugin nor the fallback regex match.
+  assert.equal(isEntryPointFile("src/util.ts", pluginCheck), false);
+});
+
+test("TypeScript plugin flags index files as entry points", () => {
+  assert.ok(typescriptPlugin.isEntryPoint, "plugin should provide isEntryPoint");
+  assert.equal(typescriptPlugin.isEntryPoint!("src/index.ts"), true);
+  assert.equal(typescriptPlugin.isEntryPoint!("index.tsx"), true);
+  assert.equal(typescriptPlugin.isEntryPoint!("pkg/index.js"), true);
+  assert.equal(typescriptPlugin.isEntryPoint!("src/agent.ts"), false);
 });
 
 test("Code map respects token budget", () => {

--- a/tests/watch-extensions.test.ts
+++ b/tests/watch-extensions.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { LanguagePlugin } from "../src/indexer/types.js";
+
+function stubPlugin(name: string, extensions: string[]): LanguagePlugin {
+  return {
+    name,
+    extensions,
+    canIndex: (filePath) => extensions.some((e) => filePath.endsWith(e)),
+    indexFile: () => [],
+  };
+}
+
+test("watchExtensionsForPlugins derives the watch set from plugin extensions", async () => {
+  const { watchExtensionsForPlugins } = await import(
+    "../src/serve/agent-bridge.js"
+  );
+
+  const exts = watchExtensionsForPlugins([
+    stubPlugin("typescript", [".ts", ".tsx", ".js", ".jsx"]),
+    stubPlugin("python", [".py", ".pyi"]),
+  ]);
+
+  assert.equal(exts.has(".ts"), true);
+  assert.equal(exts.has(".jsx"), true);
+  assert.equal(exts.has(".py"), true);
+  assert.equal(exts.has(".pyi"), true);
+  // A language with no loaded plugin is not watched.
+  assert.equal(exts.has(".go"), false);
+});


### PR DESCRIPTION
Several language-agnostic surfaces in core had TS/JS assumptions baked in
that would get in the way of the upcoming Go plugin (and future Rust/Java/
etc.). This moves the source of truth for language-specific behavior into
the LanguagePlugin interface.

- Extend LanguagePlugin with an optional `isEntryPoint(filePath)` hook.
  typescript-plugin keeps the `index.[jt]sx?` convention; python-plugin
  adds `__init__.py` / `__main__.py`.
- code-map: `isEntryPointFile` now consults the plugin-provided predicate
  and falls back to the built-in TS/JS regex when no plugin claims a file.
  Threaded through generateCodeMap -> createSymbolRanker; project-index
  supplies the plugin-derived predicate.
- agent-bridge: derive the file-watcher's extension set from
  `plugins.extensions` (new `watchExtensionsForPlugins` helper) instead of
  a hardcoded `.ts/.tsx/.js/.jsx` set, so serve-mode reindexing fires for
  Python/Go/etc.
- search tool: drop the TS-specific `*.ts` glob example from the include
  description (model-facing).

The new hook is optional, so existing plugins keep working unchanged.
`postEditDiagnose` (moving tsc out of core) is intentionally left for the
separate follow-up that relocates post-edit-diagnostics into the TS plugin,
so the hook lands together with its consumer rather than as dead interface
surface.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
