### PR TITLE
Make code map and file watcher language-agnostic via plugin hooks

### DIFF
--- a/packages/agent-sdk/src/indexer/types.ts
+++ b/packages/agent-sdk/src/indexer/types.ts
@@ -68,6 +68,15 @@ export interface LanguagePlugin {
     symbols: IndexedSymbol[],
     projectFiles: Map<string, string>,
   ): DependencyEdge[] | Promise<DependencyEdge[]>;
+
+  /**
+   * Whether `filePath` is a conventional entry-point file for this language
+   * (e.g. `index.ts` for TS/JS, `__init__.py`/`__main__.py` for Python,
+   * `main.go` for Go). Entry-point files are ranked higher in the code map.
+   * Optional: plugins that don't implement it simply contribute no entry
+   * points, and core falls back to its built-in heuristic.
+   */
+  isEntryPoint?(filePath: string): boolean;
 }
 
 /**

--- a/packages/agent-sdk/src/tools/search.ts
+++ b/packages/agent-sdk/src/tools/search.ts
@@ -137,7 +137,7 @@ export function createSearchTool(options: SearchToolOptions): ToolDefinition {
         },
         include: {
           type: "string",
-          description: "Optional glob include filter, e.g. *.ts",
+          description: "Optional glob include filter, e.g. 'src/**' or '*.json'.",
         },
       },
       required: ["pattern"],

--- a/packages/minicode-plugin-python/src/index.ts
+++ b/packages/minicode-plugin-python/src/index.ts
@@ -514,6 +514,11 @@ function createPlugin() {
       return EXTENSIONS.some((ext) => lower.endsWith(ext));
     },
 
+    isEntryPoint(filePath: string): boolean {
+      const base = filePath.replace(/\\/g, "/").split("/").pop() ?? "";
+      return base === "__init__.py" || base === "__main__.py";
+    },
+
     indexFile(filePath: string, content: string): IndexedSymbol[] {
       const tree = parse(filePath, content);
       const symbols: IndexedSymbol[] = [];

--- a/src/indexer/code-map.ts
+++ b/src/indexer/code-map.ts
@@ -1,5 +1,10 @@
 import { getSymbolDisplayName } from "./symbol-names.js";
-import type { CodeMapResult, DependencyEdge, IndexedSymbol } from "./types.js";
+import type {
+  CodeMapResult,
+  DependencyEdge,
+  IndexedSymbol,
+  LanguagePlugin,
+} from "./types.js";
 
 const DEFAULT_TOKEN_BUDGET = 1500;
 const APPROX_CHARS_PER_TOKEN = 4;
@@ -35,8 +40,20 @@ function selectFormatter(): typeof formatSymbol {
     : formatSymbolNamed;
 }
 
-function isEntryPointFile(filePath: string): boolean {
+/**
+ * Whether a file is a conventional entry point, used as the lowest-priority
+ * tiebreaker when ranking symbols for the code map. Language-specific entry
+ * points come from the loaded plugins (`isEntryPoint`); the built-in TS/JS
+ * `index.*` heuristic remains as a fallback for plugins that don't implement
+ * the hook (and when no plugins are available, e.g. plain `generateCodeMap`
+ * calls in tests).
+ */
+export function isEntryPointFile(
+  filePath: string,
+  plugins?: LanguagePlugin[],
+): boolean {
   const name = filePath.replace(/\\/g, "/");
+  if (plugins?.some((p) => p.isEntryPoint?.(name))) return true;
   return /(?:^|\/)index\.[jt]sx?$/.test(name);
 }
 
@@ -86,6 +103,7 @@ function expandFocusSet(
 function createSymbolRanker(
   adjacency: { byFrom: Map<string, DependencyEdge[]>; byTo: Map<string, DependencyEdge[]> },
   focusSymbols?: Set<string>,
+  plugins?: LanguagePlugin[],
 ) {
   const refCount = new Map<string, number>();
   for (const [target, edges] of adjacency.byTo) {
@@ -109,8 +127,8 @@ function createSymbolRanker(
     const refA = refCount.get(a.qualifiedName) ?? 0;
     const refB = refCount.get(b.qualifiedName) ?? 0;
     if (refA !== refB) return refB - refA;
-    const entryA = isEntryPointFile(a.filePath) ? 1 : 0;
-    const entryB = isEntryPointFile(b.filePath) ? 1 : 0;
+    const entryA = isEntryPointFile(a.filePath, plugins) ? 1 : 0;
+    const entryB = isEntryPointFile(b.filePath, plugins) ? 1 : 0;
     return entryB - entryA;
   };
 }
@@ -125,12 +143,15 @@ export type { CodeMapResult };
  * @param focusSymbols Optional set of symbol qualified names to boost to the top.
  *   These symbols (and their 1-hop dependency neighbors) will be ranked above all
  *   others, ensuring they survive truncation within the token budget.
+ * @param plugins Optional loaded language plugins, used to identify entry-point
+ *   files when ranking symbols. Falls back to a built-in heuristic when omitted.
  */
 export function generateCodeMap(
   symbolsByFile: Map<string, IndexedSymbol[]>,
   tokenBudget = DEFAULT_TOKEN_BUDGET,
   dependencyEdges?: DependencyEdge[],
   focusSymbols?: Set<string>,
+  plugins?: LanguagePlugin[],
 ): CodeMapResult {
   const totalCount = [...symbolsByFile.values()].reduce(
     (sum, syms) => sum + syms.length,
@@ -143,7 +164,7 @@ export function generateCodeMap(
     ? buildAdjacencyMaps(dependencyEdges)
     : { byFrom: new Map<string, DependencyEdge[]>(), byTo: new Map<string, DependencyEdge[]>() };
   const rank = dependencyEdges
-    ? createSymbolRanker(adjacency, focusSymbols)
+    ? createSymbolRanker(adjacency, focusSymbols, plugins)
     : (a: IndexedSymbol, b: IndexedSymbol) =>
         (a.exported === b.exported ? 0 : a.exported ? -1 : 1);
 

--- a/src/indexer/plugins/typescript.ts
+++ b/src/indexer/plugins/typescript.ts
@@ -86,6 +86,10 @@ function createPlugin() {
       return EXTENSIONS.some((ext) => lower.endsWith(ext));
     },
 
+    isEntryPoint(filePath: string): boolean {
+      return /(?:^|\/)index\.[jt]sx?$/.test(filePath.replace(/\\/g, "/"));
+    },
+
     indexFile(filePath: string, content: string): IndexedSymbol[] {
       const sourceFile = ts.createSourceFile(
         filePath,

--- a/src/indexer/project-index.ts
+++ b/src/indexer/project-index.ts
@@ -333,7 +333,7 @@ export function createProjectIndex(
     },
 
     getCodeMap(tokenBudget?: number, focusSymbols?: Set<string>): CodeMapResult {
-      return generateCodeMap(files, tokenBudget, dependencyEdges, focusSymbols);
+      return generateCodeMap(files, tokenBudget, dependencyEdges, focusSymbols, plugins);
     },
 
     async reindexFile(filePath: string, content: string): Promise<void> {

--- a/src/serve/agent-bridge.ts
+++ b/src/serve/agent-bridge.ts
@@ -23,7 +23,7 @@ import {
   saveIndex,
 } from "../indexer/cache.js";
 import { buildProjectIndex } from "../indexer/project-index.js";
-import type { ProjectIndex } from "../indexer/types.js";
+import type { LanguagePlugin, ProjectIndex } from "../indexer/types.js";
 import { sortModelsAlphabetically } from "../model-utils.js";
 import { createToolRegistry } from "../tools/registry.js";
 import {
@@ -37,6 +37,21 @@ import { getSymbolDisplayName } from "../indexer/symbol-names.js";
 import type { ServerMessage } from "./types.js";
 
 export type UiListener = (msg: ServerMessage) => void;
+
+/**
+ * The set of file extensions the workspace watcher should react to, derived
+ * from the loaded language plugins. Keeping this in lockstep with the indexer's
+ * plugin set means a new language plugin (Python, Go, …) automatically gets
+ * live reindexing without touching this file. Extensions are lowercased to
+ * match `path.extname(...).toLowerCase()` at the call site.
+ */
+export function watchExtensionsFromPlugins(
+  plugins: LanguagePlugin[],
+): Set<string> {
+  return new Set(
+    plugins.flatMap((p) => p.extensions.map((e) => e.toLowerCase())),
+  );
+}
 
 export class AgentBridge {
   private agent: CodingAgent | undefined;
@@ -301,7 +316,6 @@ export class AgentBridge {
 
   // ── File watcher for automatic reindexing ──
 
-  private static readonly WATCH_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx"]);
   private static readonly SKIP_DIRS = new Set(["node_modules", ".git", "dist", "build", "coverage"]);
   private static readonly REINDEX_DEBOUNCE_MS = 300;
 
@@ -313,6 +327,9 @@ export class AgentBridge {
     if (!this.projectIndex || this.fileWatcher) return;
 
     const workspaceRoot = this.config.workspaceRoot;
+    // Derive the watched extensions from the loaded plugins so any language
+    // plugin's files trigger reindexing, not just TS/JS.
+    const watchExtensions = watchExtensionsFromPlugins(this.projectIndex.plugins);
 
     try {
       this.fileWatcher = watch(workspaceRoot, { recursive: true }, (_event, filename) => {
@@ -326,7 +343,7 @@ export class AgentBridge {
 
         // Skip non-indexable extensions
         const ext = path.extname(normalized).toLowerCase();
-        if (!AgentBridge.WATCH_EXTENSIONS.has(ext)) return;
+        if (!watchExtensions.has(ext)) return;
 
         // Debounce: if same file changes rapidly, only reindex once
         const existing = this.reindexTimers.get(normalized);

--- a/templates/plugin-template/src/types.ts
+++ b/templates/plugin-template/src/types.ts
@@ -37,4 +37,10 @@ export interface LanguagePlugin {
     symbols: IndexedSymbol[],
     projectFiles: Map<string, string>,
   ): DependencyEdge[];
+  /**
+   * Optional: whether `filePath` is a conventional entry-point file for this
+   * language (e.g. `index.ts`, `__init__.py`, `main.go`). Entry-point files
+   * are ranked higher in the code map.
+   */
+  isEntryPoint?(filePath: string): boolean;
 }

--- a/tests/agent-bridge-watch.test.ts
+++ b/tests/agent-bridge-watch.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { watchExtensionsFromPlugins } from "../src/serve/agent-bridge.js";
+import type { LanguagePlugin } from "../src/indexer/types.js";
+
+function plugin(name: string, extensions: string[]): LanguagePlugin {
+  return {
+    name,
+    extensions,
+    canIndex: (f) => extensions.some((e) => f.toLowerCase().endsWith(e)),
+    indexFile: () => [],
+  };
+}
+
+test("watchExtensionsFromPlugins covers every loaded plugin's extensions", () => {
+  const exts = watchExtensionsFromPlugins([
+    plugin("typescript", [".ts", ".tsx", ".js", ".jsx"]),
+    plugin("python", [".py", ".pyi"]),
+  ]);
+
+  // Non-TS languages now trigger reindexing — the whole point of the change.
+  assert.ok(exts.has(".py"), "should watch .py");
+  assert.ok(exts.has(".pyi"), "should watch .pyi");
+  assert.ok(exts.has(".ts"), "should still watch .ts");
+});
+
+test("watchExtensionsFromPlugins normalizes extensions to lowercase", () => {
+  const exts = watchExtensionsFromPlugins([plugin("go", [".GO"])]);
+  assert.ok(exts.has(".go"), "extension matching is case-insensitive");
+});

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -4,8 +4,9 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
-import { generateCodeMap } from "../src/indexer/code-map.js";
+import { generateCodeMap, isEntryPointFile } from "../src/indexer/code-map.js";
 import { getPluginForFile, loadPlugins } from "../src/indexer/plugin-loader.js";
+import type { LanguagePlugin } from "../src/indexer/types.js";
 import { buildProjectIndex } from "../src/indexer/project-index.js";
 import { typescriptPlugin } from "../src/indexer/plugins/typescript.js";
 import { normalizeIndexedSymbols } from "../src/indexer/symbol-names.js";
@@ -58,6 +59,24 @@ test("TypeScript plugin handles arrow functions assigned to const", () => {
   assert.equal(arrow!.kind, "function");
 });
 
+test("TypeScript plugin flags index files as entry points", () => {
+  assert.ok(typescriptPlugin.isEntryPoint, "should expose isEntryPoint");
+  for (const file of ["index.ts", "src/index.tsx", "lib/index.js", "a/b/index.jsx"]) {
+    assert.equal(
+      typescriptPlugin.isEntryPoint!(file),
+      true,
+      `${file} should be an entry point`,
+    );
+  }
+  for (const file of ["src/agent.ts", "main.go", "indexer.ts", "src/index.py"]) {
+    assert.equal(
+      typescriptPlugin.isEntryPoint!(file),
+      false,
+      `${file} should not be an entry point`,
+    );
+  }
+});
+
 test("Plugin loader returns the built-in TypeScript plugin", async () => {
   const plugins = await loadPlugins("/tmp");
   assert.ok(plugins.length >= 1);
@@ -92,6 +111,29 @@ test("verify-index fixture exercises full indexing pipeline", async () => {
   const codeMap = index.getCodeMap();
   assert.ok(codeMap.text.includes("Processor"));
   assert.ok(codeMap.text.includes("parseAndProcess"));
+});
+
+test("isEntryPointFile consults plugins and falls back to the legacy heuristic", () => {
+  const goPlugin: LanguagePlugin = {
+    name: "go",
+    extensions: [".go"],
+    canIndex: (f) => f.endsWith(".go"),
+    indexFile: () => [],
+    isEntryPoint: (f) => f.endsWith("main.go"),
+  };
+
+  // Plugin-provided entry points are honored.
+  assert.equal(isEntryPointFile("cmd/main.go", [goPlugin]), true);
+  assert.equal(isEntryPointFile("cmd/server.go", [goPlugin]), false);
+
+  // Legacy TS/JS heuristic remains as the fallback, even alongside a
+  // plugin that doesn't claim the file.
+  assert.equal(isEntryPointFile("src/index.ts", [goPlugin]), true);
+
+  // No plugins: pure legacy behavior is preserved.
+  assert.equal(isEntryPointFile("src/index.tsx"), true);
+  assert.equal(isEntryPointFile("src/agent.ts"), false);
+  assert.equal(isEntryPointFile("pkg/__init__.py"), false);
 });
 
 test("Code map generator produces expected format", () => {

--- a/tests/python-plugin.test.ts
+++ b/tests/python-plugin.test.ts
@@ -26,6 +26,19 @@ test("getPluginForFile routes .pyi stub files to Python plugin", async () => {
   assert.equal(plugin!.name, "python");
 });
 
+test("Python plugin flags package/module entry points", async () => {
+  const plugins = await loadPlugins("/tmp");
+  const python = plugins.find((p) => p.name === "python");
+  assert.ok(python, "python plugin should load");
+  assert.ok(python!.isEntryPoint, "should expose isEntryPoint");
+  for (const file of ["__init__.py", "pkg/__init__.py", "pkg/__main__.py"]) {
+    assert.equal(python!.isEntryPoint!(file), true, `${file} should be an entry point`);
+  }
+  for (const file of ["pkg/module.py", "main.go", "src/index.ts"]) {
+    assert.equal(python!.isEntryPoint!(file), false, `${file} should not be an entry point`);
+  }
+});
+
 test("buildProjectIndex indexes a Python workspace", async () => {
   const workspaceRoot = await mkdtemp(path.join(tmpdir(), "minicode-py-index-"));
   await writeFile(


### PR DESCRIPTION
Move TS/JS-specific assumptions out of core ahead of the planned Go
plugin, establishing the principle that core is language-agnostic and
language-specific behavior is plugin-provided:

- LanguagePlugin gains an optional isEntryPoint(filePath) hook. The
  TypeScript plugin implements it for index.* files; the Python plugin
  for __init__.py / __main__.py.
- code-map ranking now queries plugins' isEntryPoint, falling back to
  the legacy index.* regex when no plugin claims the file (preserves
  current behavior; plugin-less callers and tests are unaffected).
- serve mode's file watcher derives its watched extensions from the
  loaded plugins (watchExtensionsFromPlugins) instead of a hardcoded
  TS/JS set, so Python/Go/etc. files now trigger reindexing.
- search tool's include-filter description drops the TS-specific *.ts
  example for a language-neutral one.

Per the issue's suggested order, relocating post-edit-diagnostics into a
TS-plugin postEditDiagnose hook is left as a separate follow-up.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
